### PR TITLE
feat: show Metaplex's metadata for T22 tokens

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -104,6 +104,11 @@ const TABS_LOOKUP: { [id: string]: Tab[] } = {
             slug: 'instructions',
             title: 'Instructions',
         },
+        {
+            path: 'metadata',
+            slug: 'metadata',
+            title: 'Metadata',
+        },
     ],
     'spl-token-2022:mint:metaplexNFT': [
         {

--- a/app/components/account/MetaplexMetadataCard.tsx
+++ b/app/components/account/MetaplexMetadataCard.tsx
@@ -10,8 +10,13 @@ export function MetaplexMetadataCard({ account, onNotFound }: { account?: Accoun
     const compressedNft = useCompressedNft({ address: account?.pubkey.toString() ?? '', url });
 
     const parsedData = account?.data?.parsed;
+
     if (!parsedData || !isTokenProgramData(parsedData) || parsedData.parsed.type !== 'mint' || !parsedData.nftData) {
         if (compressedNft && compressedNft.compression.compressed) {
+            return <CompressedMetadataCard compressedNft={compressedNft} />;
+        }
+        // Try to extract metadata for not compresed one, like PayPal USD
+        if (compressedNft && !compressedNft.compression.compressed) {
             return <CompressedMetadataCard compressedNft={compressedNft} />;
         }
         return onNotFound();


### PR DESCRIPTION
## Description

PR adds "Metadata" tab to display Metadata from Metaplex for TokenExtensions Tokens like PayPal USD

|
## Type of change

-   [x] New feature


## Screenshots

<img width="426" alt="image" src="https://github.com/user-attachments/assets/afa0b373-1130-46ff-8903-c3b0308f6d65" />


## Testing

`pnpm dev` & open: http://localhost:3000/address/2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo/metadata


## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)