### PR TITLE
Fix for Borsh version 0.7.0 to fix SAS Attestation decode

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -52,6 +52,7 @@ import { useSquadsMultisigLookup } from '@/app/providers/squadsMultisig';
 import { isAttestationAccount } from '@/app/utils/attestation-service';
 import { getFeatureInfo, useFeatureInfo } from '@/app/utils/feature-gate/utils';
 import { FullTokenInfo, getFullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
+import * as _ from '@/app/types/bigint';
 
 const TABS_LOOKUP: { [id: string]: Tab[] } = {
     'address-lookup-table': [

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 import './styles.css';
+import '@/app/types/bigint'; // polyfill toJSON for BigInt
 
 import { AddressLookupTableAccountSection } from '@components/account/address-lookup-table/AddressLookupTableAccountSection';
 import { isAddressLookupTableAccount } from '@components/account/address-lookup-table/types';
@@ -52,7 +53,6 @@ import { useSquadsMultisigLookup } from '@/app/providers/squadsMultisig';
 import { isAttestationAccount } from '@/app/utils/attestation-service';
 import { getFeatureInfo, useFeatureInfo } from '@/app/utils/feature-gate/utils';
 import { FullTokenInfo, getFullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
-import * as _ from '@/app/types/bigint';
 
 const TABS_LOOKUP: { [id: string]: Tab[] } = {
     'address-lookup-table': [

--- a/app/components/account/sas/AttestationDataCard.tsx
+++ b/app/components/account/sas/AttestationDataCard.tsx
@@ -11,7 +11,7 @@ import {
 import {
     decodeAccount,
     decodeWithType,
-    deserializeAttestationDataWithBorsh070,
+    deserializeAttestationDataWithBorsh200,
     isAttestationAccount,
 } from '@/app/utils/attestation-service';
 import { mapToPublicKey } from '@/app/utils/kit-wrapper';
@@ -63,7 +63,7 @@ function AttestationCard({ attestation }: { attestation: SasAttestation }) {
     try {
         if (schemaAccountInfo?.data) {
             const schema: SasSchema = decodeWithType(schemaAccountInfo.data, 'schema', decodeSchema)?.data.data;
-            decoded = deserializeAttestationDataWithBorsh070(schema, Uint8Array.from(attestation.data));
+            decoded = deserializeAttestationDataWithBorsh200(schema, Uint8Array.from(attestation.data));
         }
     } catch (e) {
         console.error(e);

--- a/app/types/bigint.ts
+++ b/app/types/bigint.ts
@@ -1,0 +1,8 @@
+export {};
+
+Object.defineProperty(BigInt.prototype, "toJSON", {
+  get() {
+      "use strict";
+      return () => String(this);
+  }
+});

--- a/app/types/bigint.ts
+++ b/app/types/bigint.ts
@@ -1,8 +1,11 @@
-export {};
+// eslint-disable-next-line no-prototype-builtins
+if (!BigInt.prototype.hasOwnProperty('toJSON')) {
+    Object.defineProperty(BigInt.prototype, 'toJSON', {
+        get() {
+            'use strict';
+            return () => String(this);
+        },
+    });
+}
 
-Object.defineProperty(BigInt.prototype, "toJSON", {
-  get() {
-      "use strict";
-      return () => String(this);
-  }
-});
+export {};

--- a/app/utils/attestation-service.tsx
+++ b/app/utils/attestation-service.tsx
@@ -1,6 +1,5 @@
 import { Account } from '@providers/accounts';
-import { deserialize } from 'borsh';
-import { deserialize as deserializeWithVersion200 } from 'borsh2';
+import { deserialize } from 'borsh2';
 import {
     convertSasSchemaToBorshSchema,
     decodeAttestation,
@@ -58,58 +57,11 @@ export function isAttestationAccount(account: Account) {
     }
 }
 
-/**
-    Helper function to deserialize attestation data using the borsh@0.7.0 API
-    This is annoying because sas-lib relies on @solana/kit which uses borsh@2.0.0 but metaplex & other libraries use borsh@0.7.0
-    This is a workaround to get the data deserialized correctly.
-
-    TODO: remove implementation upon refactoring with major or minor change
-
-    @deprecated - legacy deserialization should not be used
-*/
-export function deserializeAttestationDataWithBorsh070(schema: SasSchema, data: Uint8Array) {
-    // 1. Use sas-lib to convert its schema into a borsh-compatible format.
-    const sasBorshSchema = convertSasSchemaToBorshSchema(schema);
-    // @ts-expect-error borsh@0.7.0 actually exposes private schema field, even though it's not typed
-    const fields = Object.entries(sasBorshSchema.schema.struct);
-
-    // 2. We must dynamically create a class that has the properties defined in the schema.
-    const DynamicAttestationData = class {
-        constructor(properties: any) {
-            Object.keys(properties).forEach(key => {
-                (this as any)[key] = properties[key];
-            });
-        }
-    };
-
-    // Add properties to the class prototype from the schema fields
-    fields.forEach(([fieldName]) => {
-        Object.defineProperty(DynamicAttestationData.prototype, fieldName, {
-            enumerable: true,
-            writable: true,
-        });
-    });
-
-    // 3. The borsh@0.7.0 deserialize function requires a Map object
-    // where the key is the class and the value is the schema definition.
-    const schemaMap = new Map<any, any>();
-    const borsh070Schema = {
-        fields: fields,
-        kind: 'struct',
-    };
-    schemaMap.set(DynamicAttestationData, borsh070Schema);
-
-    // 4. Call borsh@0.7.0's deserialize function with the correct arguments.
-    // It will return an instance of DynamicAttestationData with populated fields.
-    return deserialize(schemaMap, DynamicAttestationData, Buffer.from(data));
-}
-
 // Helper function to deserialize attestation data using the borsh@2.0.0 API
 export function deserializeAttestationDataWithBorsh200(schema: SasSchema, data: Uint8Array) {
     // Use sas-lib to convert its schema into a borsh-compatible format.
     const sasBorshSchema = convertSasSchemaToBorshSchema(schema);
 
     // @ts-expect-error borsh@2.0.0 actually exposes private schema field, even though it's not typed
-    const deserializedData = deserializeWithVersion200(sasBorshSchema.schema, data);
-    return deserializedData;
+    return deserialize(sasBorshSchema.schema, data);
 }

--- a/app/utils/attestation-service.tsx
+++ b/app/utils/attestation-service.tsx
@@ -1,5 +1,6 @@
 import { Account } from '@providers/accounts';
 import { deserialize } from 'borsh';
+import { deserialize as deserializeWithVersion200 } from 'borsh2';
 import {
     convertSasSchemaToBorshSchema,
     decodeAttestation,
@@ -95,4 +96,14 @@ export function deserializeAttestationDataWithBorsh070(schema: SasSchema, data: 
     // 4. Call borsh@0.7.0's deserialize function with the correct arguments.
     // It will return an instance of DynamicAttestationData with populated fields.
     return deserialize(schemaMap, DynamicAttestationData, Buffer.from(data));
+}
+
+// Helper function to deserialize attestation data using the borsh@2.0.0 API
+export function deserializeAttestationDataWithBorsh200(schema: SasSchema, data: Uint8Array) {
+    // Use sas-lib to convert its schema into a borsh-compatible format.
+    const sasBorshSchema = convertSasSchemaToBorshSchema(schema);
+
+    // @ts-expect-error borsh@2.0.0 actually exposes private schema field, even though it's not typed
+    const deserializedData = deserializeWithVersion200(sasBorshSchema.schema, data);
+    return deserializedData;
 }

--- a/app/utils/attestation-service.tsx
+++ b/app/utils/attestation-service.tsx
@@ -58,9 +58,15 @@ export function isAttestationAccount(account: Account) {
     }
 }
 
-// Helper function to deserialize attestation data using the borsh@0.7.0 API
-// This is annoying because sas-lib relies on @solana/kit which uses borsh@2.0.0 but metaplex & other libraries use borsh@0.7.0
-// This is a workaround to get the data deserialized correctly.
+/**
+    Helper function to deserialize attestation data using the borsh@0.7.0 API
+    This is annoying because sas-lib relies on @solana/kit which uses borsh@2.0.0 but metaplex & other libraries use borsh@0.7.0
+    This is a workaround to get the data deserialized correctly.
+
+    TODO: remove implementation upon refactoring with major or minor change
+
+    @deprecated - legacy deserialization should not be used
+*/
 export function deserializeAttestationDataWithBorsh070(schema: SasSchema, data: Uint8Array) {
     // 1. Use sas-lib to convert its schema into a borsh-compatible format.
     const sasBorshSchema = convertSasSchemaToBorshSchema(schema);

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "bignumber.js": "^9.0.2",
         "bn.js": "5.2.1",
         "borsh": "0.7.0",
+        "borsh2": "npm:borsh@2.0.0",
         "bs58": "^4.0.1",
         "change-case": "^5.4.4",
         "chart.js": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       borsh:
         specifier: 0.7.0
         version: 0.7.0
+      borsh2:
+        specifier: npm:borsh@2.0.0
+        version: borsh@2.0.0
       bs58:
         specifier: ^4.0.1
         version: 4.0.1
@@ -4310,6 +4313,9 @@ packages:
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   borsher@4.0.0:
     resolution: {integrity: sha512-DrbMSz/xg0bFRiiqe8S0nXEr1whp96hcEHAriKFOlpG2wTihMrg5zZNFH+m4tMcnDY/klKws2YRVHjD4jpdiKg==}
@@ -13819,6 +13825,8 @@ snapshots:
       bn.js: 5.2.1
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  borsh@2.0.0: {}
 
   borsher@4.0.0:
     dependencies:


### PR DESCRIPTION
## Description

We had an issue with SAS Attestation decode using Borsh 0.7.0.
This PR fixes it using Borsh 2.0.0 and existing methods for SAS Schema conversion to Borsh schema.
Seems that we should remove previous implementation for Borsh 0.7.0 or mark it as deprecated.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<img width="1504" height="1386" alt="image" src="https://github.com/user-attachments/assets/e4a2d696-cb0d-4dc7-bc38-04d32d24b075" />

## Testing

Link to broken Attestation example:
https://explorer.solana.com/address/4qNvYnG85MWaBmDu56GXfg22gR1GyuhDPHbjUGoz2Hm3/attestation

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SAS Attestation decode by updating to Borsh 2.0.0 and updating deserialization methods.
> 
>   - **Behavior**:
>     - Fixes SAS Attestation decode issue by updating to Borsh 2.0.0.
>     - Replaces `deserializeAttestationDataWithBorsh070` with `deserializeAttestationDataWithBorsh200` in `AttestationDataCard.tsx`.
>   - **Utilities**:
>     - Adds `deserializeAttestationDataWithBorsh200()` in `attestation-service.tsx` for Borsh 2.0.0 deserialization.
>     - Retains `deserializeAttestationDataWithBorsh070()` for backward compatibility.
>   - **Dependencies**:
>     - Adds `borsh2` as an alias for Borsh 2.0.0 in `package.json`.
>   - **Misc**:
>     - Adds `toJSON` method to `BigInt.prototype` in `bigint.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 1cf7db9a4db4a1d3c12936704545673adf9bbe29. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->