### PR TITLE
Fix IDL caching

### DIFF
--- a/app/api/anchor/route.ts
+++ b/app/api/anchor/route.ts
@@ -3,7 +3,7 @@ import NodeWallet from '@coral-xyz/anchor/dist/cjs/nodewallet';
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import { NextResponse } from 'next/server';
 
-import { Cluster, clusterUrl } from '@/app/utils/cluster';
+import { Cluster, serverClusterUrl } from '@/app/utils/cluster';
 
 const CACHE_DURATION = 60 * 60; // 60 minutes
 
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
         return NextResponse.json({ error: 'Invalid query params' }, { status: 400 });
     }
 
-    const url = Number(clusterProp) in Cluster && clusterUrl(Number(clusterProp) as Cluster, '');
+    const url = Number(clusterProp) in Cluster && serverClusterUrl(Number(clusterProp) as Cluster, '');
 
     if (!url) {
         return NextResponse.json({ error: 'Invalid cluster' }, { status: 400 });

--- a/app/api/codama/route.ts
+++ b/app/api/codama/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getCodamaIdl } from '@/app/components/instruction/codama/getCodamaIdl';
-import { Cluster, clusterUrl } from '@/app/utils/cluster';
+import { Cluster, serverClusterUrl } from '@/app/utils/cluster';
 
 const CACHE_DURATION = 30 * 60; // 30 minutes
 
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
         return NextResponse.json({ error: 'Invalid query params' }, { status: 400 });
     }
 
-    const url = Number(clusterProp) in Cluster && clusterUrl(Number(clusterProp) as Cluster, '');
+    const url = Number(clusterProp) in Cluster && serverClusterUrl(Number(clusterProp) as Cluster, '');
 
     if (!url) {
         return NextResponse.json({ error: 'Invalid cluster' }, { status: 400 });

--- a/app/utils/cluster.ts
+++ b/app/utils/cluster.ts
@@ -43,15 +43,15 @@ export const MAINNET_BETA_URL = 'https://api.mainnet-beta.solana.com';
 export const TESTNET_URL = 'https://api.testnet.solana.com';
 export const DEVNET_URL = 'https://api.devnet.solana.com';
 
-export function clusterUrl(cluster: Cluster, customUrl: string): string {
-    const modifyUrl = (url: string): string => {
-        if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
-            return url;
-        } else {
-            return url.replace('api', 'explorer-api');
-        }
-    };
+const modifyUrl = (url: string): string => {
+    if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+        return url;
+    } else {
+        return url.replace('api', 'explorer-api');
+    }
+};
 
+export function clusterUrl(cluster: Cluster, customUrl: string): string {
     switch (cluster) {
         case Cluster.Devnet:
             return process.env.NEXT_PUBLIC_DEVNET_RPC_URL ?? modifyUrl(DEVNET_URL);
@@ -63,5 +63,19 @@ export function clusterUrl(cluster: Cluster, customUrl: string): string {
             return customUrl;
     }
 }
+
+export function serverClusterUrl(cluster: Cluster, customUrl: string): string {
+    switch (cluster) {
+        case Cluster.Devnet:
+            return process.env.DEVNET_RPC_URL ?? modifyUrl(DEVNET_URL);
+        case Cluster.MainnetBeta:
+            return process.env.MAINNET_RPC_URL ?? modifyUrl(MAINNET_BETA_URL);
+        case Cluster.Testnet:
+            return process.env.TESTNET_RPC_URL ?? modifyUrl(TESTNET_URL);
+        case Cluster.Custom:
+            return customUrl;
+    }
+}
+
 
 export const DEFAULT_CLUSTER = Cluster.MainnetBeta;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Env vars were not propagated to caching service, so IDLs were failing to be fetched (403 from public cluster urls)

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix IDL fetching by using server-specific environment variables for URL generation in caching service.
> 
>   - **Bug Fix**:
>     - Introduced `serverClusterUrl()` in `cluster.ts` to use server-specific environment variables for URL generation.
>     - Replaced `clusterUrl()` with `serverClusterUrl()` in `anchor/route.ts` and `codama/route.ts` to fix IDL fetching issues.
>   - **Functions**:
>     - `serverClusterUrl()` handles server-side URL generation using `DEVNET_RPC_URL`, `MAINNET_RPC_URL`, and `TESTNET_RPC_URL`.
>     - `modifyUrl()` refactored to be used by both `clusterUrl()` and `serverClusterUrl()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 872ff9a77b1d996778987538e9326747b56ad558. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->