### PR TITLE
Add error boundary to verified build component

### DIFF
--- a/app/address/[address]/verified-build/page-client.tsx
+++ b/app/address/[address]/verified-build/page-client.tsx
@@ -2,8 +2,10 @@
 
 import { ParsedAccountRenderer } from '@components/account/ParsedAccountRenderer';
 import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { VerifiedBuildCard } from '@/app/components/account/VerifiedBuildCard';
+import { ErrorCard } from '@/app/components/common/ErrorCard';
 
 type Props = Readonly<{
     params: {
@@ -19,7 +21,11 @@ function VerifiedBuildCardRenderer({
     if (!parsedData || parsedData?.program !== 'bpf-upgradeable-loader') {
         return onNotFound();
     }
-    return <VerifiedBuildCard data={parsedData} pubkey={account.pubkey} />;
+    return (
+        <ErrorBoundary fallback={<ErrorCard text="Error loading verified build information" />}>
+            <VerifiedBuildCard data={parsedData} pubkey={account.pubkey} />
+        </ErrorBoundary>
+    );
 }
 
 export default function VerifiedBuildPageClient({ params: { address } }: Props) {


### PR DESCRIPTION
Fixes #446 

When network request fails, this card will be shown instead
<img width="714" alt="Screenshot 2025-01-28 at 5 11 58 PM" src="https://github.com/user-attachments/assets/3646671e-04a8-418d-9b0d-8d602b137a3f" />
