### PR TITLE
prevent cnft compression page from crashing page

### DIFF
--- a/app/address/[address]/compression/page-client.tsx
+++ b/app/address/[address]/compression/page-client.tsx
@@ -2,8 +2,10 @@
 
 import { ParsedAccountRenderer } from '@components/account/ParsedAccountRenderer';
 import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { CompressedNFTInfoCard } from '@/app/components/account/CompressedNFTInfoCard';
+import { ErrorCard } from '@/app/components/common/ErrorCard';
 import { LoadingCard } from '@/app/components/common/LoadingCard';
 
 type Props = Readonly<{
@@ -17,9 +19,11 @@ function CompressionCardRenderer({
     onNotFound,
 }: React.ComponentProps<React.ComponentProps<typeof ParsedAccountRenderer>['renderComponent']>) {
     return (
-        <Suspense fallback={<LoadingCard />}>
-            {<CompressedNFTInfoCard account={account} onNotFound={onNotFound} />}
-        </Suspense>
+        <ErrorBoundary fallback={<ErrorCard text="Failed to load compression information" />}>
+            <Suspense fallback={<LoadingCard />}>
+                {<CompressedNFTInfoCard account={account} onNotFound={onNotFound} />}
+            </Suspense>
+        </ErrorBoundary>
     );
 }
 

--- a/app/address/[address]/compression/page-client.tsx
+++ b/app/address/[address]/compression/page-client.tsx
@@ -19,7 +19,11 @@ function CompressionCardRenderer({
     onNotFound,
 }: React.ComponentProps<React.ComponentProps<typeof ParsedAccountRenderer>['renderComponent']>) {
     return (
-        <ErrorBoundary fallback={<ErrorCard text="Failed to load compression information" />}>
+        <ErrorBoundary
+            fallbackRender={({ error }) => (
+                <ErrorCard text={`Failed to load compression information: ${error.message}`} />
+            )}
+        >
             <Suspense fallback={<LoadingCard />}>
                 {<CompressedNFTInfoCard account={account} onNotFound={onNotFound} />}
             </Suspense>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Prevent 429s from crashing application on /compression tab

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->
Locally

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

Fixes #551 

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Wrap `Suspense` with `ErrorBoundary` in `CompressionCardRenderer` to prevent crashes from 429 errors on the compression page.
> 
>   - **Behavior**:
>     - Wraps `Suspense` in `CompressionCardRenderer` with `ErrorBoundary` to prevent crashes from 429 errors.
>     - Displays `ErrorCard` with error message when compression information fails to load.
>   - **Files**:
>     - Modifies `page-client.tsx` to include `ErrorBoundary` and `ErrorCard`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 059f10cecded79b59dabb5ce9c4f0c340319458b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->