### PR TITLE
Increase search timeout from 1.5 to 5s

### DIFF
--- a/app/utils/token-search.ts
+++ b/app/utils/token-search.ts
@@ -48,7 +48,7 @@ export async function searchTokens(search: string, cluster: Cluster): Promise<Se
 
     try {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 1500);
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
         const apiResponse = await fetch(
             `https://token-list-api.solana.cloud/v1/search?query=${encodeURIComponent(
                 search


### PR DESCRIPTION
# Increase token search API timeout

## Problem
The token search API endpoint (token-list-api.solana.cloud) is consistently taking longer than 1.5 seconds to respond, causing many search requests to time out before receiving results.

## Solution
Increase the request timeout from 1.5 seconds to 5 seconds to accommodate the typical response times from the API endpoint. This change will improve the reliability of token search functionality while maintaining a reasonable timeout threshold for failed requests.

## Changes
- Updated the AbortController timeout in `token-search.ts` from 1500ms to 5000ms