### PR TITLE
Show Reserved CUs everywhere

### DIFF
--- a/app/block/[slot]/page-client.tsx
+++ b/app/block/[slot]/page-client.tsx
@@ -4,6 +4,7 @@ import { BlockHistoryCard } from '@components/block/BlockHistoryCard';
 import { useBlock, useFetchBlock } from '@providers/block';
 import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
+import { getEpochForSlot } from '@utils/epoch-schedule';
 import { notFound } from 'next/navigation';
 import React from 'react';
 
@@ -16,7 +17,16 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
     }
     const confirmedBlock = useBlock(slotNumber);
     const fetchBlock = useFetchBlock();
-    const { status } = useCluster();
+    const { status, clusterInfo } = useCluster();
+    
+    // Calculate epoch from slot
+    const epoch = React.useMemo(() => {
+        if (clusterInfo) {
+            return getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber));
+        }
+        return undefined;
+    }, [clusterInfo, slotNumber]);
+    
     // Fetch block on load
     React.useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {
@@ -24,7 +34,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
         }
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
     if (confirmedBlock?.data?.block) {
-        return <BlockHistoryCard block={confirmedBlock.data.block} />;
+        return <BlockHistoryCard block={confirmedBlock.data.block} epoch={epoch} />;
     }
     return null;
 }

--- a/app/block/[slot]/page-client.tsx
+++ b/app/block/[slot]/page-client.tsx
@@ -18,7 +18,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
     const confirmedBlock = useBlock(slotNumber);
     const fetchBlock = useFetchBlock();
     const { status, clusterInfo } = useCluster();
-    
+
     // Calculate epoch from slot
     const epoch = React.useMemo(() => {
         if (clusterInfo) {
@@ -26,7 +26,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
         }
         return undefined;
     }, [clusterInfo, slotNumber]);
-    
+
     // Fetch block on load
     React.useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import useSWR from 'swr';
 
 import { useCluster } from '@/app/providers/cluster';
+import { estimateRequestedComputeUnits } from '@/app/utils/compute-units-schedule';
 
 import { AccountsCard } from './AccountsCard';
 import { AddressTableLookupsCard } from './AddressTableLookupsCard';
@@ -430,6 +431,8 @@ const DEFAULT_FEES = {
 
 function OverviewCard({ message, raw, onClear }: { message: VersionedMessage; raw: Uint8Array; onClear: () => void }) {
     const fee = message.header.numRequiredSignatures * DEFAULT_FEES.lamportsPerSignature;
+    const { cluster } = useCluster();
+    const reservedCUs = estimateRequestedComputeUnits({ transaction: { message } }, undefined, cluster);
     const feePayerValidator = createFeePayerValidator(fee);
 
     const size = React.useMemo(() => {
@@ -465,6 +468,18 @@ function OverviewCard({ message, raw, onClear }: { message: VersionedMessage; ra
                                 <SolBalance lamports={fee} />
                                 <span className="text-muted">
                                     {`Each signature costs ${DEFAULT_FEES.lamportsPerSignature} lamports`}
+                                </span>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td>Reserved CUs</td>
+                        <td className="text-lg-end">
+                            <div className="d-flex align-items-end flex-column">
+                                {reservedCUs.toLocaleString('en-US')}
+                                <span className="text-muted">
+                                    {`Can be explicitly set with a compute budget instruction`}
                                 </span>
                             </div>
                         </td>

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -19,7 +19,6 @@ import React from 'react';
 import useSWR from 'swr';
 
 import { useCluster } from '@/app/providers/cluster';
-import { estimateRequestedComputeUnits } from '@/app/utils/compute-units-schedule';
 
 import { AccountsCard } from './AccountsCard';
 import { AddressTableLookupsCard } from './AddressTableLookupsCard';
@@ -431,8 +430,6 @@ const DEFAULT_FEES = {
 
 function OverviewCard({ message, raw, onClear }: { message: VersionedMessage; raw: Uint8Array; onClear: () => void }) {
     const fee = message.header.numRequiredSignatures * DEFAULT_FEES.lamportsPerSignature;
-    const { cluster } = useCluster();
-    const reservedCUs = estimateRequestedComputeUnits({ transaction: { message } }, undefined, cluster);
     const feePayerValidator = createFeePayerValidator(fee);
 
     const size = React.useMemo(() => {
@@ -473,17 +470,6 @@ function OverviewCard({ message, raw, onClear }: { message: VersionedMessage; ra
                         </td>
                     </tr>
 
-                    <tr>
-                        <td>Reserved CUs</td>
-                        <td className="text-lg-end">
-                            <div className="d-flex align-items-end flex-column">
-                                {reservedCUs.toLocaleString('en-US')}
-                                <span className="text-muted">
-                                    {`Can be explicitly set with a compute budget instruction`}
-                                </span>
-                            </div>
-                        </td>
-                    </tr>
                     <tr>
                         <td>
                             <div className="d-flex align-items-start flex-column">

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -36,6 +36,9 @@ import Link from 'next/link';
 import React, { Suspense, useEffect, useState } from 'react';
 import { RefreshCw, Settings } from 'react-feather';
 
+import { estimateRequestedComputeUnitsForParsedTransaction } from '@/app/utils/compute-units-schedule';
+import { getEpochForSlot } from '@/app/utils/epoch-schedule';
+
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
 
@@ -189,6 +192,10 @@ function StatusCard({ signature, autoRefresh }: SignatureProps & AutoRefreshProp
     const computeUnitsConsumed = transactionWithMeta?.meta?.computeUnitsConsumed;
     const transaction = transactionWithMeta?.transaction;
     const blockhash = transaction?.message.recentBlockhash;
+    const epoch = clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(info.slot)) : undefined;
+    const reservedCUs = transactionWithMeta?.transaction
+        ? estimateRequestedComputeUnitsForParsedTransaction(transactionWithMeta.transaction, epoch, cluster)
+        : undefined;
     const version = transactionWithMeta?.version;
     const isNonce = (() => {
         if (!transaction || transaction.message.instructions.length < 1) {
@@ -335,6 +342,13 @@ function StatusCard({ signature, autoRefresh }: SignatureProps & AutoRefreshProp
                     <tr>
                         <td>Compute units consumed</td>
                         <td className="text-lg-end">{computeUnitsConsumed.toLocaleString('en-US')}</td>
+                    </tr>
+                )}
+
+                {reservedCUs !== undefined && (
+                    <tr>
+                        <td>Reserved CUs</td>
+                        <td className="text-lg-end">{reservedCUs.toLocaleString('en-US')}</td>
                     </tr>
                 )}
 

--- a/app/utils/__tests__/compute-units-schedule.test.ts
+++ b/app/utils/__tests__/compute-units-schedule.test.ts
@@ -184,18 +184,14 @@ describe('estimateRequestedComputeUnits', () => {
             data: Uint8Array;
         }>
     ): Parameters<typeof estimateRequestedComputeUnits>[0] => {
-        const staticAccountKeys = [
-            ...new Set(instructions.map(ix => ix.programId)),
-        ].map(id => new PublicKey(id));
+        const staticAccountKeys = [...new Set(instructions.map(ix => ix.programId))].map(id => new PublicKey(id));
 
         return {
             transaction: {
                 message: {
                     compiledInstructions: instructions.map(ix => ({
                         data: ix.data,
-                        programIdIndex: staticAccountKeys.findIndex(
-                            key => key.toBase58() === ix.programId
-                        ),
+                        programIdIndex: staticAccountKeys.findIndex(key => key.toBase58() === ix.programId),
                     })),
                     staticAccountKeys,
                 },

--- a/app/utils/__tests__/compute-units-schedule.test.ts
+++ b/app/utils/__tests__/compute-units-schedule.test.ts
@@ -1,0 +1,387 @@
+import { ComputeBudgetProgram, PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+
+import { Cluster } from '../cluster';
+import { estimateRequestedComputeUnits, getReservedComputeUnits } from '../compute-units-schedule';
+
+describe('getReservedComputeUnits', () => {
+    describe('mainnet', () => {
+        it('returns default compute units before builtin feature activation', () => {
+            // Before epoch 759 on mainnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 758n,
+                    programId: '11111111111111111111111111111111', // System Program
+                })
+            ).toEqual(200_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 0n,
+                    programId: 'Vote111111111111111111111111111111111111111', // Vote Program
+                })
+            ).toEqual(200_000);
+        });
+
+        it('returns minimal compute units for builtins after feature activation', () => {
+            // After epoch 759 on mainnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 759n,
+                    programId: '11111111111111111111111111111111', // System Program
+                })
+            ).toEqual(3_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 1000n,
+                    programId: 'Vote111111111111111111111111111111111111111', // Vote Program
+                })
+            ).toEqual(3_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 759n,
+                    programId: 'ComputeBudget111111111111111111111111111111', // Compute Budget
+                })
+            ).toEqual(3_000);
+        });
+
+        it('returns default compute units for non-builtins after feature activation', () => {
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 759n,
+                    programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // Token Program
+                })
+            ).toEqual(200_000);
+        });
+
+        it('handles feature gate program migration correctly', () => {
+            // Before migration (epoch 753), feature gate is builtin
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 752n,
+                    programId: 'Feature111111111111111111111111111111111111',
+                })
+            ).toEqual(200_000); // Before builtin optimization
+
+            // After builtin optimization but before migration
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 758n, // After 753 but before 759
+                    programId: 'Feature111111111111111111111111111111111111',
+                })
+            ).toEqual(200_000); // Still default because migration happened before builtin optimization
+
+            // After both migration and builtin optimization
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: 759n,
+                    programId: 'Feature111111111111111111111111111111111111',
+                })
+            ).toEqual(200_000); // Now BPF, uses default
+        });
+    });
+
+    describe('devnet', () => {
+        it('returns correct compute units based on devnet activation epochs', () => {
+            // Before epoch 842 on devnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Devnet,
+                    epoch: 841n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(200_000);
+
+            // After epoch 842 on devnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Devnet,
+                    epoch: 842n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(3_000);
+        });
+    });
+
+    describe('testnet', () => {
+        it('returns correct compute units based on testnet activation epochs', () => {
+            // Before epoch 750 on testnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Testnet,
+                    epoch: 749n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(200_000);
+
+            // After epoch 750 on testnet
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Testnet,
+                    epoch: 750n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(3_000);
+        });
+    });
+
+    describe('custom cluster', () => {
+        it('always uses most recent configuration', () => {
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Custom,
+                    epoch: 0n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(3_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Custom,
+                    epoch: 1000n,
+                    programId: 'Feature111111111111111111111111111111111111',
+                })
+            ).toEqual(200_000);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles undefined epoch', () => {
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(200_000);
+        });
+
+        it('handles negative epoch', () => {
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.MainnetBeta,
+                    epoch: -1n,
+                    programId: '11111111111111111111111111111111',
+                })
+            ).toEqual(200_000);
+        });
+    });
+});
+
+describe('estimateRequestedComputeUnits', () => {
+    const createMockTransaction = (
+        instructions: Array<{
+            programId: string;
+            data: Uint8Array;
+        }>
+    ): Parameters<typeof estimateRequestedComputeUnits>[0] => {
+        const staticAccountKeys = [
+            ...new Set(instructions.map(ix => ix.programId)),
+        ].map(id => new PublicKey(id));
+
+        return {
+            transaction: {
+                message: {
+                    compiledInstructions: instructions.map(ix => ({
+                        data: ix.data,
+                        programIdIndex: staticAccountKeys.findIndex(
+                            key => key.toBase58() === ix.programId
+                        ),
+                    })),
+                    staticAccountKeys,
+                },
+            },
+        } as VersionedBlockResponse['transactions'][number];
+    };
+
+    describe('with explicit compute budget', () => {
+        it('returns compute units from SetComputeUnitLimit instruction', () => {
+            const computeUnits = 300_000;
+            const data = Buffer.alloc(5);
+            data[0] = 2; // SetComputeUnitLimit instruction type
+            data.writeUInt32LE(computeUnits, 1);
+
+            const tx = createMockTransaction([
+                {
+                    data,
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+            ]);
+
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(computeUnits);
+        });
+
+        it('returns compute units from deprecated RequestUnits instruction', () => {
+            const computeUnits = 150_000;
+            const data = Buffer.alloc(5);
+            data[0] = 0; // RequestUnits instruction type
+            data.writeUInt32LE(computeUnits, 1);
+
+            const tx = createMockTransaction([
+                {
+                    data,
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+            ]);
+
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(computeUnits);
+        });
+
+        it('prioritizes first compute budget instruction found', () => {
+            const data1 = Buffer.alloc(5);
+            data1[0] = 2;
+            data1.writeUInt32LE(100_000, 1);
+
+            const data2 = Buffer.alloc(5);
+            data2[0] = 2;
+            data2.writeUInt32LE(200_000, 1);
+
+            const tx = createMockTransaction([
+                {
+                    data: data1,
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+                {
+                    data: data2,
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+            ]);
+
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(100_000);
+        });
+    });
+
+    describe('without explicit compute budget', () => {
+        it('returns default for non-builtin programs', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                },
+            ]);
+
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(200_000);
+        });
+
+        it('returns minimal units for builtin programs after activation', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: '11111111111111111111111111111111',
+                },
+            ]);
+
+            // After activation
+            expect(estimateRequestedComputeUnits(tx, 759n, Cluster.MainnetBeta)).toEqual(3_000);
+
+            // Before activation
+            expect(estimateRequestedComputeUnits(tx, 758n, Cluster.MainnetBeta)).toEqual(200_000);
+        });
+
+        it('returns sum of reserved units for mixed instructions', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: '11111111111111111111111111111111', // System (3k after activation)
+                },
+                {
+                    data: new Uint8Array([4, 5, 6]),
+                    programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // Token (200k)
+                },
+            ]);
+
+            // Should return the sum (3k + 200k = 203k)
+            expect(estimateRequestedComputeUnits(tx, 759n, Cluster.MainnetBeta)).toEqual(203_000);
+        });
+
+        it('handles feature gate program correctly across epochs', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: 'Feature111111111111111111111111111111111111',
+                },
+            ]);
+
+            // Before migration - uses default
+            expect(estimateRequestedComputeUnits(tx, 752n, Cluster.MainnetBeta)).toEqual(200_000);
+
+            // After migration and builtin optimization - still uses default (now BPF)
+            expect(estimateRequestedComputeUnits(tx, 759n, Cluster.MainnetBeta)).toEqual(200_000);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles empty instruction data', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([]),
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+            ]);
+
+            // ComputeBudget is a builtin, so after activation it gets 3k
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(3_000);
+        });
+
+        it('handles invalid compute budget instruction data', () => {
+            const tx = createMockTransaction([
+                {
+                    data: new Uint8Array([2, 1, 2]), // Too short for SetComputeUnitLimit
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+            ]);
+
+            // ComputeBudget is a builtin, so after activation it gets 3k
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(3_000);
+        });
+
+        it('handles transactions with no instructions', () => {
+            const tx = createMockTransaction([]);
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(0);
+        });
+
+        it('respects the 1.4M compute unit cap', () => {
+            // Create a transaction with many instructions that would exceed 1.4M
+            const instructions = [];
+            for (let i = 0; i < 10; i++) {
+                instructions.push({
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // 200k each
+                });
+            }
+            const tx = createMockTransaction(instructions);
+
+            // Should cap at 1.4M even though sum would be 2M
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(1_400_000);
+        });
+
+        it('handles compute budget with other instructions', () => {
+            const data = Buffer.alloc(5);
+            data[0] = 2; // SetComputeUnitLimit
+            data.writeUInt32LE(500_000, 1);
+
+            const tx = createMockTransaction([
+                {
+                    data,
+                    programId: ComputeBudgetProgram.programId.toBase58(),
+                },
+                {
+                    data: new Uint8Array([1, 2, 3]),
+                    programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                },
+            ]);
+
+            // Should return the explicit compute budget, not the sum
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(500_000);
+        });
+    });
+});

--- a/app/utils/__tests__/compute-units-schedule.test.ts
+++ b/app/utils/__tests__/compute-units-schedule.test.ts
@@ -222,9 +222,10 @@ describe('estimateRequestedComputeUnits', () => {
 
         it('returns compute units from deprecated RequestUnits instruction', () => {
             const computeUnits = 150_000;
-            const data = Buffer.alloc(5);
+            const data = Buffer.alloc(9); // RequestUnits needs 9 bytes
             data[0] = 0; // RequestUnits instruction type
             data.writeUInt32LE(computeUnits, 1);
+            data.writeUInt32LE(0, 5); // additionalFee
 
             const tx = createMockTransaction([
                 {

--- a/app/utils/compute-units-schedule.ts
+++ b/app/utils/compute-units-schedule.ts
@@ -30,7 +30,6 @@ const BUILTIN_PROGRAMS_3K: readonly string[] = [
     'Ed25519SigVerify111111111111111111111111111', // Ed25519 Signature Verify
 ];
 
-
 /**
  * Represents a configuration for reserved compute units based on epoch
  */
@@ -133,10 +132,7 @@ export function getReservedComputeUnits({
 /**
  * Helper to extract compute units from a compute budget instruction
  */
-function extractComputeUnitsFromInstruction(instruction: {
-    programId: PublicKey;
-    data: Uint8Array;
-}): number | null {
+function extractComputeUnitsFromInstruction(instruction: { programId: PublicKey; data: Uint8Array }): number | null {
     if (instruction.programId.toBase58() !== ComputeBudgetProgram.programId.toBase58()) {
         return null;
     }

--- a/app/utils/compute-units-schedule.ts
+++ b/app/utils/compute-units-schedule.ts
@@ -1,0 +1,189 @@
+import { ComputeBudgetProgram, PublicKey } from '@solana/web3.js';
+
+import { Cluster } from '@/app/utils/cluster';
+
+/**
+ * Built-in programs that have minimal reserved compute units (3k)
+ * This list is based on the feature gate C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH
+ * Source: https://solana.com/docs/references/feature-gates/reserve-minimal-cus-for-builtins
+ */
+const BUILTIN_PROGRAMS_3K: readonly string[] = [
+    '11111111111111111111111111111111', // System Program
+    'Stake11111111111111111111111111111111111111', // Stake Program
+    'Vote111111111111111111111111111111111111111', // Vote Program
+    'Config1111111111111111111111111111111111111', // Config Program
+    'AddressLookupTab1e1111111111111111111111111', // Address Lookup Table Program
+    'BPFLoaderUpgradeab1e11111111111111111111111', // BPF Loader Upgradeable
+    'BPFLoader1111111111111111111111111111111111', // BPF Loader
+    'BPFLoader2111111111111111111111111111111111', // BPF Loader 2
+    'LoaderV411111111111111111111111111111111111', // Loader v4
+    'ComputeBudget111111111111111111111111111111', // Compute Budget Program
+    'KeccakSecp256k11111111111111111111111111111', // Keccak Secp256k1
+    'Ed25519SigVerify111111111111111111111111111', // Ed25519 Signature Verify
+];
+
+
+/**
+ * Represents a configuration for reserved compute units based on epoch
+ */
+interface ComputeUnitReserveConfig {
+    /** Description of the change */
+    readonly description: string;
+    /** Feature account that activated this change (if applicable) */
+    readonly featureAccount?: string;
+    /** When the configuration becomes active on each cluster */
+    readonly activations: {
+        readonly [Cluster.MainnetBeta]: number;
+        readonly [Cluster.Devnet]: number;
+        readonly [Cluster.Testnet]: number;
+    };
+    /** Function to get reserved compute units for a given program */
+    readonly getReservedUnits: (programId: string) => number;
+}
+
+/**
+ * Default compute units for transactions without explicit compute budget
+ */
+const DEFAULT_COMPUTE_UNITS = 200_000;
+
+/**
+ * Minimal compute units for built-in programs
+ */
+const MINIMAL_BUILTIN_COMPUTE_UNITS = 3_000;
+const MAX_COMPUTE_UNITS = 1_400_000;
+
+/**
+ * Compute unit reserve configurations by epoch
+ * Add new configurations here as features are activated
+ */
+const COMPUTE_UNIT_RESERVE_CONFIGS: readonly ComputeUnitReserveConfig[] = [
+    {
+        activations: {
+            [Cluster.MainnetBeta]: 0,
+            [Cluster.Devnet]: 0,
+            [Cluster.Testnet]: 0,
+        },
+        description: 'Initial configuration - no built-in program optimization',
+        getReservedUnits: (_programId: string) => DEFAULT_COMPUTE_UNITS,
+    },
+    {
+        activations: {
+            [Cluster.MainnetBeta]: 759,
+            [Cluster.Devnet]: 842,
+            [Cluster.Testnet]: 750,
+        },
+        description: 'Built-in programs use minimal compute units',
+        featureAccount: 'C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH',
+        getReservedUnits: (programId: string) => {
+            if (BUILTIN_PROGRAMS_3K.includes(programId)) {
+                return MINIMAL_BUILTIN_COMPUTE_UNITS;
+            }
+            // Feature gate program is already BPF at this point, uses default
+            return DEFAULT_COMPUTE_UNITS;
+        },
+    },
+];
+
+/**
+ * Get the reserved compute units for a program at a given epoch
+ * @param programId - The program ID to check
+ * @param epoch - The epoch to check
+ * @param cluster - The cluster to check
+ * @returns The reserved compute units for the program
+ */
+export function getReservedComputeUnits({
+    programId,
+    epoch = 0n,
+    cluster,
+}: {
+    programId: string;
+    epoch?: bigint;
+    cluster: Cluster;
+}): number {
+    if (cluster === Cluster.Custom) {
+        // For custom clusters, use the most recent configuration
+        const latestConfig = COMPUTE_UNIT_RESERVE_CONFIGS[COMPUTE_UNIT_RESERVE_CONFIGS.length - 1];
+        return latestConfig.getReservedUnits(programId);
+    }
+
+    const epochNumber = Number(epoch);
+
+    let applicableConfig = COMPUTE_UNIT_RESERVE_CONFIGS[0];
+    let highestActivationEpoch = -1;
+
+    for (const config of COMPUTE_UNIT_RESERVE_CONFIGS) {
+        const activationEpoch = config.activations[cluster];
+        if (activationEpoch <= epochNumber && activationEpoch > highestActivationEpoch) {
+            applicableConfig = config;
+            highestActivationEpoch = activationEpoch;
+        }
+    }
+
+    return applicableConfig.getReservedUnits(programId);
+}
+
+/**
+ * Estimate the requested compute units for a transaction
+ * @param tx - The transaction to analyze
+ * @param epoch - The epoch of the transaction
+ * @param cluster - The cluster the transaction is on
+ * @returns The estimated compute units requested
+ */
+export function estimateRequestedComputeUnits(
+    tx: {
+        transaction: {
+            message: {
+                compiledInstructions: Array<{
+                    programIdIndex: number;
+                    data: Uint8Array;
+                }>;
+                staticAccountKeys: PublicKey[];
+            };
+        };
+    },
+    epoch: bigint | undefined,
+    cluster: Cluster
+): number {
+    let requestedUnits: number | null = null;
+
+    // First, check for explicit compute budget instructions
+    for (const instruction of tx.transaction.message.compiledInstructions) {
+        const programId = tx.transaction.message.staticAccountKeys[instruction.programIdIndex];
+
+        if (programId.toBase58() === ComputeBudgetProgram.programId.toBase58() && instruction.data.length > 0) {
+            const data = Buffer.from(instruction.data);
+            const instructionType = data[0];
+
+            // Check for SetComputeUnitLimit instruction (type 2)
+            if (instructionType === 2 && data.length >= 5) {
+                requestedUnits = data.readUInt32LE(1);
+                break; // Found compute unit limit, stop searching
+            }
+            // Check for deprecated RequestUnits instruction (type 0)
+            else if (instructionType === 0 && data.length >= 5) {
+                requestedUnits = data.readUInt32LE(1);
+                break;
+            }
+        }
+    }
+
+    // If we found an explicit compute budget, return it
+    if (requestedUnits !== null) {
+        return requestedUnits;
+    }
+
+    // No compute budget instruction, check if all instructions are from built-in programs
+    // that would use minimal compute units
+    let totalReservedUnits = 0;
+    for (const instruction of tx.transaction.message.compiledInstructions) {
+        const programId = tx.transaction.message.staticAccountKeys[instruction.programIdIndex].toBase58();
+        const reservedUnits = getReservedComputeUnits({
+            cluster,
+            epoch,
+            programId,
+        });
+        totalReservedUnits += reservedUnits;
+    }
+
+    return Math.min(totalReservedUnits, MAX_COMPUTE_UNITS);
+}

--- a/app/utils/compute-units-schedule.ts
+++ b/app/utils/compute-units-schedule.ts
@@ -195,11 +195,10 @@ export function estimateRequestedComputeUnits(
             totalReservedUnits = requestedUnits;
             break;
         } else {
-            const programId = tx.transaction.message.staticAccountKeys[instruction.programIdIndex].toBase58();
             const reservedUnits = getReservedComputeUnits({
                 cluster,
                 epoch,
-                programId,
+                programId: programId.toBase58(),
             });
             totalReservedUnits += reservedUnits;
         }
@@ -235,11 +234,10 @@ export function estimateRequestedComputeUnitsForParsedTransaction(
                 break;
             }
         }
-        const programId = instruction.programId.toBase58();
         const reservedUnits = getReservedComputeUnits({
             cluster,
             epoch,
-            programId,
+            programId: instruction.programId.toBase58(),
         });
         totalReservedUnits += reservedUnits;
     }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Show reserved CUs on block page, per tx on the block page, on tx overview card, and on inspector overview card

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->
Added tests

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [X] My code follows the project's style guidelines
-   [X] I have added tests that prove my fix/feature works
-   [X] All tests pass locally and in CI
-   [X] I have updated documentation as needed
-   [X] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Display reserved compute units across block, transaction, and inspector views, with new functions and tests for compute unit estimation.
> 
>   - **Behavior**:
>     - Display reserved CUs on block page (`layout.tsx`), per transaction on block page (`page-client.tsx`), transaction overview card (`BlockHistoryCard.tsx`), and inspector overview card (`InspectorPage.tsx`).
>     - Add sorting by reserved CUs in `BlockHistoryCard.tsx`.
>   - **Functions**:
>     - Add `estimateRequestedComputeUnits` and `estimateRequestedComputeUnitsForParsedTransaction` in `compute-units-schedule.ts` to calculate reserved CUs.
>     - Add `getReservedComputeUnits` to determine reserved CUs based on epoch and cluster.
>   - **Tests**:
>     - Add tests in `compute-units-schedule.test.ts` for `getReservedComputeUnits` and `estimateRequestedComputeUnits` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for f060cc99aa25f689ecad9d12f9fbb2c8a6af5fe9. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->