### PR TITLE
Sigverify Ed25519 Payload Decoding Standard

### DIFF
--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -168,7 +168,6 @@ function InstructionCard({
     const key = `${index}-${childIndex}`;
     const { program: anchorProgram } = useAnchorProgram(ix.programId.toString(), url);
 
-    console.log('ix', ix);
     if ('parsed' in ix) {
         const props = {
             childIndex,

--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -168,6 +168,7 @@ function InstructionCard({
     const key = `${index}-${childIndex}`;
     const { program: anchorProgram } = useAnchorProgram(ix.programId.toString(), url);
 
+    console.log('ix', ix);
     if ('parsed' in ix) {
         const props = {
             childIndex,

--- a/app/providers/anchor.tsx
+++ b/app/providers/anchor.tsx
@@ -120,8 +120,20 @@ export function useAnchorProgram(programAddress: string, url: string): { program
     const program: Program<Idl> | null = useMemo(() => {
         if (!idl) return null;
         try {
-            const program = new Program(formatIdl(idl, programAddress), getProvider(url));
-            return program;
+            try {
+                const program = new Program(idl, getProvider(url));
+                return program;
+            } catch (e) {
+                // If raw IDL fails, try with formatted IDL
+                try {
+                    const program = new Program(formatIdl(idl, programAddress, false), getProvider(url));
+                    console.log('idl', formatIdl(idl, programAddress, false));
+                    return program;
+                } catch (e) {
+                    // Try again with types removed
+                    return new Program(formatIdl(idl, programAddress, true), getProvider(url));
+                }
+            }
         } catch (e) {
             console.error('Error creating anchor program for', programAddress, e, { idl });
             return null;

--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -155,7 +155,14 @@ export function mapAccountToRows(accountData: any, accountType: IdlTypeDef, idl:
     });
 }
 
-function mapField(key: string, value: any, type: IdlType, idl: Idl, keySuffix?: any, nestingLevel = 0): ReactNode {
+export function mapField(
+    key: string,
+    value: any,
+    type: IdlType,
+    idl: Idl,
+    keySuffix?: any,
+    nestingLevel = 0
+): ReactNode {
     let itemKey = key;
     if (/^-?\d+$/.test(keySuffix)) {
         itemKey = `#${keySuffix}`;

--- a/app/utils/convertLegacyIdl.ts
+++ b/app/utils/convertLegacyIdl.ts
@@ -436,14 +436,19 @@ export function getIdlSpecType(idl: any): IdlSpec {
 
 export type IdlSpec = '0.1.0' | 'legacy';
 
-export function formatIdl(idl: any, programAddress?: string): Idl {
+export function formatIdl(idl: any, programAddress?: string, removeTypes = true): Idl {
     const spec = getIdlSpecType(idl);
 
     switch (spec) {
         case '0.1.0':
             return idl as Idl;
-        case 'legacy':
-            return removeUnusedTypes(convertLegacyIdl(idl as LegacyIdl, programAddress));
+        case 'legacy': {
+            let converted = convertLegacyIdl(idl as LegacyIdl, programAddress);
+            if (removeTypes) {
+                converted = removeUnusedTypes(converted);
+            }
+            return converted;
+        }
         default:
             throw new Error(`IDL spec not supported: ${spec}`);
     }

--- a/app/utils/convertLegacyIdl.ts
+++ b/app/utils/convertLegacyIdl.ts
@@ -192,8 +192,8 @@ function traverseIdlFields(fields: IdlDefinedFields, refs: Set<string>) {
         typeof field === 'string'
             ? traverseType(field, refs)
             : typeof field === 'object' && 'type' in field
-            ? traverseType(field.type, refs)
-            : traverseType(field, refs)
+                ? traverseType(field.type, refs)
+                : traverseType(field, refs)
     );
 }
 


### PR DESCRIPTION
TBD - sRFC number (waiting on Drift)

This PR adds support for decoding Ed25519 payloads that reference another program's instructions.

Example transaction on devnet - [for local testing](http://localhost:3000/tx/32jTSg2bLQLytXTrA7rgRTEZGE5uU2mMEMZFrnoZK6t4DsUtjVr1nZYUmypMwSrWcgPXG2rKH7MbCGDBPPbbWwP8?cluster=devnet)

Future to-do:
- When the Ed25519 precompile data is not externally referenced, meaning it is self-contained in the ed25519 ix data, then attempt to decode using the following outer-instruction's anchor idl. 