### PR TITLE
fix: Incorrect instruction decompression in inspector

### DIFF
--- a/app/components/common/BaseRawDetails.tsx
+++ b/app/components/common/BaseRawDetails.tsx
@@ -68,7 +68,7 @@ function BaseMessageCompiledInstructionRawDetails({
     return (
         <>
             {ix.accountKeyIndexes.map((accountIndex, index) => {
-                const { lookup, dynamicLookups } = findLookupAddress(accountIndex, message, lookupsForAccountKeyIndex);
+                const dynamicLookups = findLookupAddress(accountIndex, message, lookupsForAccountKeyIndex);
 
                 return (
                     <tr key={index}>
@@ -87,7 +87,7 @@ function BaseMessageCompiledInstructionRawDetails({
                         </td>
                         <td className="text-lg-end">
                             {dynamicLookups.isStatic ? (
-                                <AddressWithContext pubkey={lookup} />
+                                <AddressWithContext pubkey={message.staticAccountKeys[accountIndex]} />
                             ) : (
                                 <AddressFromLookupTableWithContext
                                     lookupTableKey={dynamicLookups.lookups.lookupTableKey}

--- a/app/components/common/inspector/AddressTableLookupAddress.tsx
+++ b/app/components/common/inspector/AddressTableLookupAddress.tsx
@@ -13,12 +13,12 @@ export function AddressTableLookupAddress({
     hideInfo?: boolean;
 }) {
     const lookupsForAccountKeyIndex = fillAddressTableLookupsAccounts(message.addressTableLookups);
-    const { lookup, dynamicLookups } = findLookupAddress(accountIndex, message, lookupsForAccountKeyIndex);
+    const dynamicLookups = findLookupAddress(accountIndex, message, lookupsForAccountKeyIndex);
 
     return (
         <>
             {dynamicLookups.isStatic ? (
-                <AddressWithContext pubkey={lookup} hideInfo={hideInfo} />
+                <AddressWithContext pubkey={message.staticAccountKeys[accountIndex]} hideInfo={hideInfo} />
             ) : (
                 <AddressFromLookupTableWithContext
                     lookupTableKey={dynamicLookups.lookups.lookupTableKey}


### PR DESCRIPTION
## Description

The inspector is not decompressing correctly account metas, leading to lookup table addresses showing instead of the actual address

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
