### PR TITLE
feat: add sleep to leverage 429s

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,9 @@ jobs:
         run: pnpm install
 
       - name: Build
-        env:
-          NEXT_PUBLIC_MAINNET_RPC_URL: ${{ vars.NEXT_PUBLIC_MAINNET_RPC_URL }}
-          NEXT_PUBLIC_DEVNET_RPC_URL: ${{ vars.NEXT_PUBLIC_DEVNET_RPC_URL }}
         run: pnpm build
 
       - name: Test
         env:
-          NEXT_PUBLIC_MAINNET_RPC_URL: ${{ vars.NEXT_PUBLIC_MAINNET_RPC_URL }}
-          NEXT_PUBLIC_DEVNET_RPC_URL: ${{ vars.NEXT_PUBLIC_DEVNET_RPC_URL }}
+          TEST_SERIAL_TIMEOUT: ${{ vars.TEST_SERIAL_TIMEOUT }}
         run: pnpm test:ci

--- a/app/__tests__/mocks.ts
+++ b/app/__tests__/mocks.ts
@@ -92,6 +92,7 @@ export function deserializeInstruction(instruction: string): MessageCompiledInst
 }
 
 export async function sleep(ms?: number): Promise<void> {
-    const timeoutMs = ms || (process.env.TEST_SERIAL_TIMEOUT ? Number(process.env.TEST_SERIAL_TIMEOUT.trim()) : 1000);
+    const timeoutMs = ms || (process.env.TEST_SERIAL_TIMEOUT ? Number(process.env.TEST_SERIAL_TIMEOUT.trim()) : 1500);
+    console.log({timeoutMs})
     return await new Promise(resolve => setTimeout(resolve, timeoutMs));
 }

--- a/app/__tests__/mocks.ts
+++ b/app/__tests__/mocks.ts
@@ -93,6 +93,5 @@ export function deserializeInstruction(instruction: string): MessageCompiledInst
 
 export async function sleep(ms?: number): Promise<void> {
     const timeoutMs = ms || (process.env.TEST_SERIAL_TIMEOUT ? Number(process.env.TEST_SERIAL_TIMEOUT.trim()) : 1500);
-    console.log({ timeoutMs });
     return await new Promise(resolve => setTimeout(resolve, timeoutMs));
 }

--- a/app/__tests__/mocks.ts
+++ b/app/__tests__/mocks.ts
@@ -93,6 +93,6 @@ export function deserializeInstruction(instruction: string): MessageCompiledInst
 
 export async function sleep(ms?: number): Promise<void> {
     const timeoutMs = ms || (process.env.TEST_SERIAL_TIMEOUT ? Number(process.env.TEST_SERIAL_TIMEOUT.trim()) : 1500);
-    console.log({timeoutMs})
+    console.log({ timeoutMs });
     return await new Promise(resolve => setTimeout(resolve, timeoutMs));
 }

--- a/app/__tests__/mocks.ts
+++ b/app/__tests__/mocks.ts
@@ -90,3 +90,8 @@ export function deserializeInstruction(instruction: string): MessageCompiledInst
 
     return data;
 }
+
+export async function sleep(ms?: number): Promise<void> {
+    const timeoutMs = ms || (process.env.TEST_SERIAL_TIMEOUT ? Number(process.env.TEST_SERIAL_TIMEOUT.trim()) : 1000);
+    return await new Promise(resolve => setTimeout(resolve, timeoutMs));
+}

--- a/app/components/account/__test__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__test__/TokenExtensionRow.spec.tsx
@@ -2,8 +2,9 @@ import { TableCardBody } from '@components/common/TableCardBody';
 import { PublicKey } from '@solana/web3.js';
 import { render, screen } from '@testing-library/react';
 import { useSearchParams } from 'next/navigation';
-import { vi } from 'vitest';
+import { describe, vi } from 'vitest';
 
+import { sleep } from '@/app/__tests__/mocks';
 import { AccountsProvider } from '@/app/providers/accounts';
 import { ClusterProvider } from '@/app/providers/cluster';
 import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
@@ -20,6 +21,9 @@ useSearchParams.mockReturnValue({
 });
 
 describe('TokenExtensionRow', () => {
+    // sleep to allow not facing 429s
+    beforeEach(async () => await sleep());
+
     test('should render mintCloseAuthority extension', async () => {
         const data = {
             extension: 'mintCloseAuthority',

--- a/app/components/inspector/__tests__/InspectorPage.spec.tsx
+++ b/app/components/inspector/__tests__/InspectorPage.spec.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
+import { sleep } from '@/app/__tests__/mocks';
 import { AccountsProvider } from '@/app/providers/accounts';
 import { ClusterProvider } from '@/app/providers/cluster';
 import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
@@ -69,6 +70,9 @@ describe('TransactionInspectorPage with Squads Transaction', () => {
     ];
 
     beforeEach(async () => {
+        // sleep to allow not facing 429s
+        await sleep();
+
         // Setup search params mock
         const mockUseSearchParamsReturn = mockUseSearchParams();
         vi.spyOn(await import('next/navigation'), 'useSearchParams').mockReturnValue(mockUseSearchParamsReturn as any);


### PR DESCRIPTION
## Description

PR adds sleep timeout to request-intensive specs. That is needed as env variables at GithubActions are not visible across the forks.


## Type of change

-   [x] Other (please describe): chore improvement


## Testing

`pnpm t`


## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds sleep function to handle 429 errors in tests and updates CI to use `TEST_SERIAL_TIMEOUT`.
> 
>   - **Behavior**:
>     - Adds `sleep()` function in `mocks.ts` to introduce delays in tests to handle 429 errors.
>     - Updates `TokenExtensionRow.spec.tsx` and `InspectorPage.spec.tsx` to use `sleep()` in `beforeEach` to prevent rate limit errors.
>   - **CI/CD**:
>     - Updates `ci.yaml` to use `TEST_SERIAL_TIMEOUT` environment variable for test timeout configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 39b55d94950575f78f9d0c0e48d16846a8d13972. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->