### PR TITLE
fix: cancel the first set fetchers in AccountsProvider

### DIFF
--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -1,8 +1,10 @@
-import { PublicKey } from '@solana/web3.js';
-import { render, waitFor } from '@testing-library/react';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { act, render, waitFor } from '@testing-library/react';
 import { Cluster, clusterSelection, clusterUrl } from '@utils/cluster';
 import React from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
 
 vi.mock('next/navigation');
 
@@ -19,6 +21,17 @@ type Captured = NonNullable<React.ContextType<typeof FetchersContext>>;
 
 const TEST_PUBKEY = PublicKey.default;
 
+const DEVNET_ENDPOINT = clusterUrl(clusterSelection(Cluster.Devnet));
+
+// The fetchers debounce a batch by 100ms; every advance below clears that window with room to spare.
+const PAST_DEBOUNCE_MS = 200;
+
+/** Points `useCluster` at `cluster`, with `url` explicit so a test can hold one endpoint across a switch. */
+function mockCluster(cluster: Cluster, url: string) {
+    const selection = clusterSelection(cluster, url);
+    useClusterMock.mockReturnValue({ ...selection, selection, url });
+}
+
 let captured: Captured | undefined;
 function Capture() {
     const ctx = React.useContext(FetchersContext) ?? undefined;
@@ -31,8 +44,7 @@ function Capture() {
 describe('AccountsProvider', () => {
     beforeEach(() => {
         captured = undefined;
-        const selection = clusterSelection(Cluster.Devnet);
-        useClusterMock.mockReturnValue({ ...selection, selection, url: clusterUrl(selection) });
+        mockCluster(Cluster.Devnet, DEVNET_ENDPOINT);
     });
 
     afterEach(() => {
@@ -78,11 +90,7 @@ describe('AccountsProvider', () => {
 
         oldFetchers.parsed.fetch(TEST_PUBKEY);
 
-        useClusterMock.mockReturnValue({
-            cluster: Cluster.Testnet,
-            customUrl: '',
-            url: clusterUrl(clusterSelection(Cluster.Testnet)),
-        });
+        mockCluster(Cluster.Testnet, clusterUrl(clusterSelection(Cluster.Testnet)));
         rerender(
             <AccountsProvider>
                 <Capture />
@@ -98,61 +106,116 @@ describe('AccountsProvider', () => {
 });
 
 describe('AccountsProvider: fetch and mount', () => {
+    let getMultipleAccountsInfo: MockInstance<typeof Connection.prototype.getMultipleAccountsInfo>;
+
     /**
-     * Mimics a real consumer (`usePmpAccountPayload`, inspector's `AccountInfo`): fetches from a mount effect,
-     * which React flushes bottom-up, so it runs BEFORE the provider's own effect and sees the fetchers of the
-     * first render. It reports that set through `onFetch`, because the set the child fetched through is the
-     * subject of these tests, not whichever set the provider settles on afterwards.
+     * Fetches from a mount effect, the shape real consumers use (the inspector's `AccountInfo`,
+     * `usePmpAccountPayload`). React flushes effects bottom-up, so this runs BEFORE the provider's own effect
+     * and fetches through the fetchers of the first render — the very set the provider cleanup cancels.
      */
-    function FetchOnMount({ onFetch }: { onFetch: (fetchers: Captured) => void }) {
-        const ctx = React.useContext(FetchersContext);
+    function FetchOnMount() {
         const fetchAccount = useFetchAccountInfo();
         React.useEffect(() => {
-            if (ctx) onFetch(ctx);
             fetchAccount(TEST_PUBKEY, 'skip');
-        }, []); // eslint-disable-line react-hooks/exhaustive-deps -- must observe the first commit only
+        }, []); // eslint-disable-line react-hooks/exhaustive-deps -- must fetch on the first commit only
         return null;
     }
 
+    function renderProvider(children: React.ReactNode = <FetchOnMount />) {
+        return render(<AccountsProvider>{children}</AccountsProvider>);
+    }
+
+    /** Runs the debounce out so a batch either reaches the RPC or is provably gone. */
+    async function flushDebounce() {
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(PAST_DEBOUNCE_MS);
+        });
+    }
+
     beforeEach(() => {
-        useClusterMock.mockReturnValue({ cluster: Cluster.Devnet, customUrl: '', url: clusterUrl(Cluster.Devnet, '') });
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        mockCluster(Cluster.Devnet, DEVNET_ENDPOINT);
+        // Every 'skip' batch lands here. Stubbing it keeps these assertions off the network and lets each test
+        // read back the batch the provider actually sent.
+        getMultipleAccountsInfo = vi.spyOn(Connection.prototype, 'getMultipleAccountsInfo').mockResolvedValue([null]);
     });
 
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
-    it('should cancel a first-commit fetch when the provider unmounts', async () => {
-        const onFetch = vi.fn<(fetchers: Captured) => void>();
-        const { unmount } = render(
-            <AccountsProvider>
-                <FetchOnMount onFetch={onFetch} />
-            </AccountsProvider>,
-        );
-        await waitFor(() => expect(onFetch).toHaveBeenCalledTimes(1));
-        const fetchers = onFetch.mock.calls[0][0];
-        expect(fetchers.skip.fetchTimeout).toBeDefined();
+    it('should not fetch a first-commit request after the provider unmounts', async () => {
+        const { unmount } = renderProvider();
 
         unmount();
-        // unhandled "window is not defined" rejection should not occur.
-        expect(fetchers.skip.fetchTimeout).toBeUndefined();
+        await flushDebounce();
+
+        // Without the cancel this batch fired into a torn-down tree and rejected with "window is not defined".
+        expect(getMultipleAccountsInfo).not.toHaveBeenCalled();
+    });
+
+    it('should fetch a first-commit request once while the provider stays mounted', async () => {
+        renderProvider();
+
+        await flushDebounce();
+
+        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
+        const [batch] = getMultipleAccountsInfo.mock.calls[0];
+        expect(batch.map(pubkey => pubkey.toBase58())).toEqual([TEST_PUBKEY.toBase58()]);
     });
 
     it('should not drop a first-commit fetch when React.StrictMode remounts the tree', async () => {
-        const onFetch = vi.fn<(fetchers: Captured) => void>();
         render(
             <React.StrictMode>
                 <AccountsProvider>
-                    <FetchOnMount onFetch={onFetch} />
+                    <FetchOnMount />
                 </AccountsProvider>
             </React.StrictMode>,
         );
-        // StrictMode mounts, tears the tree down, then mounts again, which is also what App Router dev does, so the
-        // child's effect runs twice. The provider cleanup cancels the very set children fetch through, so that second
-        // run has to re-arm the debounce. If it does not, a dev page would sit on "Loading" forever.
-        await waitFor(() => expect(onFetch).toHaveBeenCalledTimes(2));
-        const fetchers = onFetch.mock.calls[0][0];
 
-        expect(fetchers.skip.fetchTimeout).toBeDefined();
+        // StrictMode mounts, tears the tree down, then mounts again, which is also what App Router dev does, so
+        // the child's effect runs twice. The provider cleanup cancels the very set children fetch through, so
+        // that second run has to re-arm the debounce. If it does not, a dev page sits on "Loading" forever.
+        await flushDebounce();
+
+        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep a pending batch when the cluster changes but the url does not', async () => {
+        const { rerender } = renderProvider();
+
+        // A saved custom endpoint can point at the url a preset cluster already resolves to. Only `cluster`
+        // changes here, so the fetchers must survive and the batch the child armed must still go out.
+        mockCluster(Cluster.Custom, DEVNET_ENDPOINT);
+        rerender(
+            <AccountsProvider>
+                <FetchOnMount />
+            </AccountsProvider>,
+        );
+        await flushDebounce();
+
+        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report a failed batch on a preset cluster', async () => {
+        getMultipleAccountsInfo.mockRejectedValue(new Error('rpc unreachable'));
+
+        renderProvider();
+        await flushDebounce();
+
+        expect(vi.mocked(Logger.error)).toHaveBeenCalledWith(expect.any(Error), { url: DEVNET_ENDPOINT });
+    });
+
+    it('should stay quiet about a failed batch on a custom cluster', async () => {
+        mockCluster(Cluster.Custom, DEVNET_ENDPOINT);
+        getMultipleAccountsInfo.mockRejectedValue(new Error('rpc unreachable'));
+
+        renderProvider();
+        await flushDebounce();
+
+        // A custom endpoint fails for reasons we do not control, so its failures are not ours to report.
+        expect(vi.mocked(Logger.error)).not.toHaveBeenCalled();
     });
 });

--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -13,7 +13,7 @@ vi.mock('../../cluster', async importOriginal => {
     return { ...actual, useCluster: useClusterMock };
 });
 
-import { AccountsProvider, FetchersContext } from '..';
+import { AccountsProvider, FetchersContext, useFetchAccountInfo } from '..';
 
 type Captured = NonNullable<React.ContextType<typeof FetchersContext>>;
 
@@ -94,5 +94,65 @@ describe('AccountsProvider', () => {
         expect(parsedCancel).toHaveBeenCalledTimes(1);
         expect(rawCancel).toHaveBeenCalledTimes(1);
         expect(skipCancel).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('AccountsProvider: fetch and mount', () => {
+    /**
+     * Mimics a real consumer (`usePmpAccountPayload`, inspector's `AccountInfo`): fetches from a mount effect,
+     * which React flushes bottom-up, so it runs BEFORE the provider's own effect and sees the fetchers of the
+     * first render. It reports that set through `onFetch`, because the set the child fetched through is the
+     * subject of these tests, not whichever set the provider settles on afterwards.
+     */
+    function FetchOnMount({ onFetch }: { onFetch: (fetchers: Captured) => void }) {
+        const ctx = React.useContext(FetchersContext);
+        const fetchAccount = useFetchAccountInfo();
+        React.useEffect(() => {
+            if (ctx) onFetch(ctx);
+            fetchAccount(TEST_PUBKEY, 'skip');
+        }, []); // eslint-disable-line react-hooks/exhaustive-deps -- must observe the first commit only
+        return null;
+    }
+
+    beforeEach(() => {
+        useClusterMock.mockReturnValue({ cluster: Cluster.Devnet, customUrl: '', url: clusterUrl(Cluster.Devnet, '') });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should cancel a first-commit fetch when the provider unmounts', async () => {
+        const onFetch = vi.fn<(fetchers: Captured) => void>();
+        const { unmount } = render(
+            <AccountsProvider>
+                <FetchOnMount onFetch={onFetch} />
+            </AccountsProvider>,
+        );
+        await waitFor(() => expect(onFetch).toHaveBeenCalledTimes(1));
+        const fetchers = onFetch.mock.calls[0][0];
+        expect(fetchers.skip.fetchTimeout).toBeDefined();
+
+        unmount();
+        // unhandled "window is not defined" rejection should not occur.
+        expect(fetchers.skip.fetchTimeout).toBeUndefined();
+    });
+
+    it('should not drop a first-commit fetch when React.StrictMode remounts the tree', async () => {
+        const onFetch = vi.fn<(fetchers: Captured) => void>();
+        render(
+            <React.StrictMode>
+                <AccountsProvider>
+                    <FetchOnMount onFetch={onFetch} />
+                </AccountsProvider>
+            </React.StrictMode>,
+        );
+        // StrictMode mounts, tears the tree down, then mounts again, which is also what App Router dev does, so the
+        // child's effect runs twice. The provider cleanup cancels the very set children fetch through, so that second
+        // run has to re-arm the debounce. If it does not, a dev page would sit on "Loading" forever.
+        await waitFor(() => expect(onFetch).toHaveBeenCalledTimes(2));
+        const fetchers = onFetch.mock.calls[0][0];
+
+        expect(fetchers.skip.fetchTimeout).toBeDefined();
     });
 });

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -151,9 +151,9 @@ class MultipleAccountFetcher {
 
     constructor(
         private dispatch: Dispatch,
-        private cluster: Cluster,
         private url: string,
         private dataMode: FetchAccountDataMode,
+        private onError: (error: unknown) => void,
     ) {}
     fetch = (pubkey: PublicKey) => {
         if (this.pubkeys !== undefined) this.pubkeys.add(pubkey.toBase58());
@@ -164,8 +164,8 @@ class MultipleAccountFetcher {
                     const pubkeys = Array.from(this.pubkeys).map(p => new PublicKey(p));
                     this.pubkeys.clear();
 
-                    const { dispatch, cluster, url, dataMode } = this;
-                    fetchMultipleAccounts({ cluster, dataMode, dispatch, pubkeys, url });
+                    const { dispatch, url, dataMode, onError } = this;
+                    fetchMultipleAccounts({ dataMode, dispatch, onError, pubkeys, url });
                 }
             }, 100);
         }
@@ -183,13 +183,30 @@ export function AccountsProvider({ children }: AccountsProviderProps) {
     const { cluster, url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Account>(url);
 
+    // A saved custom endpoint can resolve to the same url as a preset cluster, so `cluster` must not take part
+    // in the fetcher identity below: rebuilding the fetchers cancels batches already in flight, and switching
+    // between two selections that share one endpoint changes nothing a batch depends on. The cluster only
+    // decides whether a failure is ours to report, so the reporter reads the current one through a ref.
+    const clusterRef = React.useRef(cluster);
+    clusterRef.current = cluster;
+
+    const reportFetchError = React.useCallback(
+        (error: unknown) => {
+            // A custom endpoint fails for reasons we do not control, so its failures are not ours to report.
+            if (clusterRef.current !== Cluster.Custom) {
+                Logger.error(error, { url });
+            }
+        },
+        [url],
+    );
+
     const fetchers = React.useMemo<Fetchers>(
         () => ({
-            parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
-            raw: new MultipleAccountFetcher(dispatch, cluster, url, 'raw'),
-            skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
+            parsed: new MultipleAccountFetcher(dispatch, url, 'parsed', reportFetchError),
+            raw: new MultipleAccountFetcher(dispatch, url, 'raw', reportFetchError),
+            skip: new MultipleAccountFetcher(dispatch, url, 'skip', reportFetchError),
         }),
-        [dispatch, cluster, url],
+        [dispatch, url, reportFetchError],
     );
 
     React.useEffect(() => {
@@ -224,13 +241,13 @@ async function fetchMultipleAccounts({
     dispatch,
     pubkeys,
     dataMode,
-    cluster,
+    onError,
     url,
 }: {
     dispatch: Dispatch;
     pubkeys: PublicKey[];
     dataMode: FetchAccountDataMode;
-    cluster: Cluster;
+    onError: (error: unknown) => void;
     url: string;
 }) {
     for (const pubkey of pubkeys) {
@@ -328,9 +345,7 @@ async function fetchMultipleAccounts({
                 });
             }
         } catch (error) {
-            if (cluster !== Cluster.Custom) {
-                Logger.error(error, { url });
-            }
+            onError(error);
 
             for (const pubkey of batch) {
                 dispatch({

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -182,27 +182,28 @@ type AccountsProviderProps = { children: React.ReactNode };
 export function AccountsProvider({ children }: AccountsProviderProps) {
     const { cluster, url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Account>(url);
-    const [fetchers, setFetchers] = React.useState<Fetchers>(() => ({
-        parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
-        raw: new MultipleAccountFetcher(dispatch, cluster, url, 'raw'),
-        skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
-    }));
 
-    // Cancel pending timers on deps-change and unmount so a debounced batch can't fire into a stale tree.
-    React.useEffect(() => {
-        dispatch({ type: ActionType.Clear, url });
-        const next: Fetchers = {
+    const fetchers = React.useMemo<Fetchers>(
+        () => ({
             parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
             raw: new MultipleAccountFetcher(dispatch, cluster, url, 'raw'),
             skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
-        };
-        setFetchers(next);
+        }),
+        [dispatch, cluster, url],
+    );
+
+    React.useEffect(() => {
+        dispatch({ type: ActionType.Clear, url });
+    }, [dispatch, url]);
+
+    // Cancel pending timers on deps-change and unmount so a debounced batch can't fire into a stale tree.
+    React.useEffect(() => {
         return () => {
-            next.parsed.cancel();
-            next.raw.cancel();
-            next.skip.cancel();
+            fetchers.parsed.cancel();
+            fetchers.raw.cancel();
+            fetchers.skip.cancel();
         };
-    }, [dispatch, cluster, url]);
+    }, [fetchers]);
 
     return (
         <StateContext.Provider value={state}>


### PR DESCRIPTION
## Description

**Issue**: `AccountsProvider` built one `fetchers` set in a `useState` initializer and a second `fetchers` in its mount `useEffect`, and the cleanup only cancelled the second.

**Failed ci**:
- https://github.com/solana-foundation/explorer/actions/runs/31784032931/job/94715850650
- https://github.com/solana-foundation/explorer/actions/runs/30335680797/job/90199947344?pr=1137

```
Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
ReferenceError: window is not defined
```

Children that fetch from a mount effect run before the provider's effect, so their 100ms debounce landed on the first fetchers set. That timer fired after unmount, and once vitest had torn down jsdom, React-DOM read `window` and the run failed with an unhandled "window is not defined" rejection while every assertion passed.

**Change**:

The fetchers are now built with `useMemo`, one per (cluster, url), and the cleanup effect is keyed on it, so cancellation always lands on the fetchers set which consumers are using.
  

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

N/A

## Testing

- Switch cluster should re-fetch page data as before.
- USCD https://explorer-git-fork-hoodieshq-feat-hoo-9-97e676-solana-foundation.vercel.app/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
- Inspector page https://explorer-git-fork-hoodieshq-feat-hoo-9-97e676-solana-foundation.vercel.app/tx/inspector?message=gAEABQi6NZ9IWKplwVwEZQcCg5W%252FW2e1HNg41wL9Hhb8xJlpvYFR%252FCRr3l7hXC7QagGd%252B1%252F3tV6P1eDZ6oi9FpA%252B%252B2zzplLrXgOGo0rT%252F6UsnULUJyyZUi55TOYDMIVayWEIA9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm%252FlIRcy%252F%252BytunLDm%252Be8jOW7xfcSayxDmzpAAAAAu8d3r7po8BI%252BwMTRt%252B6JbpMBySnFWga6lRghWCWMFan2Ut%252BkcbYo2FJZtmowJriXSbouQCF%252BNtr%252FvuoVY9Q7hwXbF57DPpP5S8MhVwfk%252BwR0PsmvqEoboG9odov2ZTiJQBH3DNgrA9WBcInS2JpukN3ZjRC%252FHaU%252Fpop7ZRFHCogDBAAJA6CGAQAAAAAAAwIAAgwCAAAA0B%252BXAAAAAAAHBQIAAQUGBQMBAgAAAA%253D%253D
- Token program https://explorer-git-fork-hoodieshq-feat-hoo-9-97e676-solana-foundation.vercel.app/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
- Token transfer https://explorer-git-fork-hoodieshq-feat-hoo-9-97e676-solana-foundation.vercel.app/tx/5EczH9GMbTRmnyCUMHR9epEUsAqtKVnGoq5LrcSNLGZprAc1f1tyFWimtG91zXjHwW8GuhaqH41w3wDSErXbe9ea

## Related Issues

[HOO-912](https://linear.app/solana-fndn/issue/HOO-912/vitest-run-fails-with-referenceerror-window-is-not-defined-from)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
