### PR TITLE
feat: support search from URL query

### DIFF
--- a/app/features/search/model/__tests__/use-search-navigation.test.ts
+++ b/app/features/search/model/__tests__/use-search-navigation.test.ts
@@ -8,7 +8,7 @@ const pushMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
     useRouter: () => ({ push: pushMock }),
-    useSearchParams: () => new URLSearchParams('cluster=devnet'),
+    useSearchParams: () => new URLSearchParams('cluster=devnet&q=token'),
 }));
 
 vi.mock('@providers/cluster', () => ({

--- a/app/features/search/model/use-search-navigation.ts
+++ b/app/features/search/model/use-search-navigation.ts
@@ -35,7 +35,9 @@ export function useSearchNavigation(): (option: SearchItem) => void {
                     router.push(`${pathname}?cluster=${clusterSlug(effectiveCluster)}`);
                 }
             } else {
-                const nextQueryString = searchParams?.toString();
+                const nextSearchParams = new URLSearchParams(searchParams?.toString());
+                nextSearchParams.delete('q');
+                const nextQueryString = nextSearchParams.toString();
                 router.push(`${pathname}${nextQueryString ? `?${nextQueryString}` : ''}`);
             }
         },

--- a/app/features/search/ui/SearchBar.tsx
+++ b/app/features/search/ui/SearchBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useDebouncedValue } from '@mantine/hooks';
+import { useSearchParams } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 
 import { searchAnalytics } from '@/app/shared/lib/analytics';
@@ -15,8 +16,12 @@ import { BaseSearch } from './BaseSearch';
 export const SEARCH_DEBOUNCE_MS = 500;
 
 export function SearchBar() {
-    const [search, setSearch] = useState('');
-    const [open, setOpen] = useState(false);
+    const searchParams = useSearchParams();
+    // Lazy initializers so the `?q=` lookup runs once on mount rather than on
+    // every render, and `searchParams` is guarded (it is nullable under the
+    // App Router), matching the defensive pattern in use-search-navigation.ts.
+    const [search, setSearch] = useState(() => searchParams?.get('q') ?? '');
+    const [open, setOpen] = useState(() => (searchParams?.get('q') ?? '').trim().length > 0);
     const [activeFilter, setActiveFilter] = useState<FilterId>('all');
     const [debouncedSearch] = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
 

--- a/app/features/search/ui/__tests__/SearchBar.test.tsx
+++ b/app/features/search/ui/__tests__/SearchBar.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { searchAnalytics } from '@/app/shared/lib/analytics';
@@ -14,6 +15,7 @@ beforeAll(() => {
         unobserve() {}
         disconnect() {}
     };
+    global.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 beforeEach(() => {
@@ -27,6 +29,7 @@ afterEach(() => {
 
 vi.mock('../../model/use-search', () => ({ useSearch: vi.fn() }));
 vi.mock('../../model/use-search-navigation', () => ({ useSearchNavigation: vi.fn() }));
+vi.mock('next/navigation', () => ({ useSearchParams: vi.fn() }));
 vi.mock('@/app/shared/lib/analytics', () => ({
     searchAnalytics: {
         trackPerformed: vi.fn(),
@@ -59,6 +62,16 @@ const tokenResults: SearchOptions[] = [
 ];
 
 describe('SearchBar', () => {
+    it('should run a search from the q URL parameter', () => {
+        setup(tokenResults, false, 'token');
+
+        act(() => vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS));
+
+        expect(screen.getByRole('combobox')).toHaveValue('token');
+        expect(useSearch).toHaveBeenLastCalledWith('token');
+        expect(screen.getByText('Token A')).toBeInTheDocument();
+    });
+
     it('should navigate and reset state when a result is selected', () => {
         setup();
 
@@ -180,9 +193,10 @@ describe('SearchBar', () => {
     });
 });
 
-function setup(results: SearchOptions[] = tokenResults, isLoading = false) {
+function setup(results: SearchOptions[] = tokenResults, isLoading = false, urlQuery = '') {
     (useSearch as Mock).mockReturnValue({ data: results, isLoading });
     (useSearchNavigation as Mock).mockReturnValue(mockNavigate);
+    (useSearchParams as Mock).mockReturnValue(new URLSearchParams(urlQuery ? `q=${urlQuery}` : ''));
 
     render(<SearchBar />);
 }


### PR DESCRIPTION
## Description

Allow external tools and quick-search integrations to open Explorer with a pre-populated search using the `q` URL parameter.

The SearchBar reuses its existing debounce and search providers. When a result is selected, only the initiating `q` parameter is removed so unrelated parameters such as `cluster` remain preserved.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Protocol integration
- [ ] Documentation update
- [ ] Other

## Screenshots

A screenshot demonstrating `?q=token` with the populated search field and open results interface has been captured locally and can be added during review if requested.

## Testing

- `pnpm vitest:test app/features/search/ui/__tests__/SearchBar.test.tsx app/features/search/model/__tests__/use-search-navigation.test.ts --run` — 18/18 passed
- `pnpm vitest:test app/features/search --run` — 193/193 passed
- Targeted Prettier — passed
- Targeted ESLint — passed
- `pnpm exec next typegen` — passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed

## Related Issues

Fixes #223

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove the feature works
- [x] Relevant checks pass locally
- [x] Documentation changes are not required
- [ ] CI/CD checks pass on the PR
- [ ] Screenshot included
- [ ] Security-related links included — not applicable

## Additional Notes

No public API, protocol decoder, wallet, transaction, RPC, signing, authorization, or fund-movement behavior changes.

Existing URL parameters such as `cluster` remain preserved after result selection; only the initiating `q` parameter is removed.
