### PR TITLE
Only hyperlink proper http urls

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -969,10 +969,14 @@ function TokenExtensionRows(
                     <tr>
                         <td>URI</td>
                         <td className="text-lg-end">
-                            <a rel="noopener noreferrer" target="_blank" href={extension.uri}>
-                                {extension.uri}
-                                <ExternalLink className="align-text-top ms-2" size={13} />
-                            </a>
+                            {extension.uri.startsWith('http') ? (
+                                <a rel="noopener noreferrer" target="_blank" href={extension.uri}>
+                                    {extension.uri}
+                                    <ExternalLink className="align-text-top ms-2" size={13} />
+                                </a>
+                            ) : (
+                                extension.uri
+                            )}
                         </td>
                     </tr>
                     {extension.additionalMetadata?.length > 0 && (


### PR DESCRIPTION
## Description

Security related
<!-- Provide a brief description of the changes in this PR -->

## Type of change

-   [x] Bug fix

## Testing

Tested locally

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hyperlinking to only allow HTTP URLs in `TokenAccountSection.tsx`.
> 
>   - **Behavior**:
>     - In `TokenAccountSection.tsx`, only URLs starting with 'http' are hyperlinked in the `TokenExtensionRows` function.
>     - Non-HTTP URLs are displayed as plain text, preventing them from being clickable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 95fcb7d99be16b6ccdae4e075cf0772897a2f299. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->