### PR TITLE
chore(ci): upgrade checkout to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install package manager
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/checkout@v4. Pure maintenance, behavior unchanged.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade `actions/checkout` to v4 in CI workflow for Node 20 compatibility, with no behavior changes.
> 
>   - **CI Workflow**:
>     - Upgrade `actions/checkout` from `v3` to `v4` in `.github/workflows/ci.yaml` for Node 20 compatibility.
>     - No changes in behavior; purely a maintenance update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 1d6b23196396ad063ffbd9ded7422e015bf0794d. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->