### PR TITLE
fix: add styles for headers to remove <h*> from <tr>

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -607,7 +607,10 @@ function cmpExtension(a: TokenExtension, b: TokenExtension) {
 function HHeader({ name }: { name: string }) {
     return (
         <tr>
-            <h4>{name}</h4>
+            {/*use important here as there is rule from .table-sm that affects all the underline elements*/}
+            <th colSpan={2} className="e-mb-2 !e-p-4 e-text-[15px] e-font-normal">
+                {name}
+            </th>
         </tr>
     );
 }
@@ -657,7 +660,7 @@ export function TokenExtensionRow(
             const extension = create(tokenExtension.state, TransferFeeConfig);
             return (
                 <>
-                    {headerStyle == 'header' ? <HHeader name="Transfer Fee Config" /> : null}
+                    {headerStyle === 'header' ? <HHeader name="Transfer Fee Config" /> : null}
                     {extension.transferFeeConfigAuthority && (
                         <tr>
                             <td>Transfer Fee Authority</td>
@@ -984,7 +987,10 @@ export function TokenExtensionRow(
                     {extension.additionalMetadata?.length > 0 && (
                         <>
                             <tr>
-                                <h5>Additional Metadata</h5>
+                                {/*use important here as there is rule from .table-sm that affects all the underline elements*/}
+                                <th colSpan={2} className="e-mb-2 e-h-5 !e-pl-6 e-font-normal e-italic">
+                                    Additional Metadata
+                                </th>
                             </tr>
                             {extension.additionalMetadata?.map(keyValuePair => (
                                 <tr key="{keyValuePair[0]}">

--- a/app/components/inspector/AddressTableLookupsCard.tsx
+++ b/app/components/inspector/AddressTableLookupsCard.tsx
@@ -55,9 +55,13 @@ export function AddressTableLookupsCard({ message }: { message: VersionedMessage
                         {lookupRows.length > 0 ? (
                             <tbody className="list">{lookupRows}</tbody>
                         ) : (
-                            <div className="card-footer">
-                                <div className="text-muted text-center">No entries found</div>
-                            </div>
+                            <tbody className="card-footer">
+                                <tr>
+                                    <td colSpan={4}>
+                                        <span className="text-muted text-center">No entries found</span>
+                                    </td>
+                                </tr>
+                            </tbody>
                         )}
                     </table>
                 </div>


### PR DESCRIPTION
## Description

PR fixes invalid HTML layout


## Type of change

-   [x] Bug fix


## Testing

`pnpm t`


## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix invalid HTML by replacing `<h*>` tags with styled `<th>` elements in `TokenAccountSection.tsx` and `AddressTableLookupsCard.tsx`.
> 
>   - **HTML Structure Fix**:
>     - Replace `<h4>` with styled `<th>` in `HHeader` in `TokenAccountSection.tsx`.
>     - Replace `<h5>` with styled `<th>` for "Additional Metadata" in `TokenAccountSection.tsx`.
>     - Replace `<div>` with `<tbody>` for "No entries found" in `AddressTableLookupsCard.tsx`.
>   - **Condition Check**:
>     - Correct `headerStyle` comparison from `==` to `===` in `TokenExtensionRow` in `TokenAccountSection.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 931751f61aee8275b7ea014fa09c740fd289dd54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->