### PR TITLE
chore: improve semicolon rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
     "extends": ["next/core-web-vitals", "@solana/eslint-config-solana"],
     "plugins": ["testing-library"],
+    "rules": {
+        "semi": ["error", "always"]
+    },
     "overrides": [
         // Only uses Testing Library lint rules in test files
         {

--- a/app/api/domain-info/[domain]/route.ts
+++ b/app/api/domain-info/[domain]/route.ts
@@ -1,8 +1,8 @@
-import { Connection } from "@solana/web3.js"
-import { NextResponse } from "next/server"
+import { Connection } from "@solana/web3.js";
+import { NextResponse } from "next/server";
 
-import { MAINNET_BETA_URL } from "@/app/utils/cluster"
-import { getANSDomainInfo,getDomainInfo } from "@/app/utils/domain-info"
+import { MAINNET_BETA_URL } from "@/app/utils/cluster";
+import { getANSDomainInfo,getDomainInfo } from "@/app/utils/domain-info";
 
 type Params = {
     params: {

--- a/app/api/metadata/proxy/__tests__/endpoint.test.ts
+++ b/app/api/metadata/proxy/__tests__/endpoint.test.ts
@@ -13,12 +13,12 @@ function setEnvironment(key: string, value: string) {
 }
 
 jest.mock('node-fetch', () => {
-    const originalFetch = jest.requireActual('node-fetch')
+    const originalFetch = jest.requireActual('node-fetch');
     const mockFn = jest.fn();
 
     Object.assign(mockFn, originalFetch);
 
-    return mockFn
+    return mockFn;
 });
 
 jest.mock('dns', () => {
@@ -54,7 +54,7 @@ describe('metadata/[network] endpoint', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-    })
+    });
 
     it('should return status when disabled', async () => {
         setEnvironment('NEXT_PUBLIC_METADATA_ENABLED', 'false');
@@ -73,7 +73,7 @@ describe('metadata/[network] endpoint', () => {
     });
 
     it('should return proper status upon processig data', async () => {
-        setEnvironment('NEXT_PUBLIC_METADATA_ENABLED', 'true')
+        setEnvironment('NEXT_PUBLIC_METADATA_ENABLED', 'true');
 
         const { request, nextParams } = requestFactory();
         const response = await GET(request, nextParams);
@@ -101,5 +101,5 @@ describe('metadata/[network] endpoint', () => {
 
         const request = requestFactory(validUrl);
         expect((await GET(request.request, request.nextParams)).status).toBe(200);
-    })
+    });
 });

--- a/app/api/metadata/proxy/__tests__/fetch-resource.spec.ts
+++ b/app/api/metadata/proxy/__tests__/fetch-resource.spec.ts
@@ -6,12 +6,12 @@ import fetch, { Headers } from 'node-fetch';
 import { fetchResource } from '../feature';
 
 jest.mock('node-fetch', () => {
-    const originalFetch = jest.requireActual('node-fetch')
+    const originalFetch = jest.requireActual('node-fetch');
     const mockFn = jest.fn();
 
     Object.assign(mockFn, originalFetch);
 
-    return mockFn
+    return mockFn;
 });
 
 /**
@@ -39,7 +39,7 @@ describe('fetchResource', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-    })
+    });
 
     it('should be called with proper arguments', async () => {
         mockFetchOnce({}, new Headers({ 'Content-Type': 'application/json, charset=utf-8' }));
@@ -48,7 +48,7 @@ describe('fetchResource', () => {
 
         expect(fetch).toHaveBeenCalledWith(uri, expect.anything());
         expect(resource.data).toEqual({});
-    })
+    });
 
     it('should throw exception for unsupported media', async () => {
         mockFetchOnce();
@@ -56,7 +56,7 @@ describe('fetchResource', () => {
         expect(() => {
             return fetchResource(uri, headers, 100, 100);
         }).rejects.toThrowError('Unsupported Media Type');
-    })
+    });
 
     it('should throw exception upon exceeded size', async () => {
         mockRejectOnce(new Error('FetchError: content size at https://path/to/resour.ce over limit: 100'));
@@ -64,29 +64,29 @@ describe('fetchResource', () => {
         expect(() => {
             return fetchResource(uri, headers, 100, 100);
         }).rejects.toThrowError('Max Content Size Exceeded');
-    })
+    });
 
     it('should handle AbortSignal', async () => {
         class TimeoutError extends Error {
             constructor() {
-                super()
-                this.name = 'TimeoutError'
+                super();
+                this.name = 'TimeoutError';
             }
         }
         mockRejectOnce(new TimeoutError());
 
         expect(() => {
             return fetchResource(uri, headers, 100, 100);
-        }).rejects.toThrowError('Gateway Timeout')
-    })
+        }).rejects.toThrowError('Gateway Timeout');
+    });
 
     it('should handle size overflow', async () => {
         mockRejectOnce(new Error('file is over limit: 100'));
 
         expect(() => {
             return fetchResource(uri, headers, 100, 100);
-        }).rejects.toThrowError('Max Content Size Exceeded')
-    })
+        }).rejects.toThrowError('Max Content Size Exceeded');
+    });
 
     it('should handle unexpected result', async () => {
         // @ts-expect-error fetch does not have mocked fn
@@ -94,15 +94,15 @@ describe('fetchResource', () => {
 
         const fn = () => {
             return fetchResource(uri, headers, 100, 100);
-        }
+        };
 
         try {
             await fn();
         } catch(e: any) {
-            expect(e.message).toEqual('General Error')
-            expect(e.status).toEqual(500)
+            expect(e.message).toEqual('General Error');
+            expect(e.status).toEqual(500);
         }
-    })
+    });
 
     it('should handle malformed JSON response gracefully', async () => {
         // Mock fetch to return a response with invalid JSON
@@ -110,9 +110,9 @@ describe('fetchResource', () => {
         fetch.mockResolvedValueOnce({
             headers: new Headers({ 'Content-Type': 'application/json' }),
             // Simulate malformed JSON by rejecting during json parsing
-            json: async () => { throw new SyntaxError('Unexpected token < in JSON at position 0') }
+            json: async () => { throw new SyntaxError('Unexpected token < in JSON at position 0'); }
         });
 
         await expect(fetchResource(uri, headers, 100, 100)).rejects.toThrowError('Unsupported Media Type');
     });
-})
+});

--- a/app/api/metadata/proxy/feature/errors.ts
+++ b/app/api/metadata/proxy/feature/errors.ts
@@ -28,7 +28,7 @@ export const errors = {
     415: unsupportedMediaError,
     500: generalError,
     504: gatewayTimeoutError,
-}
+};
 
 export function matchAbortError(error: unknown): error is Error {
     return Boolean(error instanceof Error && error.name === 'AbortError');

--- a/app/api/metadata/proxy/feature/index.ts
+++ b/app/api/metadata/proxy/feature/index.ts
@@ -79,5 +79,5 @@ export async function fetchResource(
     if (isImage) return processBinary(response);
 
     // otherwise we throw error as we getting unexpected content
-    throw unsupportedMediaError
+    throw unsupportedMediaError;
 }

--- a/app/api/metadata/proxy/feature/ip.ts
+++ b/app/api/metadata/proxy/feature/ip.ts
@@ -12,14 +12,14 @@ const privateIPv4CIDRs = [
     '169.254.0.0/16',
     '100.64.0.0/10',
     '0.0.0.0/8',
-]
+];
 
 const privateIPv6CIDRs = [
     '::1/128',
     'fc00::/7',
     'fe80::/10',
     '::ffff:0:0/96'
-]
+];
 
 /**
  *  Check if an IP is in a CIDR block
@@ -34,7 +34,7 @@ function ipInRange(ip: Address.IPv4 | Address.IPv6, cidr: string) {
  *  Check if an IP falls within a private range
  */
 export function isPrivateIP(ip: string) {
-    const isIPv4 = Address.IPv4.isIPv4(ip)
+    const isIPv4 = Address.IPv4.isIPv4(ip);
     const normalizedIP = parse(ip);
 
     let isMatchedRanges: boolean;
@@ -60,7 +60,7 @@ export function isLocalhost(url: URL) {
  */
 export async function checkURLForPrivateIP(uri: URL | string) {
     try {
-        let url: URL
+        let url: URL;
         if (uri instanceof URL) {
             url = uri;
         } else {

--- a/app/api/metadata/proxy/feature/processors.ts
+++ b/app/api/metadata/proxy/feature/processors.ts
@@ -12,7 +12,7 @@ export async function processBinary(data: fetch.Response){
         // request binary data to check for max-size excess
         const buffer = await data.arrayBuffer();
 
-        return { data: buffer, headers }
+        return { data: buffer, headers };
     } catch(error) {
         if (matchMaxSizeError(error)) {
             throw errors[413];
@@ -34,7 +34,7 @@ export async function processJson(data: fetch.Response){
     try{
         const json = await data.json();
 
-        return { data: json, headers }
+        return { data: json, headers };
     } catch(error) {
         if (matchMaxSizeError(error)) {
             throw errors[413];

--- a/app/api/metadata/proxy/route.ts
+++ b/app/api/metadata/proxy/route.ts
@@ -29,7 +29,7 @@ export async function GET(
     const isProxyEnabled = process.env.NEXT_PUBLIC_METADATA_ENABLED === 'true';
 
     if (!isProxyEnabled) {
-        return respondWithError(404)
+        return respondWithError(404);
     }
 
     let uriParam: string;

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -181,7 +181,7 @@ export default function BlockLayout({ children, params }: Props) {
         <BlockProvider>
             <BlockLayoutInner params={params}>{children}</BlockLayoutInner>
         </BlockProvider>
-    )
+    );
 }
 
 const TABS: Tab[] = [

--- a/app/components/account/OwnedTokensCard.tsx
+++ b/app/components/account/OwnedTokensCard.tsx
@@ -138,11 +138,11 @@ function HoldingsDetailTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
 
 function HoldingsSummaryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     type MappedToken = {
-        amount: string,
-        logoURI?: string,
-        symbol?: string,
-        name?: string
-    }
+        amount: string;
+        logoURI?: string;
+        symbol?: string;
+        name?: string;
+    };
     const mappedTokens = new Map<string, MappedToken>();
     for (const { info: token, logoURI, symbol, name } of tokens) {
         const mintAddress = token.mint.toBase58();
@@ -157,7 +157,7 @@ function HoldingsSummaryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
             amount,
             logoURI,
             name,
-            symbol
+            symbol,
         });
     }
 

--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -298,9 +298,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
                             className={`dropdown-item${filterOption === filter ? ' active' : ''}`}
                             onClick={toggle}
                         >
-                            {filterOption === ALL_TOKENS
-                                ? 'All Tokens'
-                                : nameLookup.get(filterOption) || filterOption}
+                            {filterOption === ALL_TOKENS ? 'All Tokens' : nameLookup.get(filterOption) || filterOption}
                         </Link>
                     );
                 })}

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -30,7 +30,7 @@ type IndexedTransfer = {
 };
 
 async function fetchTokenInfo([_, address, cluster, url]: ['get-token-info', string, Cluster, string]) {
-    return await getTokenInfo(new PublicKey(address), cluster, url)
+    return await getTokenInfo(new PublicKey(address), cluster, url);
 }
 
 export function TokenTransfersCard({ address }: { address: string }) {

--- a/app/components/account/nftoken/NFTokenAccountHeader.tsx
+++ b/app/components/account/nftoken/NFTokenAccountHeader.tsx
@@ -55,8 +55,9 @@ export function NFTokenNFTHeader({ nft }: { nft: NftokenTypes.NftAccount }) {
 
                 <div>
                     <div className={'d-inline-flex align-items-center mt-2'}>
-                        <span className="badge badge-pill bg-dark">{`${nft.authority_can_update ? 'Mutable' : 'Immutable'
-                            }`}</span>
+                        <span className="badge badge-pill bg-dark">{`${
+                            nft.authority_can_update ? 'Mutable' : 'Immutable'
+                        }`}</span>
 
                         <InfoTooltip
                             bottom
@@ -92,8 +93,9 @@ export function NFTokenCollectionHeader({ collection }: { collection: NftokenTyp
 
                 <div>
                     <div className={'d-inline-flex align-items-center mt-2'}>
-                        <span className="badge badge-pill bg-dark">{`${collection.authority_can_update ? 'Mutable' : 'Immutable'
-                            }`}</span>
+                        <span className="badge badge-pill bg-dark">{`${
+                            collection.authority_can_update ? 'Mutable' : 'Immutable'
+                        }`}</span>
 
                         <InfoTooltip
                             bottom

--- a/app/components/account/nftoken/NFTokenAccountSection.tsx
+++ b/app/components/account/nftoken/NFTokenAccountSection.tsx
@@ -111,7 +111,7 @@ export const NftokenImage = ({ url, size }: { url: string | undefined; size: num
                 />
             </div>
         </>
-    )
+    );
 };
 
 const CollectionCard = ({ collection }: { collection: NftokenTypes.CollectionAccount }) => {

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -296,13 +296,13 @@ export function BlockHistoryCard({ block }: { block: VersionedBlockResponse }) {
                                             {tx.invocations.size === 0
                                                 ? 'NA'
                                                 : entries.map(([programId, count], i) => {
-                                                    return (
-                                                        <div key={i} className="d-flex align-items-center">
-                                                            <Address pubkey={new PublicKey(programId)} link />
-                                                            <span className="ms-2 text-muted">{`(${count})`}</span>
-                                                        </div>
-                                                    );
-                                                })}
+                                                      return (
+                                                          <div key={i} className="d-flex align-items-center">
+                                                              <Address pubkey={new PublicKey(programId)} link />
+                                                              <span className="ms-2 text-muted">{`(${count})`}</span>
+                                                          </div>
+                                                      );
+                                                  })}
                                         </td>
                                     </tr>
                                 );

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -97,23 +97,26 @@ const useTokenMetadata = (useMetadata: boolean | undefined, pubkey: string) => {
     const [data, setData] = useState<programs.metadata.MetadataData>();
     const { url } = useCluster();
 
-    useAsyncEffect(async isMounted => {
-        if (!useMetadata) return;
-        if (pubkey && !data) {
-            try {
-                const pda = await programs.metadata.Metadata.getPDA(pubkey);
-                const connection = new Connection(url);
-                const metadata = await programs.metadata.Metadata.load(connection, pda);
-                if (isMounted()) {
-                    setData(metadata.data);
-                }
-            } catch {
-                if (isMounted()) {
-                    setData(undefined);
+    useAsyncEffect(
+        async isMounted => {
+            if (!useMetadata) return;
+            if (pubkey && !data) {
+                try {
+                    const pda = await programs.metadata.Metadata.getPDA(pubkey);
+                    const connection = new Connection(url);
+                    const metadata = await programs.metadata.Metadata.load(connection, pda);
+                    if (isMounted()) {
+                        setData(metadata.data);
+                    }
+                } catch {
+                    if (isMounted()) {
+                        setData(undefined);
+                    }
                 }
             }
-        }
-    }, [useMetadata, pubkey, url, data, setData]);
+        },
+        [useMetadata, pubkey, url, data, setData]
+    );
     return { data };
 };
 
@@ -121,21 +124,24 @@ const useTokenInfo = (fetchTokenLabelInfo: boolean | undefined, pubkey: string) 
     const [info, setInfo] = useState<TokenLabelInfo>();
     const { cluster, url } = useCluster();
 
-    useAsyncEffect(async isMounted => {
-        if (!fetchTokenLabelInfo) return;
-        if (!info) {
-            try {
-                const token = await getTokenInfoWithoutOnChainFallback(new PublicKey(pubkey), cluster);
-                if (isMounted()) {
-                    setInfo(token);
-                }
-            } catch {
-                if (isMounted()) {
-                    setInfo(undefined);
+    useAsyncEffect(
+        async isMounted => {
+            if (!fetchTokenLabelInfo) return;
+            if (!info) {
+                try {
+                    const token = await getTokenInfoWithoutOnChainFallback(new PublicKey(pubkey), cluster);
+                    if (isMounted()) {
+                        setInfo(token);
+                    }
+                } catch {
+                    if (isMounted()) {
+                        setInfo(undefined);
+                    }
                 }
             }
-        }
-    }, [fetchTokenLabelInfo, pubkey, cluster, url, info, setInfo]);
+        },
+        [fetchTokenLabelInfo, pubkey, cluster, url, info, setInfo]
+    );
 
     return info;
 };

--- a/app/components/common/NFTArt.tsx
+++ b/app/components/common/NFTArt.tsx
@@ -34,11 +34,8 @@ export const NFTImageContent = ({ uri }: { uri?: string }) => {
     return (
         <div style={{ maxHeight: 200, width: 150 }}>
             {isLoading && <LoadingArtPlaceholder />}
-            <div
-                className={`rounded mx-auto ${isLoading ? 'd-none' : 'd-block'}`}
-                style={{ overflow: 'hidden' }}
-            >
-                <img alt="nft" src={uri? getProxiedUri(uri) : uri} width="100%" onLoad={() => setIsLoading(false)} />
+            <div className={`rounded mx-auto ${isLoading ? 'd-none' : 'd-block'}`} style={{ overflow: 'hidden' }}>
+                <img alt="nft" src={uri ? getProxiedUri(uri) : uri} width="100%" onLoad={() => setIsLoading(false)} />
             </div>
             {!isLoading && uri && <ViewOriginalArtContentLink src={uri} />}
         </div>

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -128,7 +128,13 @@ function decodeUrlParams(params: URLSearchParams): [TransactionData | string, UR
     }
 }
 
-export function TransactionInspectorPage({ signature, showTokenBalanceChanges }: { signature?: string; showTokenBalanceChanges: boolean }) {
+export function TransactionInspectorPage({
+    signature,
+    showTokenBalanceChanges,
+}: {
+    signature?: string;
+    showTokenBalanceChanges: boolean;
+}) {
     const [transaction, setTransaction] = React.useState<TransactionData>();
     const currentSearchParams = useSearchParams();
     const currentPathname = usePathname();
@@ -198,7 +204,11 @@ export function TransactionInspectorPage({ signature, showTokenBalanceChanges }:
             {signature ? (
                 <PermalinkView signature={signature} reset={reset} showTokenBalanceChanges={showTokenBalanceChanges} />
             ) : transaction ? (
-                <LoadedView transaction={transaction} onClear={reset} showTokenBalanceChanges={showTokenBalanceChanges} />
+                <LoadedView
+                    transaction={transaction}
+                    onClear={reset}
+                    showTokenBalanceChanges={showTokenBalanceChanges}
+                />
             ) : (
                 <RawInput value={paramString} setTransactionData={setTransaction} />
             )}
@@ -206,7 +216,14 @@ export function TransactionInspectorPage({ signature, showTokenBalanceChanges }:
     );
 }
 
-function PermalinkView({ signature, showTokenBalanceChanges }: { signature: string; reset: () => void; showTokenBalanceChanges: boolean }) {
+function PermalinkView({
+    signature,
+    showTokenBalanceChanges,
+}: {
+    signature: string;
+    reset: () => void;
+    showTokenBalanceChanges: boolean;
+}) {
     const details = useRawTransactionDetails(signature);
     const fetchTransaction = useFetchRawTransaction();
     const refreshTransaction = () => fetchTransaction(signature);
@@ -236,7 +253,15 @@ function PermalinkView({ signature, showTokenBalanceChanges }: { signature: stri
     return <LoadedView transaction={tx} onClear={reset} showTokenBalanceChanges={showTokenBalanceChanges} />;
 }
 
-function LoadedView({ transaction, onClear, showTokenBalanceChanges }: { transaction: TransactionData; onClear: () => void; showTokenBalanceChanges: boolean }) {
+function LoadedView({
+    transaction,
+    onClear,
+    showTokenBalanceChanges,
+}: {
+    transaction: TransactionData;
+    onClear: () => void;
+    showTokenBalanceChanges: boolean;
+}) {
     const { message, rawMessage, signatures } = transaction;
 
     const fetchAccountInfo = useFetchAccountInfo();

--- a/app/components/inspector/SimulatorCard.tsx
+++ b/app/components/inspector/SimulatorCard.tsx
@@ -1,17 +1,44 @@
 import { ProgramLogsCardBody } from '@components/ProgramLogsCardBody';
 import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@providers/accounts/tokens';
 import { useCluster } from '@providers/cluster';
-import { AccountLayout, MintLayout } from "@solana/spl-token";
-import { AccountInfo, AddressLookupTableAccount, Connection, MessageAddressTableLookup, ParsedAccountData, ParsedMessageAccount, SimulatedTransactionAccountInfo, TokenBalance, VersionedMessage, VersionedTransaction } from '@solana/web3.js';
+import { AccountLayout, MintLayout } from '@solana/spl-token';
+import {
+    AccountInfo,
+    AddressLookupTableAccount,
+    Connection,
+    MessageAddressTableLookup,
+    ParsedAccountData,
+    ParsedMessageAccount,
+    SimulatedTransactionAccountInfo,
+    TokenBalance,
+    VersionedMessage,
+    VersionedTransaction,
+} from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import { InstructionLogs, parseProgramLogs } from '@utils/program-logs';
 import React from 'react';
 
-import { generateTokenBalanceRows,TokenBalancesCardInner, TokenBalancesCardInnerProps } from '../transaction/TokenBalancesCard';
+import {
+    generateTokenBalanceRows,
+    TokenBalancesCardInner,
+    TokenBalancesCardInnerProps,
+} from '../transaction/TokenBalancesCard';
 
-export function SimulatorCard({ message, showTokenBalanceChanges }: { message: VersionedMessage; showTokenBalanceChanges: boolean }) {
+export function SimulatorCard({
+    message,
+    showTokenBalanceChanges,
+}: {
+    message: VersionedMessage;
+    showTokenBalanceChanges: boolean;
+}) {
     const { cluster, url } = useCluster();
-    const { simulate, simulating, simulationLogs: logs, simulationError, simulationTokenBalanceRows } = useSimulator(message);
+    const {
+        simulate,
+        simulating,
+        simulationLogs: logs,
+        simulationError,
+        simulationTokenBalanceRows,
+    } = useSimulator(message);
     if (simulating) {
         return (
             <div className="card">
@@ -64,7 +91,10 @@ export function SimulatorCard({ message, showTokenBalanceChanges }: { message: V
                 </div>
                 <ProgramLogsCardBody message={message} logs={logs} cluster={cluster} url={url} />
             </div>
-            {showTokenBalanceChanges && simulationTokenBalanceRows && !simulationError && simulationTokenBalanceRows.rows.length ? (
+            {showTokenBalanceChanges &&
+            simulationTokenBalanceRows &&
+            !simulationError &&
+            simulationTokenBalanceRows.rows.length ? (
                 <TokenBalancesCardInner rows={simulationTokenBalanceRows.rows} />
             ) : null}
         </>
@@ -93,18 +123,25 @@ function useSimulator(message: VersionedMessage) {
         (async () => {
             try {
                 const addressTableLookups: MessageAddressTableLookup[] = message.addressTableLookups;
-                const addressTableLookupKeys: PublicKey[] = addressTableLookups.map((addressTableLookup: MessageAddressTableLookup) => {
-                    return addressTableLookup.accountKey;
-                });
-                const addressTableLookupsFetched: (AccountInfo<Buffer> | null)[] = await connection.getMultipleAccountsInfo(addressTableLookupKeys);
-                const nonNullAddressTableLookups: AccountInfo<Buffer>[] = addressTableLookupsFetched.filter((o): o is AccountInfo<Buffer> => !!o);
+                const addressTableLookupKeys: PublicKey[] = addressTableLookups.map(
+                    (addressTableLookup: MessageAddressTableLookup) => {
+                        return addressTableLookup.accountKey;
+                    }
+                );
+                const addressTableLookupsFetched: (AccountInfo<Buffer> | null)[] =
+                    await connection.getMultipleAccountsInfo(addressTableLookupKeys);
+                const nonNullAddressTableLookups: AccountInfo<Buffer>[] = addressTableLookupsFetched.filter(
+                    (o): o is AccountInfo<Buffer> => !!o
+                );
 
-                const addressLookupTablesParsed: AddressLookupTableAccount[] = nonNullAddressTableLookups.map((addressTableLookup: AccountInfo<Buffer>, index) => {
-                    return new AddressLookupTableAccount({
-                        key: addressTableLookupKeys[index],
-                        state: AddressLookupTableAccount.deserialize(addressTableLookup.data)
-                    });
-                });
+                const addressLookupTablesParsed: AddressLookupTableAccount[] = nonNullAddressTableLookups.map(
+                    (addressTableLookup: AccountInfo<Buffer>, index) => {
+                        return new AddressLookupTableAccount({
+                            key: addressTableLookupKeys[index],
+                            state: AddressLookupTableAccount.deserialize(addressTableLookup.data),
+                        });
+                    }
+                );
 
                 // Fetch all the accounts before simulating
                 const accountKeys = message.getAccountKeys({
@@ -124,10 +161,10 @@ function useSimulator(message: VersionedMessage) {
                     replaceRecentBlockhash: true,
                 });
 
-                const mintToDecimals: { [mintPk: string]: number} =  getMintDecimals(
+                const mintToDecimals: { [mintPk: string]: number } = getMintDecimals(
                     accountKeys,
                     parsedAccountsPre.value,
-                    resp.value.accounts as SimulatedTransactionAccountInfo[],
+                    resp.value.accounts as SimulatedTransactionAccountInfo[]
                 );
 
                 const preTokenBalances: TokenBalance[] = [];
@@ -244,7 +281,7 @@ function getMintDecimals(
     accountKeys: PublicKey[],
     parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | null)[],
     accountDatasPost: SimulatedTransactionAccountInfo[]
-): { [mintPk: string]: number} {
+): { [mintPk: string]: number } {
     const mintToDecimals: { [mintPk: string]: number } = {};
     // Get all the necessary mint decimals by looking at parsed token accounts
     // and mints before, as well as mints after.
@@ -274,7 +311,11 @@ function getMintDecimals(
         // Token account after
         const accountDataPost = accountDatasPost.at(index)?.data[0];
         const accountOwnerPost = accountDatasPost.at(index)?.owner;
-        if (accountOwnerPost && isTokenProgramBase58(accountOwnerPost) && Buffer.from(accountDataPost!, 'base64').length === 82) {
+        if (
+            accountOwnerPost &&
+            isTokenProgramBase58(accountOwnerPost) &&
+            Buffer.from(accountDataPost!, 'base64').length === 82
+        ) {
             const accountParsedPost = MintLayout.decode(Buffer.from(accountDataPost!, 'base64'));
             mintToDecimals[key.toBase58()] = accountParsedPost.decimals;
         }

--- a/app/components/inspector/SimulatorCard.tsx
+++ b/app/components/inspector/SimulatorCard.tsx
@@ -104,7 +104,7 @@ function useSimulator(message: VersionedMessage) {
                         key: addressTableLookupKeys[index],
                         state: AddressLookupTableAccount.deserialize(addressTableLookup.data)
                     });
-                })
+                });
 
                 // Fetch all the accounts before simulating
                 const accountKeys = message.getAccountKeys({
@@ -128,7 +128,7 @@ function useSimulator(message: VersionedMessage) {
                     accountKeys,
                     parsedAccountsPre.value,
                     resp.value.accounts as SimulatedTransactionAccountInfo[],
-                )
+                );
 
                 const preTokenBalances: TokenBalance[] = [];
                 const postTokenBalances: TokenBalance[] = [];

--- a/app/components/transaction/TokenBalancesCard.tsx
+++ b/app/components/transaction/TokenBalancesCard.tsx
@@ -44,9 +44,8 @@ export function TokenBalancesCard({ signature }: SignatureProps) {
 }
 
 export type TokenBalancesCardInnerProps = {
-    rows: TokenBalanceRow[]
-}
-
+    rows: TokenBalanceRow[];
+};
 
 export function TokenBalancesCardInner({ rows }: TokenBalancesCardInnerProps) {
     const { cluster, url } = useCluster();

--- a/app/components/transaction/TokenBalancesCard.tsx
+++ b/app/components/transaction/TokenBalancesCard.tsx
@@ -40,7 +40,7 @@ export function TokenBalancesCard({ signature }: SignatureProps) {
         return null;
     }
 
-    return <TokenBalancesCardInner rows={rows} />
+    return <TokenBalancesCardInner rows={rows} />;
 }
 
 export type TokenBalancesCardInnerProps = {
@@ -61,7 +61,7 @@ export function TokenBalancesCardInner({ rows }: TokenBalancesCardInnerProps) {
                 setTokenInfosLoading(false);
             }
         });
-    }, [])
+    }, []);
 
     const accountRows = rows.map(({ account, delta, balance, mint }) => {
         const key = account.toBase58() + mint;

--- a/app/epoch/[epoch]/layout.tsx
+++ b/app/epoch/[epoch]/layout.tsx
@@ -2,9 +2,5 @@ import { EpochProvider } from '@providers/epoch';
 import { PropsWithChildren } from 'react';
 
 export default function EpochLayout({ children }: PropsWithChildren<Record<string, never>>) {
-  return (
-    <EpochProvider>
-      {children}
-    </EpochProvider>
-  );
+    return <EpochProvider>{children}</EpochProvider>;
 }

--- a/app/features/metadata/utils.ts
+++ b/app/features/metadata/utils.ts
@@ -8,4 +8,4 @@ export const getProxiedUri = (uri: string): string => {
     if (!["http:", "https:"].includes(url.protocol)) return uri;
 
     return `/api/metadata/proxy?uri=${encodeURIComponent(uri)}`;
-}
+};

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -66,24 +66,39 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
         const { value: tokenAccounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
             programId: TOKEN_PROGRAM_ID,
         });
-        const { value: token2022Accounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
-            programId: TOKEN_2022_PROGRAM_ID,
-        });
+        const { value: token2022Accounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(
+            pubkey,
+            {
+                programId: TOKEN_2022_PROGRAM_ID,
+            }
+        );
 
-        const tokens: TokenInfoWithPubkey[] = tokenAccounts.concat(token2022Accounts).slice(0, 101).map(accountInfo => {
-            const parsedInfo = accountInfo.account.data.parsed.info;
-            const info = create(parsedInfo, TokenAccountInfo);
-            return { info, pubkey: accountInfo.pubkey };
-        });
+        const tokens: TokenInfoWithPubkey[] = tokenAccounts
+            .concat(token2022Accounts)
+            .slice(0, 101)
+            .map(accountInfo => {
+                const parsedInfo = accountInfo.account.data.parsed.info;
+                const info = create(parsedInfo, TokenAccountInfo);
+                return { info, pubkey: accountInfo.pubkey };
+            });
 
         // Fetch symbols and logos for tokens
-        const tokenMintInfos = await getTokenInfos(tokens.map(t => t.info.mint), cluster, url);
+        const tokenMintInfos = await getTokenInfos(
+            tokens.map(t => t.info.mint),
+            cluster,
+            url
+        );
         if (tokenMintInfos) {
-            const mappedTokenInfos = Object.fromEntries(tokenMintInfos.map(t => [t.address, {
-                logoURI: t.logoURI,
-                name: t.name,
-                symbol: t.symbol
-            }]));
+            const mappedTokenInfos = Object.fromEntries(
+                tokenMintInfos.map(t => [
+                    t.address,
+                    {
+                        logoURI: t.logoURI,
+                        name: t.name,
+                        symbol: t.symbol,
+                    },
+                ])
+            );
             tokens.forEach(t => {
                 const tokenInfo = mappedTokenInfos[t.info.mint.toString()];
                 if (tokenInfo) {
@@ -95,7 +110,7 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
         }
 
         data = {
-            tokens
+            tokens,
         };
         status = FetchStatus.Fetched;
     } catch (error) {

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -83,15 +83,15 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
                 logoURI: t.logoURI,
                 name: t.name,
                 symbol: t.symbol
-            }]))
+            }]));
             tokens.forEach(t => {
-                const tokenInfo = mappedTokenInfos[t.info.mint.toString()]
+                const tokenInfo = mappedTokenInfos[t.info.mint.toString()];
                 if (tokenInfo) {
                     t.logoURI = tokenInfo.logoURI ?? undefined;
                     t.symbol = tokenInfo.symbol;
                     t.name = tokenInfo.name;
                 }
-            })
+            });
         }
 
         data = {

--- a/app/providers/stats/solanaDashboardInfo.tsx
+++ b/app/providers/stats/solanaDashboardInfo.tsx
@@ -24,11 +24,11 @@ export enum DashboardInfoActionType {
 }
 
 export type EpochInfo = {
-    absoluteSlot: bigint,
-    blockHeight: bigint,
-    epoch: bigint,
-    slotIndex: bigint,
-    slotsInEpoch: bigint,
+    absoluteSlot: bigint;
+    blockHeight: bigint;
+    epoch: bigint;
+    slotIndex: bigint;
+    slotsInEpoch: bigint;
 };
 
 export type DashboardInfoActionSetPerfSamples = {
@@ -94,7 +94,8 @@ export function dashboardInfoReducer(state: DashboardInfo, action: DashboardInfo
                     return sum + cur;
                 }, 0) / samplesInHour;
 
-            const status = state.epochInfo.absoluteSlot !== BigInt(0) ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
+            const status =
+                state.epochInfo.absoluteSlot !== BigInt(0) ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
 
             return {
                 ...state,
@@ -115,9 +116,11 @@ export function dashboardInfoReducer(state: DashboardInfo, action: DashboardInfo
                 state.avgSlotTime_1h !== 0 &&
                 action.data.absoluteSlot >= state.lastBlockTime.slot
             ) {
-                blockTime =
-                    Number(BigInt(state.lastBlockTime.blockTime) +
-                        (action.data.absoluteSlot - state.lastBlockTime.slot) * BigInt(Math.floor(state.avgSlotTime_1h * 1000)));
+                blockTime = Number(
+                    BigInt(state.lastBlockTime.blockTime) +
+                        (action.data.absoluteSlot - state.lastBlockTime.slot) *
+                            BigInt(Math.floor(state.avgSlotTime_1h * 1000))
+                );
             }
 
             return {

--- a/app/utils/__tests__/epoch-schedule.ts
+++ b/app/utils/__tests__/epoch-schedule.ts
@@ -1,4 +1,4 @@
-import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch } from "../epoch-schedule"
+import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch } from "../epoch-schedule";
 
 describe('getEpoch', () => {
     it('returns the correct epoch for a slot after `firstNormalSlot`', () => {
@@ -6,14 +6,14 @@ describe('getEpoch', () => {
             firstNormalEpoch: 0n,
             firstNormalSlot: 0n,
             slotsPerEpoch: 432_000n
-        }
+        };
 
         expect(getEpochForSlot(schedule, 1n)).toEqual(0n);
         expect(getEpochForSlot(schedule, 431_999n)).toEqual(0n);
         expect(getEpochForSlot(schedule, 432_000n)).toEqual(1n);
         expect(getEpochForSlot(schedule, 500_000n)).toEqual(1n);
         expect(getEpochForSlot(schedule, 228_605_332n)).toEqual(529n);
-    })
+    });
 
     it('returns the correct epoch for a slot before `firstNormalSlot`', () => {
         const schedule: EpochSchedule = {
@@ -25,8 +25,8 @@ describe('getEpoch', () => {
         expect(getEpochForSlot(schedule, 1n)).toEqual(0n);
         expect(getEpochForSlot(schedule, 31n)).toEqual(0n);
         expect(getEpochForSlot(schedule, 32n)).toEqual(1n);
-    })
-})
+    });
+});
 
 describe('getFirstSlotInEpoch', () => {
     it('returns the first slot for an epoch after `firstNormalEpoch`', () => {
@@ -34,12 +34,12 @@ describe('getFirstSlotInEpoch', () => {
             firstNormalEpoch: 0n,
             firstNormalSlot: 0n,
             slotsPerEpoch: 100n
-        }
+        };
 
         expect(getFirstSlotInEpoch(schedule, 1n)).toEqual(100n);
         expect(getFirstSlotInEpoch(schedule, 2n)).toEqual(200n);
         expect(getFirstSlotInEpoch(schedule, 10n)).toEqual(1000n);
-    })
+    });
 
     it('returns the first slot for an epoch before `firstNormalEpoch`', () => {
         const schedule: EpochSchedule = {
@@ -52,8 +52,8 @@ describe('getFirstSlotInEpoch', () => {
         expect(getFirstSlotInEpoch(schedule, 1n)).toEqual(32n);
         expect(getFirstSlotInEpoch(schedule, 2n)).toEqual(96n);
         expect(getFirstSlotInEpoch(schedule, 10n)).toEqual(32_736n);
-    })
-})
+    });
+});
 
 describe('getLastSlotInEpoch', () => {
     it('returns the last slot for an epoch after `firstNormalEpoch`', () => {
@@ -61,12 +61,12 @@ describe('getLastSlotInEpoch', () => {
             firstNormalEpoch: 0n,
             firstNormalSlot: 0n,
             slotsPerEpoch: 100n
-        }
+        };
 
         expect(getLastSlotInEpoch(schedule, 1n)).toEqual(199n);
         expect(getLastSlotInEpoch(schedule, 2n)).toEqual(299n);
         expect(getLastSlotInEpoch(schedule, 10n)).toEqual(1099n);
-    })
+    });
 
     it('returns the first slot for an epoch before `firstNormalEpoch`', () => {
         const schedule: EpochSchedule = {
@@ -79,6 +79,6 @@ describe('getLastSlotInEpoch', () => {
         expect(getLastSlotInEpoch(schedule, 1n)).toEqual(95n);
         expect(getLastSlotInEpoch(schedule, 2n)).toEqual(223n);
         expect(getLastSlotInEpoch(schedule, 10n)).toEqual(65_503n);
-    })
-})
+    });
+});
 

--- a/app/utils/__tests__/math-test.ts
+++ b/app/utils/__tests__/math-test.ts
@@ -2,8 +2,8 @@ import { percentage } from '@utils/math';
 
 describe('percentage', () => {
   it('returns a number with the right decimals', () => {
-    expect(percentage(BigInt(1), BigInt(3), 0)).toEqual(33)
-    expect(percentage(BigInt(1), BigInt(3), 1)).toEqual(33.3)
-    expect(percentage(BigInt(1), BigInt(3), 2)).toEqual(33.33)
+    expect(percentage(BigInt(1), BigInt(3), 0)).toEqual(33);
+    expect(percentage(BigInt(1), BigInt(3), 1)).toEqual(33.3);
+    expect(percentage(BigInt(1), BigInt(3), 2)).toEqual(33.33);
   });
 });

--- a/app/utils/ans-domains.tsx
+++ b/app/utils/ans-domains.tsx
@@ -1,12 +1,11 @@
-import { NameRecordHeader,TldParser } from '@onsol/tldparser';
+import { NameRecordHeader, TldParser } from '@onsol/tldparser';
 import { Connection } from '@solana/web3.js';
 import pLimit from 'p-limit';
-import { useEffect,useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useCluster } from '../providers/cluster';
 import { Cluster } from './cluster';
 import { DomainInfo } from './domain-info';
-
 
 export const useUserANSDomains = (userAddress: string): [DomainInfo[] | null, boolean] => {
     const { url, cluster } = useCluster();
@@ -46,10 +45,7 @@ export const useUserANSDomains = (userAddress: string): [DomainInfo[] | null, bo
 
                         const tld = await parser.getTldFromParentAccount(domainRecord?.parentName);
 
-                        const domain = await parser.reverseLookupNameAccount(
-                            address,
-                            domainParentNameAccount?.owner
-                        );
+                        const domain = await parser.reverseLookupNameAccount(address, domainParentNameAccount?.owner);
 
                         // domain not found or might be a subdomain.
                         if (!domain) return;

--- a/app/utils/coingecko.tsx
+++ b/app/utils/coingecko.tsx
@@ -46,7 +46,7 @@ export type CoinGeckoResult = {
 };
 
 export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
-    const { cluster } = useCluster()
+    const { cluster } = useCluster();
     const [coinInfo, setCoinInfo] = React.useState<CoinGeckoResult>();
     const { visible: isTabVisible } = useTabVisibility();
     React.useEffect(() => {

--- a/app/utils/coingecko.tsx
+++ b/app/utils/coingecko.tsx
@@ -71,14 +71,14 @@ export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
                 try {
                     const response = await fetch(
                         `https://api.coingecko.com/api/v3/coins/${coinId}?` +
-                        [
-                            'community_data=false',
-                            'developer_data=false',
-                            'localization=false',
-                            'market_data=true',
-                            'sparkline=false',
-                            'tickers=false',
-                        ].join('&')
+                            [
+                                'community_data=false',
+                                'developer_data=false',
+                                'localization=false',
+                                'market_data=true',
+                                'sparkline=false',
+                                'tickers=false',
+                            ].join('&')
                     );
                     if (stale) {
                         return;

--- a/app/utils/token-info.ts
+++ b/app/utils/token-info.ts
@@ -92,11 +92,11 @@ export async function getTokenInfoWithoutOnChainFallback(
             "Content-Type": "application/json",
         },
         method: 'POST',
-    })
+    });
 
     if (response.status >= 400) {
         console.error(`Error calling UTL API for address ${address} on chain ID ${chainId}. Status ${response.status}`);
-        return undefined
+        return undefined;
     }
 
     const fetchedData = await response.json() as UtlApiResponse;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start": "next start",
         "scan": "next dev & react-scan localhost:3000",
         "lint": "next lint",
+        "format": "prettier **.{ts,tsx} *.json --check",
         "test": "jest --watch",
         "test:ci": "jest --ci"
     },


### PR DESCRIPTION
- [x] Add semicolon rule for `eslint`
    - Current configuration allows to be inconsistent with semicolon
- [x] Add script to check for format errors (it uses current configuration for `prettier`)

Next thing that might be good to implement: check for prettier' errors at lint step. This allows to prevent passing CI checks for codebase formatted incorrectly.