### PR TITLE
Show T22 metadata name even when metadata json missing

### DIFF
--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -13,6 +13,7 @@ import { CompressedNftAccountHeader } from '@/app/components/account/CompressedN
 import { useMetadataJsonLink } from '@/app/providers/compressed-nft';
 import { FullTokenInfo } from '@/app/utils/token-info';
 import { MintAccountInfo } from '@/app/validators/accounts/token';
+import { getProxiedUri } from '@/app/features/metadata/utils';
 
 const IDENTICON_WIDTH = 64;
 
@@ -42,6 +43,7 @@ export function AccountHeader({
     }
 
     if (isToken && !isTokenInfoLoading) {
+        console.log('token', tokenInfo);
         return <TokenMintHeader address={address} mintInfo={mintInfo} parsedData={parsedData} tokenInfo={tokenInfo} />;
     }
 
@@ -93,6 +95,8 @@ function TokenMintHeader({
     );
 
     if (metadataPointerExtension && metadataExtension) {
+        console.log('pointer', metadataPointerExtension);
+        console.log('extension', metadataExtension);
         return (
             <>
                 <ErrorBoundary fallback={defaultCard}>
@@ -131,24 +135,23 @@ function Token22MintHeader({
     metadataExtension: { extension: 'tokenMetadata'; state?: any };
     metadataPointerExtension: { extension: 'metadataPointer'; state?: any };
 }) {
+    console.log('hit');
     const tokenMetadata = create(metadataExtension.state, TokenMetadata);
     const { metadataAddress } = create(metadataPointerExtension.state, MetadataPointer);
-    const metadata = useMetadataJsonLink(tokenMetadata.uri, { suspense: true });
+    const metadata = useMetadataJsonLink(getProxiedUri(tokenMetadata.uri), { suspense: true });
 
-    if (!metadata) {
-        throw new Error(`Could not load metadata from given URI: ${tokenMetadata.uri}`);
+    const headerTokenMetadata = {
+        logoURI: '',
+        name: tokenMetadata.name,
+    };
+    if (metadata) {
+        headerTokenMetadata.logoURI = metadata.image;
     }
 
     // Handles the basic case where MetadataPointer is referencing the Token Metadata extension directly
     // Does not handle the case where MetadataPointer is pointing at a separate account.
     if (metadataAddress?.toString() === address) {
-        return (
-            <TokenMintHeaderCard
-                address={address}
-                token={{ logoURI: metadata.image, name: metadata.name }}
-                unverified={false}
-            />
-        );
+        return <TokenMintHeaderCard address={address} token={headerTokenMetadata} unverified={false} />;
     }
     throw new Error('Metadata loading for non-token 2022 programs is not yet supported');
 }

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -10,10 +10,10 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { create } from 'superstruct';
 
 import { CompressedNftAccountHeader } from '@/app/components/account/CompressedNftCard';
+import { getProxiedUri } from '@/app/features/metadata/utils';
 import { useMetadataJsonLink } from '@/app/providers/compressed-nft';
 import { FullTokenInfo } from '@/app/utils/token-info';
 import { MintAccountInfo } from '@/app/validators/accounts/token';
-import { getProxiedUri } from '@/app/features/metadata/utils';
 
 const IDENTICON_WIDTH = 64;
 
@@ -43,7 +43,6 @@ export function AccountHeader({
     }
 
     if (isToken && !isTokenInfoLoading) {
-        console.log('token', tokenInfo);
         return <TokenMintHeader address={address} mintInfo={mintInfo} parsedData={parsedData} tokenInfo={tokenInfo} />;
     }
 
@@ -95,8 +94,6 @@ function TokenMintHeader({
     );
 
     if (metadataPointerExtension && metadataExtension) {
-        console.log('pointer', metadataPointerExtension);
-        console.log('extension', metadataExtension);
         return (
             <>
                 <ErrorBoundary fallback={defaultCard}>
@@ -135,7 +132,6 @@ function Token22MintHeader({
     metadataExtension: { extension: 'tokenMetadata'; state?: any };
     metadataPointerExtension: { extension: 'metadataPointer'; state?: any };
 }) {
-    console.log('hit');
     const tokenMetadata = create(metadataExtension.state, TokenMetadata);
     const { metadataAddress } = create(metadataPointerExtension.state, MetadataPointer);
     const metadata = useMetadataJsonLink(getProxiedUri(tokenMetadata.uri), { suspense: true });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
http://localhost:3000/address/J7r61vKwbof6VKwXfEW3R3hwzeF6sSnGjVmRxXHdyvW

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `Token22MintHeader` now displays token name from `tokenMetadata` even if metadata JSON is missing, using `getProxiedUri` for URI fetching.
> 
>   - **Behavior**:
>     - `Token22MintHeader` in `AccountHeader.tsx` now shows token name from `tokenMetadata` even if metadata JSON is missing.
>     - Uses `getProxiedUri` for URI fetching in `Token22MintHeader`.
>   - **Error Handling**:
>     - Removes error throw when metadata JSON is missing in `Token22MintHeader`.
>   - **Misc**:
>     - Minor refactor in `Token22MintHeader` to use `headerTokenMetadata` object for token data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 438cdd08bc11eb00798f090ddae69867ab85304a. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->