### PR TITLE
Show verified build status from different Osec Endpoint

### DIFF
--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -18,6 +18,7 @@ export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAcc
         programData: data.programData,
         programId: pubkey,
     });
+
     if (!data.programData) {
         return <ErrorCard text="Account has no data" />;
     }

--- a/app/components/common/VerifiedProgramBadge.tsx
+++ b/app/components/common/VerifiedProgramBadge.tsx
@@ -15,7 +15,11 @@ export function VerifiedProgramBadge({
     pubkey: PublicKey;
 }) {
     const { cluster } = useCluster();
-    const { isLoading, data: isVerified, error } = useIsProgramVerified({
+    const {
+        isLoading,
+        data: isVerified,
+        error,
+    } = useIsProgramVerified({
         programData,
         programId: pubkey,
     });

--- a/app/components/common/VerifiedProgramBadge.tsx
+++ b/app/components/common/VerifiedProgramBadge.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useCluster } from '@/app/providers/cluster';
 import { Cluster } from '@/app/utils/cluster';
 import { useClusterPath } from '@/app/utils/url';
-import { useVerifiedProgram } from '@/app/utils/verified-builds';
+import { useIsProgramVerified } from '@/app/utils/verified-builds';
 import { ProgramDataAccountInfo } from '@/app/validators/accounts/upgradeable-program';
 
 export function VerifiedProgramBadge({
@@ -15,9 +15,8 @@ export function VerifiedProgramBadge({
     pubkey: PublicKey;
 }) {
     const { cluster } = useCluster();
-    const { isLoading, data: registryInfo } = useVerifiedProgram({
-        programAuthority: programData.authority ? new PublicKey(programData.authority) : null,
-        programData: programData,
+    const { isLoading, data: isVerified, error } = useIsProgramVerified({
+        programData,
         programId: pubkey,
     });
     const verifiedBuildTabPath = useClusterPath({ pathname: `/address/${pubkey.toBase58()}/verified-build` });
@@ -34,16 +33,22 @@ export function VerifiedProgramBadge({
                 <span className="badge">Loading...</span>
             </h3>
         );
-    } else if (registryInfo) {
+    } else if (error) {
+        return (
+            <h3 className="mb-0">
+                <span className="badge bg-warning-soft rank">Error fetching verified build information</span>
+            </h3>
+        );
+    } else {
         let badgeClass = '';
         let badgeText = '';
 
-        if (registryInfo.is_verified) {
+        if (isVerified) {
             badgeClass = 'bg-success-soft';
             badgeText = 'Program Source Verified';
         } else {
             badgeClass = 'bg-warning-soft';
-            badgeText = 'Not verified';
+            badgeText = 'Program Not Verified';
         }
 
         return (
@@ -51,14 +56,6 @@ export function VerifiedProgramBadge({
                 <Link className={`c-pointer badge ${badgeClass} rank`} href={verifiedBuildTabPath}>
                     {badgeText}
                 </Link>
-            </h3>
-        );
-    } else {
-        const message =
-            !registryInfo || !registryInfo['repo_url'] ? 'Source Code Not Provided' : 'Program Not Verified';
-        return (
-            <h3 className="mb-0">
-                <span className="badge bg-warning-soft rank">{message}</span>
             </h3>
         );
     }

--- a/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
+++ b/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
@@ -8,55 +8,71 @@ import { Cluster } from '@/app/utils/cluster';
 import { VerifiedProgramBadge } from '../VerifiedProgramBadge';
 
 vi.mock('@/app/providers/cluster', () => ({
-  useCluster: vi.fn(),
+    useCluster: vi.fn(),
 }));
 vi.mock('@/app/utils/url', () => ({
-  useClusterPath: vi.fn(() => '/address/mock/verified-build'),
+    useClusterPath: vi.fn(() => '/address/mock/verified-build'),
 }));
 
 // Mock the useIsProgramVerified hook
 vi.mock('@/app/utils/verified-builds', () => ({
-  useIsProgramVerified: vi.fn(),
+    useIsProgramVerified: vi.fn(),
 }));
 
 import { useCluster } from '@/app/providers/cluster';
 import { useIsProgramVerified } from '@/app/utils/verified-builds';
 
 const mockProgramData = {
-  authority: new PublicKey('11111111111111111111111111111111'),
-  data: ['deadbeef', 'base64'] as [string, 'base64'],
-  slot: 123,
+    authority: new PublicKey('11111111111111111111111111111111'),
+    data: ['deadbeef', 'base64'] as [string, 'base64'],
+    slot: 123,
 };
 const mockPubkey = new PublicKey('cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK');
 
 describe('VerifiedProgramBadge (mocked useIsProgramVerified)', () => {
-  afterEach(() => vi.clearAllMocks());
+    afterEach(() => vi.clearAllMocks());
 
-  it('shows verified badge when isVerified is true', () => {
-    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
-    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: true, error: false, isLoading: false });
-    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
-    expect(screen.getByText(/Program Source Verified/i)).toBeInTheDocument();
-  });
+    it('shows verified badge when isVerified is true', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: true,
+            error: false,
+            isLoading: false,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/Program Source Verified/i)).toBeInTheDocument();
+    });
 
-  it('shows not verified badge when isVerified is false', () => {
-    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
-    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: false, isLoading: false });
-    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
-    expect(screen.getByText(/Not verified/i)).toBeInTheDocument();
-  });
+    it('shows not verified badge when isVerified is false', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: false,
+            error: false,
+            isLoading: false,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/Not verified/i)).toBeInTheDocument();
+    });
 
-  it('shows error badge when error is true', () => {
-    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
-    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: true, isLoading: false });
-    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
-    expect(screen.getByText(/Error fetching verified build information/i)).toBeInTheDocument();
-  });
+    it('shows error badge when error is true', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: false,
+            error: true,
+            isLoading: false,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/Error fetching verified build information/i)).toBeInTheDocument();
+    });
 
-  it('shows loading badge when isLoading is true', () => {
-    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
-    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: false, isLoading: true });
-    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
-  });
-}); 
+    it('shows loading badge when isLoading is true', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: false,
+            error: false,
+            isLoading: true,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    });
+});

--- a/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
+++ b/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
@@ -1,0 +1,62 @@
+import { PublicKey } from '@solana/web3.js';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+import { Cluster } from '@/app/utils/cluster';
+
+import { VerifiedProgramBadge } from '../VerifiedProgramBadge';
+
+vi.mock('@/app/providers/cluster', () => ({
+  useCluster: vi.fn(),
+}));
+vi.mock('@/app/utils/url', () => ({
+  useClusterPath: vi.fn(() => '/address/mock/verified-build'),
+}));
+
+// Mock the useIsProgramVerified hook
+vi.mock('@/app/utils/verified-builds', () => ({
+  useIsProgramVerified: vi.fn(),
+}));
+
+import { useCluster } from '@/app/providers/cluster';
+import { useIsProgramVerified } from '@/app/utils/verified-builds';
+
+const mockProgramData = {
+  authority: new PublicKey('11111111111111111111111111111111'),
+  data: ['deadbeef', 'base64'] as [string, 'base64'],
+  slot: 123,
+};
+const mockPubkey = new PublicKey('cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK');
+
+describe('VerifiedProgramBadge (mocked useIsProgramVerified)', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows verified badge when isVerified is true', () => {
+    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: true, error: false, isLoading: false });
+    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+    expect(screen.getByText(/Program Source Verified/i)).toBeInTheDocument();
+  });
+
+  it('shows not verified badge when isVerified is false', () => {
+    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: false, isLoading: false });
+    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+    expect(screen.getByText(/Not verified/i)).toBeInTheDocument();
+  });
+
+  it('shows error badge when error is true', () => {
+    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: true, isLoading: false });
+    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+    expect(screen.getByText(/Error fetching verified build information/i)).toBeInTheDocument();
+  });
+
+  it('shows loading badge when isLoading is true', () => {
+    (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.MainnetBeta });
+    (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: false, error: false, isLoading: true });
+    render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+}); 

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -74,17 +74,40 @@ export function useVerifiedProgramRegistry({
     }
 
     // Only trust entries that are verified and signed by a trusted signer or the program authority
-    const trustedEntries = registryData.filter(
-        entry => (TRUSTED_SIGNERS[entry.signer] || entry.signer === programAuthority?.toBase58()) && entry.is_verified
-    );
+    let orderedVerifiedEntries: OsecInfo[] = [];
+    if (programAuthority) {
+        const trustedEntries = registryData.filter(
+            entry =>
+                (TRUSTED_SIGNERS[entry.signer] || entry.signer === programAuthority?.toBase58()) && entry.is_verified
+        );
 
-    // Update the verification status of the trusted entries based on the on-chain hash
-    const hash = hashProgramData(programData);
-    trustedEntries.forEach(entry => {
-        entry.is_verified = hash === entry['on_chain_hash'];
-    });
+        // Update the verification status of the trusted entries based on the on-chain hash
+        const hash = hashProgramData(programData);
+        trustedEntries.forEach(entry => {
+            entry.is_verified = hash === entry['on_chain_hash'];
+        });
 
-    return { data: trustedEntries, isLoading: isRegistryLoading };
+        const mappedBySigner: Record<string, OsecInfo> = {};
+
+        // Map the registryData by signer in order to enforce hierarchy of trust
+        trustedEntries.forEach(entry => {
+            mappedBySigner[entry.signer] = entry;
+        });
+
+        // Get the program authority's entry first, then the trusted signers
+        const hierarchy = [...(programAuthority ? [programAuthority.toBase58()] : []), ...Object.keys(TRUSTED_SIGNERS)];
+        for (const signer of hierarchy) {
+            if (mappedBySigner[signer]) {
+                orderedVerifiedEntries.push(mappedBySigner[signer]);
+            }
+        }
+    } else {
+        orderedVerifiedEntries = registryData
+            .filter(entry => entry.is_verified && entry.is_frozen)
+            .sort((a, b) => new Date(a.last_verified_at).getTime() - new Date(b.last_verified_at).getTime());
+    }
+
+    return { data: orderedVerifiedEntries, isLoading: isRegistryLoading };
 }
 
 export function useIsProgramVerified({
@@ -128,31 +151,15 @@ export function useVerifiedProgram({
     options?: { suspense: boolean };
     programData?: ProgramDataAccountInfo;
 }) {
-    const { data: registryData } = useVerifiedProgramRegistry({
+    const { data: orderedVerifiedEntries } = useVerifiedProgramRegistry({
         options,
         programAuthority,
         programData,
         programId,
     });
 
-    const mappedBySigner: Record<string, OsecInfo> = {};
-
-    // Map the registryData by signer in order to enforce hierarchy of trust
-    registryData?.forEach(entry => {
-        mappedBySigner[entry.signer] = entry;
-    });
-
-    // Get the program authority's entry first, then the trusted signers
-    const hierarchy = [...(programAuthority ? [programAuthority.toBase58()] : []), ...Object.keys(TRUSTED_SIGNERS)];
-    const orderedVerifiedEntries: OsecInfo[] = [];
-    for (const signer of hierarchy) {
-        if (mappedBySigner[signer]) {
-            orderedVerifiedEntries.push(mappedBySigner[signer]);
-        }
-    }
-
     // Get the first verified entry
-    const verifiedData = orderedVerifiedEntries.find(entry => entry.is_verified);
+    const verifiedData = orderedVerifiedEntries?.find(entry => entry.is_verified);
 
     return useEnrichedOsecInfo({ options, osecInfo: verifiedData, programId });
 }
@@ -207,6 +214,8 @@ function useEnrichedOsecInfo({
 
     const message = TRUSTED_SIGNERS[osecInfo?.signer || '']
         ? 'Verification information provided by a trusted signer.'
+        : osecInfo.is_frozen
+        ? 'Verification information provided by the program deployer.'
         : 'Verification information provided by the program authority.';
 
     const enrichedOsecInfo: OsecRegistryInfo = {

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -87,7 +87,13 @@ export function useVerifiedProgramRegistry({
     return { data: trustedEntries, isLoading: isRegistryLoading };
 }
 
-export function useIsProgramVerified({ programId, programData }: { programId: PublicKey; programData: ProgramDataAccountInfo }) {
+export function useIsProgramVerified({
+    programId,
+    programData,
+}: {
+    programId: PublicKey;
+    programData: ProgramDataAccountInfo;
+}) {
     return useSWRImmutable(
         ['is-program-verified', programId.toBase58(), hashProgramData(programData)],
         async ([_prefix, programId, hash]) => {
@@ -96,7 +102,7 @@ export function useIsProgramVerified({ programId, programData }: { programId: Pu
             }
 
             const response = await fetch(`${OSEC_REGISTRY_URL}/status/${programId}`);
-            const osecInfo = await response.json() as OsecInfo;
+            const osecInfo = (await response.json()) as OsecInfo;
             return osecInfo.is_verified && hash === osecInfo['on_chain_hash'];
         }
     );


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Move from using `/status-all` to `/status` now that verify.osec.io uses PDA verification status for `/status`.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->
Adds tests for VerifiedBuildBadge and tab 

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

Fixes #456 

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches verification status endpoint to `/status`, updates logic, and adds tests for `VerifiedProgramBadge`.
> 
>   - **Behavior**:
>     - Switch from `/status-all` to `/status` endpoint in `useIsProgramVerified()` in `verified-builds.tsx`.
>     - Update `VerifiedProgramBadge` to handle new verification logic, including error and loading states.
>     - Display error message if fetching verification info fails.
>   - **Testing**:
>     - Add tests for `VerifiedProgramBadge` in `VerifiedProgramBadge.spec.tsx` to cover verified, not verified, error, and loading states.
>   - **Misc**:
>     - Rename `useVerifiedProgram` to `useIsProgramVerified` in `VerifiedProgramBadge.tsx` and `VerifiedBuildCard.tsx`.
>     - Add `is_frozen` field to `OsecInfo` type in `verified-builds.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for ca56a7ffbff9f0fff1aa237ee8136f91e5abf9d9. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->