### PR TITLE
chore: disable no-explicit-any rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
     "extends": ["next/core-web-vitals", "@solana/eslint-config-solana"],
     "plugins": ["testing-library"],
+    "rules": {
+        // Temporary rule to ignore any explicit any type warnings in TypeScript files
+        "@typescript-eslint/no-explicit-any": "off"
+    },
     "overrides": [
         // Only uses Testing Library lint rules in test files
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "plugins": ["testing-library"],
     "rules": {
         // Temporary rule to ignore any explicit any type warnings in TypeScript files
-        "@typescript-eslint/no-explicit-any": "off"
+        "@typescript-eslint/no-explicit-any": "off",
+        "object-curly-spacing": ["error", "always"]
     },
     "overrides": [
         // Only uses Testing Library lint rules in test files


### PR DESCRIPTION
That PR turns `no-explicit-any` rule off.

Current codebase has quite a lot of these warnings. Disable it to not cover other warnings and errors.

Another candidate is `@typescript-eslint/no-non-null-assertion`. It's kinda frequent, but it's better to fix (not disable) it at the separate PR.