### PR TITLE
feat: highlight identical addresses on hover

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -70,9 +70,28 @@ export function Address({
         addressLabel = overrideText;
     }
 
+    const handleMouseEnter = (text: string) => {
+        const elements = document.querySelectorAll(`[data-address="${text}"]`);
+        elements.forEach(el => {
+            (el as HTMLElement).classList.add('address-highlight');
+        });
+    };
+
+    const handleMouseLeave = (text: string) => {
+        const elements = document.querySelectorAll(`[data-address="${text}"]`);
+        elements.forEach(el => {
+            (el as HTMLElement).classList.remove('address-highlight');
+        });
+    };
+
     const content = (
         <Copyable text={address} replaceText={!alignRight}>
-            <span className="font-monospace">
+            <span
+                data-address={address}
+                className="font-monospace"
+                onMouseEnter={() => handleMouseEnter(address)}
+                onMouseLeave={() => handleMouseLeave(address)}
+            >
                 {link ? (
                     <Link className={truncate ? 'text-truncate address-truncate' : ''} href={addressPath}>
                         {addressLabel}

--- a/app/scss/_solana.scss
+++ b/app/scss/_solana.scss
@@ -571,3 +571,9 @@ pre {
 .feature-icon {
     font-size: 1.5rem;
 }
+
+.address-highlight {
+    outline: 1px dashed #33a382;
+    border-radius: 4px; 
+    box-sizing: border-box; 
+}


### PR DESCRIPTION
Highlight identical addresses on the page when hovering over an address with the mouse.

## Description

Implemented the effect by adding the CSS class `.address-highlight` and corresponding mouse event handlers to highlight identical address elements.

<!-- Provide a brief description of the changes in this PR -->

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/28a1ec38-b3c6-4c9f-b02d-5fcedf99fe72" />


<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [x] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds feature to highlight identical addresses on hover using mouse event handlers and a new CSS class in `Address.tsx` and `_solana.scss`.
> 
>   - **Behavior**:
>     - Adds mouse event handlers `handleMouseEnter` and `handleMouseLeave` in `Address.tsx` to add/remove `address-highlight` class on hover.
>     - Highlights identical addresses by adding `address-highlight` class to elements with matching `data-address` attribute.
>   - **Styles**:
>     - Adds `.address-highlight` class in `_solana.scss` with dashed outline and border-radius for styling highlighted addresses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 7148cd75e39ccf523010bbe7082c1423c3d39f93. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->