### PR TITLE
chore: add default timeout for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   Build-And-Test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description

PR adds timeout for tests at CI

## Type of change

-   [x] Other (please describe): CI improvement


## Testing

`pnpm test:ci`


## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 20-minute timeout to `Build-And-Test` job in CI configuration.
> 
>   - **CI Configuration**:
>     - Adds `timeout-minutes: 20` to `Build-And-Test` job in `.github/workflows/ci.yaml` to limit CI job duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 5c09463b6eef90b2ddd077311cc04b8c6a4f360e. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->