### PR TITLE
Fix issue where Feature Gate activated before merged as simd

### DIFF
--- a/app/utils/feature-gate/featureGates.json
+++ b/app/utils/feature-gate/featureGates.json
@@ -936,5 +936,24 @@
     "comms_required": null,
     "mainnet_activation_epoch": null,
     "description": null
+  },
+  {
+    "key": "JE86WkYvTrzW8HgNmrHY7dFYpCmSptUpKupbo2AdQ9cG",
+    "title": "Dynamic stack frames",
+    "simd_link": [
+      "https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0166-dynamic-stack-frames.md"
+    ],
+    "simds": [
+      "0166"
+    ],
+    "owners": [],
+    "min_agave_versions": [],
+    "min_fd_versions": [],
+    "min_jito_versions": [],
+    "testnet_activation_epoch": 797,
+    "devnet_activation_epoch": 902,
+    "comms_required": null,
+    "mainnet_activation_epoch": 809,
+    "description": null
   }
 ]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Include feat gate in list of activate feat gaes

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a new feature gate entry for "Dynamic stack frames" to `featureGates.json`, setting activation epochs for testnet, devnet, and mainnet.
> 
>   - **Behavior**:
>     - Adds a new feature gate entry for "Dynamic stack frames" in `featureGates.json`.
>     - Sets `testnet_activation_epoch` to 797, `devnet_activation_epoch` to 902, and `mainnet_activation_epoch` to 809.
>   - **Misc**:
>     - Ensures the feature gate is included in the list of activated feature gates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for caae659088c640c3bb16cc1872a360004e2010cc. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->