### PR TITLE
Parse Solana Attestation Service emit event ix properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "react-select": "^5.10.1",
         "remark-frontmatter": "^4.0.1",
         "remark-gfm": "^3.0.1",
-        "sas-lib": "^1.0.6",
+        "sas-lib": "1.0.8",
         "superstruct": "^0.15.3",
         "swr": "^2.2.0",
         "tailwind-merge": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       sas-lib:
-        specifier: ^1.0.6
-        version: 1.0.6(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+        specifier: 1.0.8
+        version: 1.0.8(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       superstruct:
         specifier: ^0.15.3
         version: 0.15.3
@@ -7276,8 +7276,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sas-lib@1.0.6:
-    resolution: {integrity: sha512-6dmtgz4XiEv0KDNB1MsG9aKhJ6YhJb4bqBBcLNb7RE7FwE/8Wow9PcS7uzkmA0G3AKUfkFEDYJQFAImd6phHsQ==}
+  sas-lib@1.0.8:
+    resolution: {integrity: sha512-+uGvLnqtgxSMiKt0zSymNri2VVjgYPZktekydHlW89HiA0HpTME+HhHTix9lgmp4Vfjpep37wA3Vd5kKm/pesQ==}
 
   sass@1.53.0:
     resolution: {integrity: sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==}
@@ -17426,7 +17426,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sas-lib@1.0.6(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)):
+  sas-lib@1.0.8(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)):
     dependencies:
       '@solana/kit': 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       bn.js: 5.2.1


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

`sas-lib` IDL for emit event instruction wasn't formatted properly, causing the generated parsers to throw, which prevented us from decoding the ix.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->
http://localhost:3000/tx/347b1iWi3pm4HJ2fQPhtStnkTzbuoeuczHoy2Lhws2vTVRqiHjm47EDhh3cqsjsC5axgnWWG5qBLkmmEDVmp7Ubk

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
