### PR TITLE
fix(cluster): keep the consent question on screen while the dialog closes

### DIFF
--- a/app/features/cluster-switcher/ui/CustomUrlConsentDialog.tsx
+++ b/app/features/cluster-switcher/ui/CustomUrlConsentDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from '@components/shared/ui/dialog';
 import type { RpcEndpoint } from '@entities/cluster';
 import { Alert } from '@shared/ui/Alert';
+import { useRef } from 'react';
 
 // Two things share this dialog: a link supplying an endpoint nobody has agreed to, and the developer
 // toggle that stops asking altogether.
@@ -28,6 +29,10 @@ type Props = {
 };
 
 export function CustomUrlConsentDialog({ request, onConfirm, onCancel }: Props) {
+    // What the dialog shows, which outlives what it is asking: the same `undefined` that closes it would
+    // otherwise blank the body, and the content stays on screen for the whole exit animation.
+    const shown = useRetainedRequest(request);
+
     // Anything that closes the dialog — Escape, the X, Cancel — is a decline: the safe outcome has to be
     // the default one. A click outside closes nothing, though: this asks a security question, and a stray
     // click on the backdrop is not an answer to it.
@@ -38,11 +43,13 @@ export function CustomUrlConsentDialog({ request, onConfirm, onCancel }: Props) 
                 zIndex={CONSENT_Z_INDEX}
                 onInteractOutside={event => event.preventDefault()}
             >
-                {request?.kind === 'endpoint' ? (
-                    <EndpointConsent endpoint={request.endpoint} onConfirm={onConfirm} onCancel={onCancel} />
-                ) : (
+                {/* Per kind, never a two-way ternary: the request the dialog closed on is `undefined`, and an
+                    `else` branch would answer one question with the other one's copy. */}
+                {shown?.kind === 'endpoint' ? (
+                    <EndpointConsent endpoint={shown.endpoint} onConfirm={onConfirm} onCancel={onCancel} />
+                ) : shown?.kind === 'developer-bypass' ? (
                     <BypassConsent onConfirm={onConfirm} onCancel={onCancel} />
-                )}
+                ) : undefined}
             </DialogContent>
         </Dialog>
     );
@@ -119,4 +126,13 @@ function BypassConsent({ onConfirm, onCancel }: Pick<Props, 'onCancel' | 'onConf
             </DialogFooter>
         </>
     );
+}
+
+// Radix keeps the content mounted until the exit animation ends (`duration-200` on `DialogContent`), so the
+// request has to outlive the prop that cleared it. Retaining it also keeps the endpoint's host on screen
+// while the box fades, rather than collapsing it onto nothing.
+function useRetainedRequest(request: ConsentRequest | undefined) {
+    const retained = useRef(request);
+    if (request !== undefined) retained.current = request;
+    return retained.current;
 }

--- a/app/features/cluster-switcher/ui/__tests__/CustomUrlConsentDialog.spec.tsx
+++ b/app/features/cluster-switcher/ui/__tests__/CustomUrlConsentDialog.spec.tsx
@@ -1,0 +1,74 @@
+import { rpcEndpoint } from '@entities/cluster';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type ConsentRequest, CustomUrlConsentDialog } from '../CustomUrlConsentDialog';
+
+const ENDPOINT_REQUEST: ConsentRequest = { endpoint: rpcEndpoint('https://my-node.example/rpc'), kind: 'endpoint' };
+const BYPASS_REQUEST: ConsentRequest = { kind: 'developer-bypass' };
+
+const ENDPOINT_QUESTION = 'Connect to this RPC server?';
+const BYPASS_QUESTION = 'Stop asking about custom RPC servers?';
+
+describe('CustomUrlConsentDialog', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('should keep the endpoint question on screen while it animates closed', () => {
+        // Answering used to swap the copy on the way out: the last thing a visitor saw after refusing one
+        // server was a red button offering to stop asking about all of them.
+        stubExitAnimation();
+        const { close } = renderDialog(ENDPOINT_REQUEST);
+
+        close();
+
+        expect(screen.getByTestId('custom-url-consent')).toHaveAttribute('data-state', 'closed');
+        expect(screen.getByText(ENDPOINT_QUESTION)).toBeInTheDocument();
+        expect(screen.getByTestId('consent-host')).toHaveTextContent('my-node.example');
+        expect(screen.queryByText(BYPASS_QUESTION)).not.toBeInTheDocument();
+    });
+
+    it('should keep the bypass question on screen while it animates closed', () => {
+        stubExitAnimation();
+        const { close } = renderDialog(BYPASS_REQUEST);
+
+        close();
+
+        expect(screen.getByTestId('custom-url-consent')).toHaveAttribute('data-state', 'closed');
+        expect(screen.getByText(BYPASS_QUESTION)).toBeInTheDocument();
+        expect(screen.queryByText(ENDPOINT_QUESTION)).not.toBeInTheDocument();
+    });
+
+    it('should ask nothing before a request arrives', () => {
+        renderDialog(undefined);
+
+        expect(screen.queryByTestId('custom-url-consent')).not.toBeInTheDocument();
+    });
+});
+
+function renderDialog(request: ConsentRequest | undefined) {
+    const props = { onCancel: vi.fn(), onConfirm: vi.fn() };
+    const { rerender } = render(<CustomUrlConsentDialog request={request} {...props} />);
+    // Answering clears the request, which is all a caller of this dialog does — both of them derive it from
+    // state the answer resolves.
+    return { close: () => rerender(<CustomUrlConsentDialog request={undefined} {...props} />) };
+}
+
+// Radix holds the dialog mounted until its exit animation ends, and jsdom runs no animations: without this
+// the content unmounts on the tick that closes it, and the closing render — the one this file is about —
+// never happens. `Presence` decides from `getComputedStyle().animationName`, so report what the stylesheet
+// would for the state Radix has just written to the DOM.
+function stubExitAnimation() {
+    const computeStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+        const styles = computeStyle(element, pseudoElement ?? undefined);
+        return new Proxy(styles, {
+            get(target, property) {
+                if (property === 'animationName') {
+                    return element.getAttribute('data-state') === 'closed' ? 'exit' : 'enter';
+                }
+                const value = Reflect.get(target, property);
+                return typeof value === 'function' ? value.bind(target) : value;
+            },
+        });
+    });
+}

--- a/app/features/cookie/ui/CookieConsent.tsx
+++ b/app/features/cookie/ui/CookieConsent.tsx
@@ -107,8 +107,12 @@ export function PrivacyPolicyLink({ children }: { children: React.ReactNode }) {
 export function CookieCard({ children, className }: { children: React.ReactNode; className?: string }) {
     return (
         <div
+            data-testid="cookie-consent"
             className={cn(
-                'fixed bottom-2.5 left-2.5 right-2.5 z-[1200] rounded-lg border border-slate-100 bg-black p-4 [border-style:solid] md:right-auto md:max-w-[400px]',
+                // Below the shared dialog's `z-50`, so a modal dims the banner rather than leaving it lit.
+                // Radix disables pointer events outside an open modal, and that kills these buttons too:
+                // over the overlay the banner kept full contrast while answering nothing.
+                'fixed bottom-2.5 left-2.5 right-2.5 z-40 rounded-lg border border-slate-100 bg-black p-4 [border-style:solid] md:right-auto md:max-w-[400px]',
                 className,
             )}
         >

--- a/app/features/cookie/ui/__tests__/CookieConsent.spec.tsx
+++ b/app/features/cookie/ui/__tests__/CookieConsent.spec.tsx
@@ -60,6 +60,18 @@ describe('CookieConsent', () => {
         expect(setCookie).not.toHaveBeenCalled();
     });
 
+    it('should sit below modal dialogs so one dims the banner', async () => {
+        // Radix disables pointer events outside an open modal, so a dialog turns these buttons off. The
+        // banner has to stay under the dialog overlay's `z-50` (`components/shared/ui/dialog`), or it keeps
+        // full contrast while answering nothing — what the RPC consent prompt showed.
+        render(<CookieConsent />);
+        const banner = await screen.findByTestId('cookie-consent');
+
+        // jsdom loads no stylesheet, so Tailwind's `z-*` reaches the DOM as a class name only. `z-40` is
+        // the highest step of Tailwind's scale that stays under the overlay.
+        expect(banner.className).toContain('z-40');
+    });
+
     it('should handle accept click', async () => {
         render(<CookieConsent />);
         const btn = await screen.findByText('ACCEPT', {}, { timeout: 3000 });

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -4,33 +4,33 @@
 |------|-------|------|---------------|
 | Static | `/` | 120 kB | 520 kB |
 | Static | `/_not-found` | 0 B | 400 kB |
-| Dynamic | `/address/[address]` | 510 kB | 910 kB |
-| Dynamic | `/address/[address]/account-data` | 520 kB | 920 kB |
-| Dynamic | `/address/[address]/anchor-account` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/anchor-program` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/attestation` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/attributes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/blockhashes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/compression` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/concurrent-merkle-tree` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/domains` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/entries` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/feature-gate` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/idl` | 610 kB | 0.98 MB |
-| Dynamic | `/address/[address]/instructions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/metadata` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/program-multisig` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/rewards` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/security` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/slot-hashes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/stake-history` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/subscriptions` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/token-extensions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/tokens` | 490 kB | 890 kB |
-| Dynamic | `/address/[address]/transfers` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/verified-build` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/vote-history` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/account-data` | 500 kB | 900 kB |
+| Dynamic | `/address/[address]/anchor-account` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/anchor-program` | 460 kB | 850 kB |
+| Dynamic | `/address/[address]/attestation` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/attributes` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/blockhashes` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/compression` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/concurrent-merkle-tree` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/domains` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/entries` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/feature-gate` | 460 kB | 850 kB |
+| Dynamic | `/address/[address]/idl` | 600 kB | 0.97 MB |
+| Dynamic | `/address/[address]/instructions` | 470 kB | 860 kB |
+| Dynamic | `/address/[address]/metadata` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/program-multisig` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/rewards` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/security` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/slot-hashes` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/stake-history` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/subscriptions` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/token-extensions` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/tokens` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]/transfers` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]/verified-build` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/vote-history` | 460 kB | 860 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
 | Dynamic | `/api/geo-location` | — | — |
@@ -49,10 +49,10 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 280 kB | 680 kB |
-| Dynamic | `/block/[slot]/accounts` | 280 kB | 670 kB |
-| Dynamic | `/block/[slot]/programs` | 280 kB | 670 kB |
-| Dynamic | `/block/[slot]/rewards` | 280 kB | 670 kB |
+| Dynamic | `/block/[slot]` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/accounts` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/programs` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/rewards` | 260 kB | 660 kB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
 | Static | `/feature-gates` | 40 kB | 440 kB |
 | Dynamic | `/mcp` | — | — |
@@ -61,6 +61,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 400 kB |
-| Dynamic | `/tx/[signature]` | 670 kB | 1.04 MB |
-| Dynamic | `/tx/[signature]/inspect` | 470 kB | 870 kB |
-| Static | `/tx/inspector` | 470 kB | 870 kB |
+| Dynamic | `/tx/[signature]` | 540 kB | 940 kB |
+| Dynamic | `/tx/[signature]/inspect` | 450 kB | 850 kB |
+| Static | `/tx/inspector` | 450 kB | 850 kB |


### PR DESCRIPTION
## Description

`CustomUrlConsentDialog` branched with a two-way ternary over a three-state prop, so the `undefined` that closes the dialog rendered the developer-bypass copy:

```tsx
{request?.kind === 'endpoint' ? <EndpointConsent … /> : <BypassConsent … />}
```

Radix keeps `DialogContent` mounted until its exit animation ends (`duration-200`), so answering the endpoint question swapped it for "Stop asking about custom RPC servers?" — red **Turn on anyway** button included — for ~200ms on the way out. Every close path hits it: Cancel, Connect, Escape and the X. On Cancel it is camouflaged: `router.replace` repaints the navbar, cluster and stats at that same instant, so the eye follows the page, not the box that is already dismissing.

No consent can be granted in that window. The visible button is wired to the pending-consent mount, whose `onConfirm` is guarded on the request, and `customUrlEnabledAtom` is only ever written from the developer-settings switch. The bug is the message, not the gate: the last thing shown after refusing one server was an offer to stop asking about all of them.

The fix retains the last request, so a closing dialog keeps the question it asked — the endpoint's host stays on screen while the box fades, rather than collapsing onto nothing — and branches per `kind`, so a future third kind cannot fall into the bypass copy either.

From #1209, which added the dialog.

**Why the existing specs were green.** jsdom runs no animations, so `getComputedStyle().animationName` is `none` and Radix `Presence` unmounts on the tick that closes the dialog — the closing render never happens, and the specs assert the dialog is simply gone. The new spec reports the animation name the stylesheet would for the `data-state` Radix has just written, which puts the dialog into `unmountSuspended` exactly as a browser does, then asserts the closing dialog still shows the question it asked and never the other one. Reverting the component fails it.

## Type of change

-   [x] Bug fix

## Testing

Manual testing on the preview deployment:

- [Root page, endpoint prompt — Cancel, then reload and Connect: the question must keep its own copy while the box fades](https://explorer-git-fork-hoodieshq-fix-consen-15c88c-solana-foundation.vercel.app/?cluster=custom&customUrl=https://api.devnet.solana.com)
- [Address page, the same prompt from a deep link — Escape and the X close it the same way](https://explorer-git-fork-hoodieshq-fix-consen-15c88c-solana-foundation.vercel.app/address/SysvarC1ock11111111111111111111111111111111?cluster=custom&customUrl=https://api.devnet.solana.com)
- [Cluster switcher → Developer Settings → "Trust any custom url param" → Cancel: the bypass question keeps its copy on the way out](https://explorer-git-fork-hoodieshq-fix-consen-15c88c-solana-foundation.vercel.app/)

## Related Issues

Closes [HOO-1155](https://linear.app/solana-fndn/issue/HOO-1155/closing-the-endpoint-consent-dialog-flashes-the-developer-bypass)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

`bench/BUILD.md` is regenerated in its own commit. The `/address/*` size deltas there are pre-existing drift on `master`, not from this change: two consecutive `build:info` runs on this tree produce the committed table byte for byte, and the fix touches one client component in the cluster switcher.

