### PR TITLE
fix: Add dynamic compute unit limits per epoch

### DIFF
--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -11,6 +11,7 @@ import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { displayTimestamp, displayTimestampUtc } from '@utils/date';
 import { useClusterPath } from '@utils/url';
+import { getMaxComputeUnitsInBlock } from '@/app/utils/epoch-schedule';
 import Link from 'next/link';
 import { notFound, useSelectedLayoutSegment } from 'next/navigation';
 import React, { PropsWithChildren } from 'react';
@@ -18,8 +19,6 @@ import React, { PropsWithChildren } from 'react';
 import { getEpochForSlot } from '@/app/utils/epoch-schedule';
 
 type Props = PropsWithChildren<{ params: { slot: string } }>;
-
-const MAX_CU_PER_BLOCK = 50_000_000;
 
 function BlockLayoutInner({ children, params: { slot } }: Props) {
     const slotNumber = Number(slot);
@@ -57,6 +56,7 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
         const showSuccessfulCount = block.transactions.every(tx => tx.meta !== null);
         const successfulTxs = block.transactions.filter(tx => tx.meta?.err === null);
         const epoch = clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber)) : undefined;
+        const maxComputeUnits = getMaxComputeUnitsInBlock(epoch ? Number(epoch) : undefined);
 
         content = (
             <>
@@ -172,8 +172,8 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
                             <td className="w-100">Compute Unit Utilization</td>
                             <td className="text-lg-end font-monospace">
                                 <span>
-                                    {totalCUs.toLocaleString()} / {MAX_CU_PER_BLOCK.toLocaleString()} (
-                                    {Math.round((totalCUs / MAX_CU_PER_BLOCK) * 100)}%)
+                                    {totalCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
+                                    {Math.round((totalCUs / maxComputeUnits) * 100)}%)
                                 </span>
                             </td>
                         </tr>
@@ -181,8 +181,8 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
                             <td className="w-100">Successful Compute Unit Utilization</td>
                             <td className="text-lg-end font-monospace">
                                 <span>
-                                    {successfulCUs.toLocaleString()} / {MAX_CU_PER_BLOCK.toLocaleString()} (
-                                    {Math.round((successfulCUs / MAX_CU_PER_BLOCK) * 100)}%)
+                                    {successfulCUs.toLocaleString()} / {maxComputeUnits.toLocaleString()} (
+                                    {Math.round((successfulCUs / maxComputeUnits) * 100)}%)
                                 </span>
                             </td>
                         </tr>

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -27,7 +27,7 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
     }
     const confirmedBlock = useBlock(slotNumber);
     const fetchBlock = useFetchBlock();
-    const { clusterInfo, status } = useCluster();
+    const { clusterInfo, status, cluster } = useCluster();
     const refresh = () => fetchBlock(slotNumber);
 
     // Fetch block on load
@@ -56,7 +56,7 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
         const showSuccessfulCount = block.transactions.every(tx => tx.meta !== null);
         const successfulTxs = block.transactions.filter(tx => tx.meta?.err === null);
         const epoch = clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber)) : undefined;
-        const maxComputeUnits = getMaxComputeUnitsInBlock(epoch ? Number(epoch) : undefined);
+        const maxComputeUnits = getMaxComputeUnitsInBlock({epoch, cluster});
 
         content = (
             <>

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -11,12 +11,11 @@ import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { displayTimestamp, displayTimestampUtc } from '@utils/date';
 import { useClusterPath } from '@utils/url';
-import { getMaxComputeUnitsInBlock } from '@/app/utils/epoch-schedule';
 import Link from 'next/link';
 import { notFound, useSelectedLayoutSegment } from 'next/navigation';
 import React, { PropsWithChildren } from 'react';
 
-import { getEpochForSlot } from '@/app/utils/epoch-schedule';
+import { getEpochForSlot, getMaxComputeUnitsInBlock } from '@/app/utils/epoch-schedule';
 
 type Props = PropsWithChildren<{ params: { slot: string } }>;
 
@@ -56,7 +55,7 @@ function BlockLayoutInner({ children, params: { slot } }: Props) {
         const showSuccessfulCount = block.transactions.every(tx => tx.meta !== null);
         const successfulTxs = block.transactions.filter(tx => tx.meta?.err === null);
         const epoch = clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber)) : undefined;
-        const maxComputeUnits = getMaxComputeUnitsInBlock({epoch, cluster});
+        const maxComputeUnits = getMaxComputeUnitsInBlock({ cluster, epoch });
 
         content = (
             <>

--- a/app/utils/__tests__/epoch-schedule.ts
+++ b/app/utils/__tests__/epoch-schedule.ts
@@ -1,4 +1,4 @@
-import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch } from '../epoch-schedule';
+import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch, getMaxComputeUnitsInBlock } from '../epoch-schedule';
 
 describe('getEpoch', () => {
     it('returns the correct epoch for a slot after `firstNormalSlot`', () => {
@@ -79,5 +79,18 @@ describe('getLastSlotInEpoch', () => {
         expect(getLastSlotInEpoch(schedule, 1n)).toEqual(95n);
         expect(getLastSlotInEpoch(schedule, 2n)).toEqual(223n);
         expect(getLastSlotInEpoch(schedule, 10n)).toEqual(65_503n);
+    });
+});
+
+describe('getMaxComputeUnitsForEpoch', () => {
+    it('returns the correct max compute units for an epoch', () => {
+        expect(getMaxComputeUnitsInBlock(0)).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock(769)).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock(770)).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock(821)).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock(822)).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock(823)).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock(undefined)).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock(-1)).toEqual(48_000_000);
     });
 });

--- a/app/utils/__tests__/epoch-schedule.ts
+++ b/app/utils/__tests__/epoch-schedule.ts
@@ -1,3 +1,4 @@
+import { Cluster } from '../cluster';
 import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch, getMaxComputeUnitsInBlock } from '../epoch-schedule';
 
 describe('getEpoch', () => {
@@ -83,14 +84,47 @@ describe('getLastSlotInEpoch', () => {
 });
 
 describe('getMaxComputeUnitsForEpoch', () => {
-    it('returns the correct max compute units for an epoch', () => {
-        expect(getMaxComputeUnitsInBlock(0)).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock(769)).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock(770)).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock(821)).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock(822)).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock(823)).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock(undefined)).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock(-1)).toEqual(48_000_000);
+    it('returns the correct max compute units for an epoch on mainnet', () => {
+        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 769n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 770n, cluster: Cluster.MainnetBeta})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 821n, cluster: Cluster.MainnetBeta})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 822n, cluster: Cluster.MainnetBeta})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 823n, cluster: Cluster.MainnetBeta})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
+    });
+
+    it('returns the correct max compute units for an epoch on devnet', () => {
+        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Devnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 856n, cluster: Cluster.Devnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 857n, cluster: Cluster.Devnet})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 914n, cluster: Cluster.Devnet})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 915n, cluster: Cluster.Devnet})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 916n, cluster: Cluster.Devnet})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Devnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Devnet})).toEqual(48_000_000);
+    });
+
+    it('returns the correct max compute units for an epoch on testnet', () => {
+        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Testnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 763n, cluster: Cluster.Testnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 764n, cluster: Cluster.Testnet})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 811n, cluster: Cluster.Testnet})).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 812n, cluster: Cluster.Testnet})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 813n, cluster: Cluster.Testnet})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Testnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Testnet})).toEqual(48_000_000);
+    });
+
+    it('returns the correct max compute units for an epoch on custom', () => {
+        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 769n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 770n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 821n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 822n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: 823n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Custom})).toEqual(60_000_000);
     });
 });

--- a/app/utils/__tests__/epoch-schedule.ts
+++ b/app/utils/__tests__/epoch-schedule.ts
@@ -1,5 +1,11 @@
 import { Cluster } from '../cluster';
-import { EpochSchedule, getEpochForSlot, getFirstSlotInEpoch, getLastSlotInEpoch, getMaxComputeUnitsInBlock } from '../epoch-schedule';
+import {
+    EpochSchedule,
+    getEpochForSlot,
+    getFirstSlotInEpoch,
+    getLastSlotInEpoch,
+    getMaxComputeUnitsInBlock,
+} from '../epoch-schedule';
 
 describe('getEpoch', () => {
     it('returns the correct epoch for a slot after `firstNormalSlot`', () => {
@@ -85,46 +91,46 @@ describe('getLastSlotInEpoch', () => {
 
 describe('getMaxComputeUnitsForEpoch', () => {
     it('returns the correct max compute units for an epoch on mainnet', () => {
-        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 769n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 770n, cluster: Cluster.MainnetBeta})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 821n, cluster: Cluster.MainnetBeta})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 822n, cluster: Cluster.MainnetBeta})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 823n, cluster: Cluster.MainnetBeta})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.MainnetBeta})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 0n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 769n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 770n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 821n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 822n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: 823n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: undefined })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.MainnetBeta, epoch: -1n })).toEqual(48_000_000);
     });
 
     it('returns the correct max compute units for an epoch on devnet', () => {
-        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Devnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 856n, cluster: Cluster.Devnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 857n, cluster: Cluster.Devnet})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 914n, cluster: Cluster.Devnet})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 915n, cluster: Cluster.Devnet})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 916n, cluster: Cluster.Devnet})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Devnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Devnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 0n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 856n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 857n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 914n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 915n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: 916n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: undefined })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Devnet, epoch: -1n })).toEqual(48_000_000);
     });
 
     it('returns the correct max compute units for an epoch on testnet', () => {
-        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Testnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 763n, cluster: Cluster.Testnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 764n, cluster: Cluster.Testnet})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 811n, cluster: Cluster.Testnet})).toEqual(50_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 812n, cluster: Cluster.Testnet})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 813n, cluster: Cluster.Testnet})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Testnet})).toEqual(48_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Testnet})).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 0n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 763n })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 764n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 811n })).toEqual(50_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 812n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: 813n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: undefined })).toEqual(48_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Testnet, epoch: -1n })).toEqual(48_000_000);
     });
 
     it('returns the correct max compute units for an epoch on custom', () => {
-        expect(getMaxComputeUnitsInBlock({epoch: 0n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 769n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 770n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 821n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 822n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: 823n, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: undefined, cluster: Cluster.Custom})).toEqual(60_000_000);
-        expect(getMaxComputeUnitsInBlock({epoch: -1n, cluster: Cluster.Custom})).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 0n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 769n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 770n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 821n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 822n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: 823n })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: undefined })).toEqual(60_000_000);
+        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: -1n })).toEqual(60_000_000);
     });
 });

--- a/app/utils/epoch-schedule.ts
+++ b/app/utils/epoch-schedule.ts
@@ -1,4 +1,4 @@
-import { Cluster, clusterName } from "@/app/utils/cluster";
+import { Cluster } from '@/app/utils/cluster';
 
 const MINIMUM_SLOT_PER_EPOCH = BigInt(32);
 
@@ -80,7 +80,6 @@ export function getLastSlotInEpoch(epochSchedule: EpochSchedule, epoch: bigint):
     return getFirstSlotInEpoch(epochSchedule, epoch + 1n) - 1n;
 }
 
-
 /**
  * Represents a SIMD configuration for compute units per block.
  * Each configuration defines the maximum compute units allowed in a block and when it becomes active on each cluster.
@@ -106,32 +105,32 @@ interface ComputeUnitConfigEntry {
  */
 const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
     {
-        maxComputeUnits: 48_000_000,
         activations: {
             [Cluster.MainnetBeta]: 0,
             [Cluster.Devnet]: 0,
             [Cluster.Testnet]: 0,
         },
+        maxComputeUnits: 48_000_000,
     },
     {
-        simd: '0207',
-        featureAccount: '5oMCU3JPaFLr8Zr4ct7yFA7jdk6Mw1RmB8K4u9ZbS42z',
-        maxComputeUnits: 50_000_000,
         activations: {
             [Cluster.MainnetBeta]: 770,
             [Cluster.Devnet]: 857,
             [Cluster.Testnet]: 764,
         },
+        featureAccount: '5oMCU3JPaFLr8Zr4ct7yFA7jdk6Mw1RmB8K4u9ZbS42z',
+        maxComputeUnits: 50_000_000,
+        simd: '0207',
     },
     {
-        simd: '0256',
-        featureAccount: '6oMCUgfY6BzZ6jwB681J6ju5Bh6CjVXbd7NeWYqiXBSu',
-        maxComputeUnits: 60_000_000,
         activations: {
             [Cluster.MainnetBeta]: 822,
             [Cluster.Devnet]: 915,
             [Cluster.Testnet]: 812,
         },
+        featureAccount: '6oMCUgfY6BzZ6jwB681J6ju5Bh6CjVXbd7NeWYqiXBSu',
+        maxComputeUnits: 60_000_000,
+        simd: '0256',
     },
 ];
 
@@ -141,23 +140,17 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
  * @param cluster - The cluster to get the maximum compute units for. (for custom clusters, fallback to the most recent config w/ highest max compute units)
  * @returns (number) The maximum compute units allowed in a block for the given epoch and cluster.
  */
-export function getMaxComputeUnitsInBlock({
-    epoch = 0n,
-    cluster
-}: {
-    epoch?: bigint;
-    cluster: Cluster;
-}): number {
+export function getMaxComputeUnitsInBlock({ epoch = 0n, cluster }: { epoch?: bigint; cluster: Cluster }): number {
     if (cluster === Cluster.Custom) {
         // Fallback to the most recent config w/ highest max compute units (e.g., local host should use most recent even if epoch is 0)
         return COMPUTE_UNIT_CONFIGS.reduce((max, config) => Math.max(max, config.maxComputeUnits), 0);
     }
 
-    let epochNumber = Number(epoch);
+    const epochNumber = Number(epoch);
 
     let applicableConfig = COMPUTE_UNIT_CONFIGS[0];
     let highestActivationEpoch = -1;
-    
+
     for (const config of COMPUTE_UNIT_CONFIGS) {
         const activationEpoch = config.activations[cluster];
         if (activationEpoch <= epochNumber && activationEpoch > highestActivationEpoch) {
@@ -165,6 +158,6 @@ export function getMaxComputeUnitsInBlock({
             highestActivationEpoch = activationEpoch;
         }
     }
-    
+
     return applicableConfig.maxComputeUnits;
 }


### PR DESCRIPTION
## Description

Currently we use a static value `MAX_CU_PER_BLOCK` to render the denominator for number of CU per block. Max CU per block is actually a function of epoch. This PR introduces `getMaxComputeUnitsInBlock` to determine block compute unit limits based on epoch, reflecting historical changes in Solana's network. Updates block layout to use this function and adds corresponding tests for various epochs. Fallback to original compute value to prevent UI issues (though I can't foresee why this would ever trigger).

Updated to include cluster param based on when feature was enabled. For custom, defaults to most recent/highest value. 

The result: 
- If you visit a block page in epoch 500, you will see 48M denominator; 
- in epoch 800 => 50M  
- in epoch 822 => 60M 

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):


## Testing

Added utility test to `app/utils/__tests__/epoch-schedule.ts`

## Related Issues

n/a

## Checklist

-   [X] My code follows the project's style guidelines
-   [X] I have added tests that prove my fix/feature works
-   [X] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [X] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
