### PR TITLE
chore: update vite config to remove deplrecation warnings with CJS fe…

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -26,8 +26,10 @@ export default defineConfig({
         coverage: {
             provider: 'v8'
         },
-        deps: {
-            inline: ['@noble', 'change-case', '@react-hook/previous']
+        server: {
+            deps: {
+                inline: ['@noble', 'change-case', '@react-hook/previous']
+            },
         },
         environment: 'jsdom',
         globals: true,


### PR DESCRIPTION
## Description

Update config for vitest to disable deprecated usage of CJS implementation of fetch. Changed deprecated format for deps also.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Other (please describe): fix deprecations

## Testing

`pnpm t`

You won't wee deprecation warnings from vitest

## Related Issues

Relates to #494 

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `vite.config.mts` to remove deprecation warnings by moving `deps` under `server`.
> 
>   - **Configuration Update**:
>     - Renamed `vite.config.ts` to `vite.config.mts`.
>     - Moved `deps` configuration under `server` in `vite.config.mts` to address deprecation warnings related to CJS fetch implementation.
>   - **Testing**:
>     - Running `pnpm t` will no longer show deprecation warnings from vitest.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for beafd40f5ee0cd8c138773f5ae4772dd0958690f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->