### PR TITLE
Add commit hash to URL

### DIFF
--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -127,7 +127,14 @@ export function useVerifiedProgramRegistry({
                 verifiedData.verify_command += ` ${argsString}`;
             }
         }
-        verifiedData.repo_url = pdaData.gitUrl;
+
+        if (!verifiedData.repo_url) {
+            verifiedData.repo_url = pdaData.gitUrl;
+            if (pdaData.commit) {
+                verifiedData.repo_url = addCommitHashToUrl(verifiedData.repo_url, pdaData.commit);
+            }
+        }
+
         if (registryData.verification_status === VerificationStatus.NotVerified) {
             verifiedData.message = 'Verify command was provided by the program authority.';
             verifiedData.verification_status = VerificationStatus.PdaUploaded;
@@ -144,6 +151,15 @@ export function useVerifiedProgramRegistry({
     }
 
     return { data: null, isLoading };
+}
+
+function addCommitHashToUrl(repoUrl: string, commitHash: string): string {
+    // Ensure the URL doesn't already include a branch or tree reference
+    const cleanUrl = repoUrl.replace(/\/tree\/[^/]+$/, '').replace(/\/$/, '');
+
+    // Append the commit hash with the "tree" path
+    const urlWithCommit = `${cleanUrl}/tree/${commitHash}`;
+    return urlWithCommit;
 }
 
 function isMainnet(currentCluster: Cluster): boolean {


### PR DESCRIPTION
Problem: 
The URL from the verified on chain data did not have the commit hash attached. 

Solution: 
Added the commit with the /tree/ formate same way the osec API does it. 
Also changed it so that the Osec api is prefered instead of overwritten from the PDA when available.

When commit hash available: 
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/8ba8ce3c-265f-48dc-97b5-dcb6fae43767">
 
When there is no commit hash: 
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/111aa225-17ab-41e5-94d5-d67ee4d6808a">

