### PR TITLE
Add Support for Pausable Account Token Extension

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -516,6 +516,7 @@ function cmpExtension(a: TokenExtension, b: TokenExtension) {
         'nonTransferable',
         'nonTransferableAccount',
         'cpiGuard',
+        'pausableAccount',
         'permanentDelegate',
         'transferHook',
         'transferHookAccount',
@@ -801,6 +802,14 @@ export function TokenExtensionRow(
                         </td>
                     </tr>
                 </>
+            );
+        }
+        case 'pausableAccount': {
+            return (
+                <tr>
+                    <td>Pausable Account</td>
+                    <td className="text-lg-end">enabled</td>
+                </tr>
             );
         }
         case 'pausableConfig': {

--- a/app/components/account/__test__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__test__/TokenExtensionRow.spec.tsx
@@ -251,9 +251,7 @@ describe('TokenExtensionRow', () => {
     test('should render pausableAccount extension', async () => {
         const data = {
             extension: 'pausableAccount',
-            state: {
-                paused: true,
-            },
+            state: {},
         } as TokenExtension;
 
         render(

--- a/app/components/account/__test__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__test__/TokenExtensionRow.spec.tsx
@@ -248,6 +248,28 @@ describe('TokenExtensionRow', () => {
         expect(screen.getByText('4.22')).toBeInTheDocument();
     });
 
+    test('should render pausableAccount extension', async () => {
+        const data = {
+            extension: 'pausableAccount',
+            state: {
+                paused: true,
+            },
+        } as TokenExtension;
+
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <AccountsProvider>
+                        <TableCardBody>{TokenExtensionRow(data, undefined, 6, undefined)}</TableCardBody>
+                    </AccountsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>
+        );
+
+        expect(await screen.findByText('Pausable Account')).toBeInTheDocument();
+        expect(screen.getByText('enabled')).toBeInTheDocument();
+    });
+
     test('should render pausableConfig extension', async () => {
         const data = {
             extension: 'pausableConfig',

--- a/app/utils/token-extension.ts
+++ b/app/utils/token-extension.ts
@@ -233,7 +233,9 @@ export function populatePartialParsedTokenExtension(
         }
         case 'pausableAccount': {
             return {
-                externalLinks: [{ label: 'Docs', url: 'https://www.solana-program.com/docs/token-2022/extensions#pausable' }],
+                externalLinks: [
+                    { label: 'Docs', url: 'https://www.solana-program.com/docs/token-2022/extensions#pausable' },
+                ],
                 name: 'Pausable Account',
                 status: 'active',
                 tooltip: 'This account can be paused by the Pausable extension',

--- a/app/utils/token-extension.ts
+++ b/app/utils/token-extension.ts
@@ -231,6 +231,14 @@ export function populatePartialParsedTokenExtension(
                 tooltip: description,
             };
         }
+        case 'pausableAccount': {
+            return {
+                externalLinks: [{ label: 'Docs', url: 'https://www.solana-program.com/docs/token-2022/extensions#pausable' }],
+                name: 'Pausable Account',
+                status: 'active',
+                tooltip: 'This account can be paused by the Pausable extension',
+            };
+        }
         case 'pausableConfig': {
             const description =
                 'Allows the token program to pause all interactions including transfers, mints, and burns';

--- a/app/validators/accounts/token-extension.ts
+++ b/app/validators/accounts/token-extension.ts
@@ -27,6 +27,7 @@ const ExtensionType = enums([
     'tokenGroup',
     'tokenGroupMember',
     'scaledUiAmountConfig',
+    'pausableAccount',
     'pausableConfig',
     'unparseableExtension',
 ]);


### PR DESCRIPTION
# Add Support for Pausable Account Token Extension

## Description

<!-- Provide a brief description of the changes in this PR -->
This PR adds support for the new `pausableAccount` token extension in the Solana Explorer. The pausable account extension signifies token accounts that can be paused by the pausable extension.

## Type of change

<!-- Check the appropriate options that apply to this PR -->
- Added `pausableAccount` to the list of supported token extensions in `TokenAccountSection.tsx`
- Implemented UI rendering for the pausable account extension in `TokenExtensionRow`
- Added `pausableAccount` to the `ExtensionType` enum in `token-extension.ts`
- Added unit tests for the pausable account extension in `TokenExtensionRow.spec.tsx`

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots
![image](https://github.com/user-attachments/assets/fe8c2cb8-5a74-4a07-bc8a-f1bcf55dfca2)

## Testing

- Added unit tests to verify the correct rendering of the pausable account extension
- Test coverage includes verification of the extension's display and status

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->
N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [x] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `pausableAccount` token extension in Solana Explorer, including UI, enum updates, and tests.
> 
>   - **Behavior**:
>     - Add `pausableAccount` to supported token extensions in `TokenAccountSection.tsx`.
>     - Implement UI rendering for `pausableAccount` in `TokenExtensionRow`.
>     - Add `pausableAccount` to `ExtensionType` enum in `token-extension.ts`.
>   - **Testing**:
>     - Add unit tests for `pausableAccount` in `TokenExtensionRow.spec.tsx`.
>   - **Documentation**:
>     - Update `populatePartialParsedTokenExtension` in `token-extension.ts` to include `pausableAccount`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 353682d53fedf2c9da02dd96e3caad7cb22c55db. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->