### PR TITLE
feature: Support base58 transaction messages

### DIFF
--- a/app/components/inspector/RawInputCard.tsx
+++ b/app/components/inspector/RawInputCard.tsx
@@ -231,13 +231,18 @@ export function RawInput({
             if (err instanceof Error) setError(err.message);
         }
 
-        // If not an account address, try to parse as base64 transaction data
         try {
-            buffer = Uint8Array.from(atob(input), c => c.charCodeAt(0));
+            // Try base58 decode, use result as Uint8Array
+            buffer = new Uint8Array(base58.decode(input));
         } catch (err) {
-            console.error(err);
-            setError('Input must be base64 encoded or a valid account address');
-            return;
+            // If base58 fails, try base64
+            try {
+                buffer = Uint8Array.from(atob(input), c => c.charCodeAt(0));
+            } catch (err) {
+                console.error(err);
+                setError('Input must be base58/base64 encoded or a valid account address');
+                return;
+            }
         }
 
         try {
@@ -277,7 +282,7 @@ export function RawInput({
         }
     }, [value, onInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const placeholder = 'Paste a raw base64 encoded transaction message or Squads vault transaction account';
+    const placeholder = 'Paste a raw base58/base64 encoded transaction message or Squads vault transaction account';
     return (
         <div className="card">
             <div className="card-header">


### PR DESCRIPTION
## Description

Many Solana wallets, RPCs and dApps use base58 transactions in their network requests. To improve the developer experience, support parsing base58 and base64 transactions on the inspector page.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/77842f3b-acc6-4c43-90c9-1e31f85c7cf8" />


## Testing

Tested with a base58 transaction and a base64 transaction

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for base58 transaction messages in `RawInputCard.tsx`, enhancing input parsing to handle both base58 and base64 formats.
> 
>   - **Behavior**:
>     - `RawInputCard.tsx` now supports parsing base58 and base64 transaction messages.
>     - Updates error message to "Input must be base58/base64 encoded or a valid account address".
>     - Changes placeholder text to "Paste a raw base58/base64 encoded transaction message or Squads vault transaction account".
>   - **Functions**:
>     - Adds base58 decoding logic in `RawInput` function.
>     - Modifies `onInput` to attempt base58 decoding before base64.
>   - **Misc**:
>     - Updates error handling to accommodate new input format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 52067d040c00388059c87176e9baef2603d57f21. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->