### PR TITLE
Refactor/hoo 1186 read v1 blocks with kit

### DIFF
--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -1,5 +1,6 @@
 import { Address } from '@components/common/Address';
-import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import type { BlockWithV1 } from '@entities/block-data';
+import { PublicKey } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React from 'react';
@@ -16,7 +17,7 @@ type AccountStats = {
 
 const PAGE_SIZE = 25;
 
-export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockResponse; blockSlot: number }) {
+export function BlockAccountsCard({ block, blockSlot }: { block: BlockWithV1; blockSlot: number }) {
     const [numDisplayed, setNumDisplayed] = React.useState(10);
     const totalTransactions = block.transactions.length;
 

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -3,15 +3,10 @@ import { ErrorCard } from '@components/common/ErrorCard';
 import { Signature } from '@components/common/Signature';
 import { SolBalance } from '@components/common/SolBalance';
 import { cn } from '@components/shared/utils';
+import type { BlockWithV1 } from '@entities/block-data';
 import { estimateRequestedComputeUnits } from '@entities/compute-unit';
 import { useCluster } from '@providers/cluster';
-import {
-    ConfirmedTransactionMeta,
-    PublicKey,
-    TransactionSignature,
-    VersionedBlockResponse,
-    VOTE_PROGRAM_ID,
-} from '@solana/web3.js';
+import { ConfirmedTransactionMeta, PublicKey, TransactionSignature, VOTE_PROGRAM_ID } from '@solana/web3.js';
 import { parseProgramLogs } from '@utils/program-logs';
 import { displayAddress } from '@utils/tx';
 import { useBuildClusterPath } from '@utils/url';
@@ -67,7 +62,7 @@ type TransactionWithInvocations = {
     logTruncated: boolean;
 };
 
-export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockResponse; epoch: bigint | undefined }) {
+export function BlockHistoryCard({ block, epoch }: { block: BlockWithV1; epoch: bigint | undefined }) {
     const [numDisplayed, setNumDisplayed] = React.useState(PAGE_SIZE);
     const currentPathname = usePathname();
     const currentSearchParams = useSearchParams();

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -1,13 +1,14 @@
 import { Address } from '@components/common/Address';
 import { TableCardBody } from '@components/common/TableCardBody';
-import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import type { BlockWithV1 } from '@entities/block-data';
+import { PublicKey } from '@solana/web3.js';
 import React from 'react';
 
 import { invariant } from '@/app/shared/lib/invariant';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
-export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) {
+export function BlockProgramsCard({ block }: { block: BlockWithV1 }) {
     const totalTransactions = block.transactions.length;
     const txSuccesses = new Map<string, number>();
     const txFrequency = new Map<string, number>();

--- a/app/components/block/BlockRewardsCard.tsx
+++ b/app/components/block/BlockRewardsCard.tsx
@@ -1,6 +1,7 @@
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
-import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import type { BlockWithV1 } from '@entities/block-data';
+import { PublicKey } from '@solana/web3.js';
 import React from 'react';
 
 import { Button } from '@/app/components/shared/ui/button';
@@ -9,7 +10,7 @@ import { BaseTable } from '@/app/shared/ui/Table';
 
 const PAGE_SIZE = 10;
 
-export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
+export function BlockRewardsCard({ block }: { block: BlockWithV1 }) {
     const [rewardsDisplayed, setRewardsDisplayed] = React.useState(PAGE_SIZE);
 
     if (!block.rewards || block.rewards.length < 1) {

--- a/app/components/block/__stories__/BlockHistoryCard.responsive.stories.tsx
+++ b/app/components/block/__stories__/BlockHistoryCard.responsive.stories.tsx
@@ -1,4 +1,4 @@
-import type { VersionedBlockResponse } from '@solana/web3.js';
+import type { BlockWithV1 } from '@entities/block-data';
 import { nextjsParameters, withCluster } from '@storybook-config/decorators';
 import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
@@ -11,7 +11,7 @@ const emptyBlock = {
     parentSlot: 0,
     previousBlockhash: 'GnPnX9Y6w6vYi3iWQGfh',
     transactions: [],
-} as unknown as VersionedBlockResponse;
+} as unknown as BlockWithV1;
 
 const meta: Meta<typeof BlockHistoryCard> = {
     component: BlockHistoryCard,

--- a/app/components/block/__stories__/BlockHistoryCard.stories.tsx
+++ b/app/components/block/__stories__/BlockHistoryCard.stories.tsx
@@ -1,10 +1,10 @@
-import type { VersionedBlockResponse } from '@solana/web3.js';
+import type { BlockWithV1 } from '@entities/block-data';
 import { nextjsParameters, withCluster } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
 
 import { BlockHistoryCard } from '../BlockHistoryCard';
 
-// Real block decoding requires a fully-formed VersionedBlockResponse with compiled instructions,
+// Real block decoding requires a fully-formed BlockWithV1 with compiled instructions,
 // account keys, and meta — heavy fixture work. Empty-transactions case exercises the
 // "no transactions" ErrorCard fallback and is the natural prop-driven story for this card.
 const emptyBlock = {
@@ -13,7 +13,7 @@ const emptyBlock = {
     parentSlot: 0,
     previousBlockhash: 'GnPnX9Y6w6vYi3iWQGfh',
     transactions: [],
-} as unknown as VersionedBlockResponse;
+} as unknown as BlockWithV1;
 
 const meta = {
     component: BlockHistoryCard,

--- a/app/components/block/__stories__/BlockProgramsCard.stories.tsx
+++ b/app/components/block/__stories__/BlockProgramsCard.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof BlockProgramsCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Empty block exercises the wrapper without a full VersionedBlockResponse fixture.
+// Empty block exercises the wrapper without a full BlockWithV1 fixture.
 export const EmptyBlock: Story = {
     args: {
         block: { transactions: [] } as any,

--- a/app/entities/block-data/__fixtures__/block-responses.ts
+++ b/app/entities/block-data/__fixtures__/block-responses.ts
@@ -1,0 +1,66 @@
+/** A block whose only transaction is v1, setting a 10,000 compute unit limit and a 65,536 byte
+ *  loaded accounts data size limit in its message config. */
+export const V1_BLOCK_RESPONSE = {
+    blockTime: 1787266078,
+    blockhash: 'SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxx1a429ax7',
+    parentSlot: 440572821,
+    previousBlockhash: 'SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxx1a429ax6',
+    rewards: [],
+    transactions: [
+        {
+            meta: {
+                computeUnitsConsumed: 150,
+                err: null,
+                fee: 5000,
+                innerInstructions: [],
+                loadedAddresses: { readonly: [], writable: [] },
+                logMessages: [
+                    'Program 11111111111111111111111111111111 invoke [1]',
+                    'Program 11111111111111111111111111111111 success',
+                ],
+                postBalances: [997995000, 2000000, 1],
+                postTokenBalances: [],
+                preBalances: [1000000000, 0, 1],
+                preTokenBalances: [],
+            },
+            transaction: [
+                'gQEAAQwAAAAGhoWdOMgKlyFIGEFpF+C/j8oVfkZPmMz9D4tgIT98jwEDsN70je2SuXm7PnZ9i0Lz/knxA03MHr2RRKYsalX9GoiGHkfgwNARedNTiP/pTTwpIBHdo7ySD6or+jVtd1PgBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECcAAAAAAQACAgwAAAECAAAAgIQeAAAAAAB5mCptdJ9aqZlgZ4HLuylhytDOdG4PLSd0GkNRDffSvwpTh653j/m23zHKRCHpnRbFc17OUWzwU4Jxs1mCmd0P',
+                'base64',
+            ],
+            version: 1,
+        },
+    ],
+};
+
+/** A block whose only transaction is legacy, which sets no resource limits at all. */
+export const LEGACY_BLOCK_RESPONSE = {
+    blockTime: 1787266077,
+    blockhash: 'SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxx1a429ax4',
+    parentSlot: 440572818,
+    previousBlockhash: 'SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxx1a429ax3',
+    rewards: [],
+    transactions: [
+        {
+            meta: {
+                computeUnitsConsumed: 150,
+                err: null,
+                fee: 5000,
+                innerInstructions: [],
+                loadedAddresses: { readonly: [], writable: [] },
+                logMessages: [
+                    'Program 11111111111111111111111111111111 invoke [1]',
+                    'Program 11111111111111111111111111111111 success',
+                ],
+                postBalances: [999997999990000, 1000000000, 1],
+                postTokenBalances: [],
+                preBalances: [999998999995000, 0, 1],
+                preTokenBalances: [],
+            },
+            transaction: [
+                'AXrEnD2Oa7boZg7ptqhDNwo2ML+xxeneIfUdQY4MzG7IZyM+2j1dLUsWP+dJqvlLCwmFl7FgStmJ1iGf9NPciAoBAAEDXoh+x6PKPLaf+cYvBMnfGk7xmLPzBQsggSyuASY1XaKw3vSN7ZK5ebs+dn2LQvP+SfEDTcwevZFEpixqVf0aiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAAAMqaOwAAAAA=',
+                'base64',
+            ],
+            version: 'legacy',
+        },
+    ],
+};

--- a/app/entities/block-data/api/__tests__/fetch-block.spec.ts
+++ b/app/entities/block-data/api/__tests__/fetch-block.spec.ts
@@ -143,6 +143,21 @@ describe('fetchBlock', () => {
         expect(block?.blockTime).toBe(1_787_266_078);
     });
 
+    it('should carry a commission only on the rewards that have one', async () => {
+        respondWith({
+            ...V1_BLOCK_RESPONSE,
+            rewards: [
+                { commission: 5, lamports: 12, postBalance: 100, pubkey: 'Vote111', rewardType: 'Voting' },
+                { lamports: 3, postBalance: 50, pubkey: 'Fee111', rewardType: 'Fee' },
+            ],
+        });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.rewards?.[0].commission).toBe(5);
+        expect(block?.rewards?.[1].commission).toBeUndefined();
+    });
+
     it('should render each transaction signature in signer order', async () => {
         respondWith(V1_BLOCK_RESPONSE);
 

--- a/app/entities/block-data/api/__tests__/fetch-block.spec.ts
+++ b/app/entities/block-data/api/__tests__/fetch-block.spec.ts
@@ -158,6 +158,47 @@ describe('fetchBlock', () => {
         expect(block?.rewards?.[1].commission).toBeUndefined();
     });
 
+    it('should keep the readable transactions when one cannot be decoded', async () => {
+        const [transaction] = LEGACY_BLOCK_RESPONSE.transactions;
+        respondWith({
+            ...LEGACY_BLOCK_RESPONSE,
+            transactions: [{ ...transaction, transaction: ['not-base64-bytes', 'base64'] }, transaction],
+        });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions).toHaveLength(1);
+        expect(block?.transactions[0].version).toBe('legacy');
+    });
+
+    it('should drop a transaction whose meta does not match the shape the cards read', async () => {
+        const [transaction] = LEGACY_BLOCK_RESPONSE.transactions;
+        const meta = { ...transaction.meta, postBalances: 'not-an-array' };
+        respondWith({ ...LEGACY_BLOCK_RESPONSE, transactions: [{ ...transaction, meta }] });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions).toEqual([]);
+    });
+
+    it('should adapt a transaction whose meta records no token balances', async () => {
+        const [transaction] = LEGACY_BLOCK_RESPONSE.transactions;
+        const meta = { ...transaction.meta, postTokenBalances: null, preTokenBalances: null };
+        respondWith({ ...LEGACY_BLOCK_RESPONSE, transactions: [{ ...transaction, meta }] });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].meta?.postTokenBalances).toBeUndefined();
+        expect(block?.transactions[0].meta?.preTokenBalances).toBeUndefined();
+    });
+
+    it('should reject a block that is missing the fields every subpage renders', async () => {
+        const withoutBlockhash = { ...V1_BLOCK_RESPONSE, blockhash: undefined };
+        respondWith(withoutBlockhash);
+
+        await expect(fetchBlock(URL, SLOT)).rejects.toThrow();
+    });
+
     it('should render each transaction signature in signer order', async () => {
         respondWith(V1_BLOCK_RESPONSE);
 

--- a/app/entities/block-data/api/__tests__/fetch-block.spec.ts
+++ b/app/entities/block-data/api/__tests__/fetch-block.spec.ts
@@ -1,0 +1,155 @@
+import type * as SolanaKit from '@solana/kit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LEGACY_BLOCK_RESPONSE, V1_BLOCK_RESPONSE } from '../../__fixtures__/block-responses';
+import { fetchBlock } from '../fetch-block';
+
+// The global setup stubs `createSolanaRpc` so no test reaches the network; these tests exercise the
+// real client against a stubbed `fetch` instead.
+vi.mock('@solana/kit', async () => await vi.importActual<typeof SolanaKit>('@solana/kit'));
+
+const URL = 'https://mock.rpc';
+const SLOT = 440_572_822;
+
+const fetchMock = vi.fn();
+
+function respondWith(result: unknown) {
+    const body = JSON.stringify({ id: 1, jsonrpc: '2.0', result });
+    // kit reads the body as text so it can upcast integers to bigints as it parses.
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, text: async () => body });
+}
+
+function requestBody() {
+    return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('fetchBlock', () => {
+    it('should ask for base64 transactions at the newest version Explorer renders', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        await fetchBlock(URL, SLOT);
+
+        expect(requestBody().params).toEqual([
+            SLOT,
+            {
+                commitment: 'confirmed',
+                encoding: 'base64',
+                maxSupportedTransactionVersion: 1,
+                rewards: true,
+                transactionDetails: 'full',
+            },
+        ]);
+    });
+
+    it('should return null when the RPC does not hold the block', async () => {
+        respondWith(null);
+
+        await expect(fetchBlock(URL, SLOT)).resolves.toBeNull();
+    });
+
+    it('should read a v1 transaction that a maxSupportedTransactionVersion of 0 would reject', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions).toHaveLength(1);
+        expect(block?.transactions[0].version).toBe(1);
+    });
+
+    it('should surface a v1 transaction resource limits from the message config', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].transactionConfig).toEqual({
+            computeUnitLimit: 10_000,
+            loadedAccountsDataSizeLimit: 65_536,
+        });
+    });
+
+    it('should expose a v1 message through the web3.js interface the block cards read', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+        const message = block?.transactions[0].transaction.message;
+
+        expect(message?.compiledInstructions).toHaveLength(1);
+        expect(message?.staticAccountKeys).toHaveLength(3);
+        expect(message?.isAccountWritable(0)).toBe(true);
+        expect(message?.getAccountKeys({ accountKeysFromLookups: undefined }).get(2)?.toBase58()).toBe(
+            '11111111111111111111111111111111',
+        );
+    });
+
+    it('should carry no resource limits for a legacy transaction', async () => {
+        respondWith(LEGACY_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].version).toBe('legacy');
+        expect(block?.transactions[0].transactionConfig).toBeUndefined();
+    });
+
+    it('should narrow meta amounts to the numbers web3.js consumers expect', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+        const meta = block?.transactions[0].meta;
+
+        expect(meta?.fee).toBe(5000);
+        expect(meta?.computeUnitsConsumed).toBe(150);
+        expect(meta?.preBalances).toEqual([1_000_000_000, 0, 1]);
+        expect(meta?.logMessages).toHaveLength(2);
+    });
+
+    it('should adapt a transaction whose meta omits inner instructions and loaded addresses', async () => {
+        const [transaction] = LEGACY_BLOCK_RESPONSE.transactions;
+        const meta = { ...transaction.meta, innerInstructions: undefined, loadedAddresses: undefined };
+        respondWith({ ...LEGACY_BLOCK_RESPONSE, transactions: [{ ...transaction, meta }] });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].meta?.innerInstructions).toBeUndefined();
+        expect(block?.transactions[0].meta?.loadedAddresses).toBeUndefined();
+        expect(block?.transactions[0].version).toBe('legacy');
+    });
+
+    it('should adapt a transaction with no meta recorded', async () => {
+        const [transaction] = LEGACY_BLOCK_RESPONSE.transactions;
+        respondWith({ ...LEGACY_BLOCK_RESPONSE, transactions: [{ ...transaction, meta: null }] });
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].meta).toBeNull();
+    });
+
+    it('should report the block header fields the overview renders', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.blockhash).toBe(V1_BLOCK_RESPONSE.blockhash);
+        expect(block?.previousBlockhash).toBe(V1_BLOCK_RESPONSE.previousBlockhash);
+        expect(block?.parentSlot).toBe(440_572_821);
+        expect(block?.blockTime).toBe(1_787_266_078);
+    });
+
+    it('should render each transaction signature in signer order', async () => {
+        respondWith(V1_BLOCK_RESPONSE);
+
+        const block = await fetchBlock(URL, SLOT);
+
+        expect(block?.transactions[0].transaction.signatures).toEqual([
+            '3S16GMLh2fH28SAhXWRRqogYudd8MPvZD39Ee22ZS6F2jeJQLhYNpKfdkZxo49dnKDsoXvtdBxQFRaDbvd1QnZaW',
+        ]);
+    });
+});

--- a/app/entities/block-data/api/fetch-block.ts
+++ b/app/entities/block-data/api/fetch-block.ts
@@ -44,6 +44,8 @@ export async function fetchBlock(url: string, slot: number): Promise<BlockWithV1
         parentSlot: Number(response.parentSlot),
         previousBlockhash: response.previousBlockhash,
         rewards: response.rewards?.map(reward => ({
+            // Only staking and voting rewards carry a commission.
+            commission: 'commission' in reward ? reward.commission : undefined,
             lamports: Number(reward.lamports),
             postBalance: reward.postBalance === null ? null : Number(reward.postBalance),
             pubkey: reward.pubkey,

--- a/app/entities/block-data/api/fetch-block.ts
+++ b/app/entities/block-data/api/fetch-block.ts
@@ -6,12 +6,18 @@ import {
     MAX_SUPPORTED_TRANSACTION_VERSION,
     type Slot,
     type Transaction,
-    type TransactionError,
 } from '@solana/kit';
-import { PublicKey, type TokenBalance, VersionedMessage } from '@solana/web3.js';
+import { PublicKey, VersionedMessage } from '@solana/web3.js';
+import { create } from 'superstruct';
 
+import { Logger } from '@/app/shared/lib/logger';
 import { bridgeV1MessageBytes, isV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
 
+import {
+    BlockResponseSchema,
+    type BlockTransactionResponse,
+    BlockTransactionResponseSchema,
+} from '../model/block-response-schema';
 import type { BlockTransaction, BlockWithV1 } from '../model/types';
 
 /**
@@ -38,54 +44,44 @@ export async function fetchBlock(url: string, slot: number): Promise<BlockWithV1
         return null;
     }
 
+    // A block missing any of these fields cannot be rendered at all, so validation failure surfaces
+    // as a fetch error rather than a half-drawn page.
+    const block = create(response, BlockResponseSchema);
+
     return {
-        blockTime: response.blockTime === null ? null : Number(response.blockTime),
-        blockhash: response.blockhash,
-        parentSlot: Number(response.parentSlot),
-        previousBlockhash: response.previousBlockhash,
-        rewards: response.rewards?.map(reward => ({
+        blockTime: block.blockTime === null ? null : Number(block.blockTime),
+        blockhash: block.blockhash,
+        parentSlot: Number(block.parentSlot),
+        previousBlockhash: block.previousBlockhash,
+        rewards: block.rewards?.map(reward => ({
             // Only staking and voting rewards carry a commission.
-            commission: 'commission' in reward ? reward.commission : undefined,
+            commission: reward.commission,
             lamports: Number(reward.lamports),
             postBalance: reward.postBalance === null ? null : Number(reward.postBalance),
             pubkey: reward.pubkey,
             rewardType: reward.rewardType,
         })),
-        transactions: response.transactions.map(adaptTransaction),
+        transactions: block.transactions.flatMap((rpcTransaction, index) =>
+            adaptTransactionOrDrop(rpcTransaction, index, slot),
+        ),
     };
 }
 
-/** Numeric fields the RPC serves that kit's meta type does not declare. `costUnits` feeds the block
- *  history cost column and the block's cost total. */
-type UndeclaredMeta = Readonly<{ costUnits?: number | bigint }>;
+/**
+ * Adapts one transaction, dropping it if either its shape or its bytes cannot be read.
+ *
+ * A single unreadable transaction costs its own row rather than the whole block: the cards derive
+ * every position from the array this returns, so a shorter array stays internally consistent.
+ */
+function adaptTransactionOrDrop(rpcTransaction: unknown, index: number, slot: number): BlockTransaction[] {
+    try {
+        return [adaptTransaction(create(rpcTransaction, BlockTransactionResponseSchema))];
+    } catch (error) {
+        Logger.error(error, { index, sentry: true, slot });
 
-type RpcBlockTransaction = Readonly<{
-    meta:
-        | (Readonly<{
-              computeUnitsConsumed?: bigint;
-              err: TransactionError | null;
-              fee: bigint;
-              innerInstructions?:
-                  | readonly Readonly<{
-                        index: number;
-                        instructions: readonly Readonly<{
-                            accounts: readonly number[];
-                            data: string;
-                            programIdIndex: number;
-                        }>[];
-                    }>[]
-                  | null;
-              loadedAddresses?: Readonly<{ readonly: readonly string[]; writable: readonly string[] }> | null;
-              logMessages: readonly string[] | null;
-              postBalances: readonly bigint[];
-              postTokenBalances?: readonly TokenBalance[];
-              preBalances: readonly bigint[];
-              preTokenBalances?: readonly TokenBalance[];
-          }> &
-              UndeclaredMeta)
-        | null;
-    transaction: readonly [string, 'base64'];
-}>;
+        return [];
+    }
+}
 
 /**
  * Adapts one block transaction from its wire bytes into the web3.js-shaped view the cards read.
@@ -93,7 +89,7 @@ type RpcBlockTransaction = Readonly<{
  * The cards need web3.js's `VersionedMessage` for `getAccountKeys` and `isAccountWritable`;
  * `bridgeV1MessageBytes` supplies that interface for v1 and also yields the resource limits.
  */
-function adaptTransaction(rpcTransaction: RpcBlockTransaction): BlockTransaction {
+function adaptTransaction(rpcTransaction: BlockTransactionResponse): BlockTransaction {
     const wireBytes = new Uint8Array(getBase64Encoder().encode(rpcTransaction.transaction[0]));
     const transaction = getTransactionDecoder().decode(wireBytes);
     // The decoded bytes are a view over the response buffer; copy so the message owns its own.
@@ -111,7 +107,7 @@ function adaptTransaction(rpcTransaction: RpcBlockTransaction): BlockTransaction
 }
 
 /** Converts meta into web3.js `ConfirmedTransactionMeta`, whose numeric fields are all `number`. */
-function adaptMeta(meta: RpcBlockTransaction['meta']): BlockTransaction['meta'] {
+function adaptMeta(meta: BlockTransactionResponse['meta']): BlockTransaction['meta'] {
     if (meta === null) {
         // The cards distinguish "no meta recorded" from an empty one.
         return null;
@@ -139,9 +135,10 @@ function adaptMeta(meta: RpcBlockTransaction['meta']): BlockTransaction['meta'] 
             : undefined,
         logMessages: meta.logMessages === null ? null : [...meta.logMessages],
         postBalances: meta.postBalances.map(Number),
-        postTokenBalances: meta.postTokenBalances === undefined ? undefined : [...meta.postTokenBalances],
+        // The RPC serves `null` for blocks written before it recorded token balances.
+        postTokenBalances: meta.postTokenBalances ?? undefined,
         preBalances: meta.preBalances.map(Number),
-        preTokenBalances: meta.preTokenBalances === undefined ? undefined : [...meta.preTokenBalances],
+        preTokenBalances: meta.preTokenBalances ?? undefined,
     };
 }
 

--- a/app/entities/block-data/api/fetch-block.ts
+++ b/app/entities/block-data/api/fetch-block.ts
@@ -1,0 +1,160 @@
+import {
+    createSolanaRpc,
+    getBase58Decoder,
+    getBase64Encoder,
+    getTransactionDecoder,
+    MAX_SUPPORTED_TRANSACTION_VERSION,
+    type Slot,
+    type Transaction,
+    type TransactionError,
+} from '@solana/kit';
+import { PublicKey, type TokenBalance, VersionedMessage } from '@solana/web3.js';
+
+import { bridgeV1MessageBytes, isV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
+
+import type { BlockTransaction, BlockWithV1 } from '../model/types';
+
+/**
+ * Fetches a block and its transactions for the block pages.
+ *
+ * `base64` encoding rather than `json` so each transaction arrives as the bytes the network holds:
+ * those bytes are the only place a v1 transaction's resource limits can be found.
+ */
+// web3.js types `blockTime`, `postBalance` and `logMessages` as required `T | null`.
+/* eslint-disable unicorn/no-null */
+export async function fetchBlock(url: string, slot: number): Promise<BlockWithV1 | null> {
+    const response = await createSolanaRpc(url)
+        .getBlock(BigInt(slot) as Slot, {
+            commitment: 'confirmed',
+            encoding: 'base64',
+            maxSupportedTransactionVersion: MAX_SUPPORTED_TRANSACTION_VERSION,
+            rewards: true,
+            transactionDetails: 'full',
+        })
+        .send();
+
+    if (response === null) {
+        // The cache providers distinguish "fetched, not found" from "not fetched yet" by null vs undefined.
+        return null;
+    }
+
+    return {
+        blockTime: response.blockTime === null ? null : Number(response.blockTime),
+        blockhash: response.blockhash,
+        parentSlot: Number(response.parentSlot),
+        previousBlockhash: response.previousBlockhash,
+        rewards: response.rewards?.map(reward => ({
+            lamports: Number(reward.lamports),
+            postBalance: reward.postBalance === null ? null : Number(reward.postBalance),
+            pubkey: reward.pubkey,
+            rewardType: reward.rewardType,
+        })),
+        transactions: response.transactions.map(adaptTransaction),
+    };
+}
+
+/** Numeric fields the RPC serves that kit's meta type does not declare. `costUnits` feeds the block
+ *  history cost column and the block's cost total. */
+type UndeclaredMeta = Readonly<{ costUnits?: number | bigint }>;
+
+type RpcBlockTransaction = Readonly<{
+    meta:
+        | (Readonly<{
+              computeUnitsConsumed?: bigint;
+              err: TransactionError | null;
+              fee: bigint;
+              innerInstructions?:
+                  | readonly Readonly<{
+                        index: number;
+                        instructions: readonly Readonly<{
+                            accounts: readonly number[];
+                            data: string;
+                            programIdIndex: number;
+                        }>[];
+                    }>[]
+                  | null;
+              loadedAddresses?: Readonly<{ readonly: readonly string[]; writable: readonly string[] }> | null;
+              logMessages: readonly string[] | null;
+              postBalances: readonly bigint[];
+              postTokenBalances?: readonly TokenBalance[];
+              preBalances: readonly bigint[];
+              preTokenBalances?: readonly TokenBalance[];
+          }> &
+              UndeclaredMeta)
+        | null;
+    transaction: readonly [string, 'base64'];
+}>;
+
+/**
+ * Adapts one block transaction from its wire bytes into the web3.js-shaped view the cards read.
+ *
+ * The cards need web3.js's `VersionedMessage` for `getAccountKeys` and `isAccountWritable`;
+ * `bridgeV1MessageBytes` supplies that interface for v1 and also yields the resource limits.
+ */
+function adaptTransaction(rpcTransaction: RpcBlockTransaction): BlockTransaction {
+    const wireBytes = new Uint8Array(getBase64Encoder().encode(rpcTransaction.transaction[0]));
+    const transaction = getTransactionDecoder().decode(wireBytes);
+    // The decoded bytes are a view over the response buffer; copy so the message owns its own.
+    const messageBytes = new Uint8Array(transaction.messageBytes);
+    // kit delivers the response's numeric fields as bigint, so the version comes from the bytes.
+    const bridged = isV1MessageBytes(messageBytes) ? bridgeV1MessageBytes(messageBytes) : undefined;
+    const message = bridged?.message ?? VersionedMessage.deserialize(messageBytes);
+
+    return {
+        meta: adaptMeta(rpcTransaction.meta),
+        transaction: { message, signatures: toBase58Signatures(transaction.signatures) },
+        transactionConfig: bridged?.transactionConfig,
+        version: bridged ? 1 : message.version,
+    };
+}
+
+/** Converts meta into web3.js `ConfirmedTransactionMeta`, whose numeric fields are all `number`. */
+function adaptMeta(meta: RpcBlockTransaction['meta']): BlockTransaction['meta'] {
+    if (meta === null) {
+        // The cards distinguish "no meta recorded" from an empty one.
+        return null;
+    }
+
+    return {
+        computeUnitsConsumed: meta.computeUnitsConsumed === undefined ? undefined : Number(meta.computeUnitsConsumed),
+        costUnits: meta.costUnits === undefined ? undefined : Number(meta.costUnits),
+        err: meta.err,
+        fee: Number(meta.fee),
+        innerInstructions:
+            meta.innerInstructions?.map(({ index, instructions }) => ({
+                index,
+                instructions: instructions.map(({ accounts, data, programIdIndex }) => ({
+                    accounts: [...accounts],
+                    data,
+                    programIdIndex,
+                })),
+            })) ?? undefined,
+        loadedAddresses: meta.loadedAddresses
+            ? {
+                  readonly: meta.loadedAddresses.readonly.map(address => new PublicKey(address)),
+                  writable: meta.loadedAddresses.writable.map(address => new PublicKey(address)),
+              }
+            : undefined,
+        logMessages: meta.logMessages === null ? null : [...meta.logMessages],
+        postBalances: meta.postBalances.map(Number),
+        postTokenBalances: meta.postTokenBalances === undefined ? undefined : [...meta.postTokenBalances],
+        preBalances: meta.preBalances.map(Number),
+        preTokenBalances: meta.preTokenBalances === undefined ? undefined : [...meta.preTokenBalances],
+    };
+}
+
+/* eslint-enable unicorn/no-null */
+
+/**
+ * Renders a transaction's signatures in signer order.
+ *
+ * The map is insertion-ordered, matching the message's signer order. A transaction that reached a
+ * block carries every required signature, so no slot is dropped in practice.
+ */
+function toBase58Signatures(signatures: Transaction['signatures']): string[] {
+    const base58Decoder = getBase58Decoder();
+
+    return Object.values(signatures)
+        .filter(signature => signature !== null)
+        .map(signature => base58Decoder.decode(signature));
+}

--- a/app/entities/block-data/index.ts
+++ b/app/entities/block-data/index.ts
@@ -1,0 +1,2 @@
+export { fetchBlock } from './api/fetch-block';
+export type { BlockTransaction, BlockWithV1 } from './model/types';

--- a/app/entities/block-data/model/block-response-schema.ts
+++ b/app/entities/block-data/model/block-response-schema.ts
@@ -1,0 +1,107 @@
+import {
+    array,
+    bigint,
+    type Infer,
+    literal,
+    nullable,
+    number,
+    optional,
+    record,
+    string,
+    tuple,
+    type,
+    union,
+    unknown,
+} from 'superstruct';
+
+/**
+ * An unsigned integer as it arrives from the RPC.
+ *
+ * kit's JSON parser upcasts the integers its schema declares to `bigint` and leaves the rest as
+ * `number`, so a field can hold either.
+ */
+const u64 = () => union([bigint(), number()]);
+
+const TokenBalanceSchema = type({
+    accountIndex: number(),
+    mint: string(),
+    owner: optional(string()),
+    programId: optional(string()),
+    uiTokenAmount: type({
+        amount: string(),
+        decimals: number(),
+        uiAmount: nullable(number()),
+        uiAmountString: optional(string()),
+    }),
+});
+
+/** web3.js models a transaction error as an opaque object or a string. */
+const TransactionErrorSchema = nullable(union([string(), record(string(), unknown())]));
+
+const TransactionMetaSchema = nullable(
+    type({
+        computeUnitsConsumed: optional(u64()),
+        /** Feeds the block history cost column and the block's cost total; kit's meta type omits it. */
+        costUnits: optional(u64()),
+        err: TransactionErrorSchema,
+        fee: u64(),
+        innerInstructions: optional(
+            nullable(
+                array(
+                    type({
+                        index: number(),
+                        instructions: array(
+                            type({
+                                accounts: array(number()),
+                                data: string(),
+                                programIdIndex: number(),
+                            }),
+                        ),
+                    }),
+                ),
+            ),
+        ),
+        loadedAddresses: optional(nullable(type({ readonly: array(string()), writable: array(string()) }))),
+        logMessages: nullable(array(string())),
+        postBalances: array(u64()),
+        postTokenBalances: optional(nullable(array(TokenBalanceSchema))),
+        preBalances: array(u64()),
+        preTokenBalances: optional(nullable(array(TokenBalanceSchema))),
+    }),
+);
+
+/**
+ * One `getBlock` transaction under `base64` encoding.
+ *
+ * Validated per transaction rather than with the block so a shape surprise costs one row instead of
+ * the whole page.
+ */
+export const BlockTransactionResponseSchema = type({
+    meta: TransactionMetaSchema,
+    transaction: tuple([string(), literal('base64')]),
+});
+
+/** The `getBlock` fields the block pages read. Transactions stay opaque here; see above. */
+export const BlockResponseSchema = type({
+    blockTime: nullable(u64()),
+    blockhash: string(),
+    parentSlot: u64(),
+    previousBlockhash: string(),
+    rewards: optional(
+        nullable(
+            array(
+                type({
+                    commission: optional(nullable(number())),
+                    lamports: u64(),
+                    postBalance: nullable(u64()),
+                    pubkey: string(),
+                    rewardType: nullable(string()),
+                }),
+            ),
+        ),
+    ),
+    transactions: array(unknown()),
+});
+
+export type BlockResponse = Infer<typeof BlockResponseSchema>;
+export type BlockTransactionResponse = Infer<typeof BlockTransactionResponseSchema>;

--- a/app/entities/block-data/model/types.ts
+++ b/app/entities/block-data/model/types.ts
@@ -1,0 +1,24 @@
+import type { TransactionVersion } from '@solana/kit';
+import type { VersionedBlockResponse } from '@solana/web3.js';
+
+import type { V1TransactionConfig } from '@/app/shared/lib/v1-message-bridge';
+
+/**
+ * A block transaction in the shape the block cards consume.
+ *
+ * Matches a web3.js `VersionedBlockResponse` entry so existing consumers are unaffected, with the
+ * version widened to cover v1, which web3.js `TransactionVersion` cannot describe.
+ */
+export type BlockTransaction = Omit<VersionedBlockResponse['transactions'][number], 'version'> & {
+    transactionConfig?: V1TransactionConfig;
+    version: TransactionVersion;
+};
+
+/**
+ * A block in the shape the block pages consume.
+ *
+ * Matches web3.js `VersionedBlockResponse` apart from the widened transaction version.
+ */
+export type BlockWithV1 = Omit<VersionedBlockResponse, 'transactions'> & {
+    transactions: BlockTransaction[];
+};

--- a/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
+++ b/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
@@ -383,4 +383,41 @@ describe('estimateRequestedComputeUnits', () => {
             expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(500_000);
         });
     });
+
+    describe('v1 transactions', () => {
+        // Every case carries a ComputeBudget instruction, so the config has to win to pass.
+        const createV1Transaction = (transactionConfig?: {
+            computeUnitLimit?: number;
+        }): Parameters<typeof estimateRequestedComputeUnits>[0] => {
+            const data = alloc(5);
+            data[0] = 2; // SetComputeUnitLimit
+            writeUint32LE(data, 999_999, 1);
+
+            return {
+                ...createMockTransaction([{ data, programId: ComputeBudgetProgram.programId.toBase58() }]),
+                transactionConfig,
+                version: 1,
+            };
+        };
+
+        it('should read the limit from the message config rather than the instructions', () => {
+            const tx = createV1Transaction({ computeUnitLimit: 10_000 });
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(10_000);
+        });
+
+        it('should report zero when the config sets no compute unit limit', () => {
+            const tx = createV1Transaction({});
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(0);
+        });
+
+        it('should report zero when the message carries no config at all', () => {
+            const tx = createV1Transaction(undefined);
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(0);
+        });
+
+        it('should respect the 1.4M compute unit cap', () => {
+            const tx = createV1Transaction({ computeUnitLimit: 5_000_000 });
+            expect(estimateRequestedComputeUnits(tx, 1000n, Cluster.MainnetBeta)).toEqual(1_400_000);
+        });
+    });
 });

--- a/app/entities/compute-unit/lib/compute-units-schedule.ts
+++ b/app/entities/compute-unit/lib/compute-units-schedule.ts
@@ -184,10 +184,17 @@ export function estimateRequestedComputeUnits(
                 staticAccountKeys: PublicKey[];
             };
         };
+        transactionConfig?: { computeUnitLimit?: number };
+        version?: 'legacy' | 0 | 1;
     },
     epoch: bigint | undefined,
     cluster: Cluster,
 ): number {
+    // v1 carries its compute unit limit in the message config; an absent limit means zero.
+    if (tx.version === 1) {
+        return Math.min(tx.transactionConfig?.computeUnitLimit ?? 0, MAX_COMPUTE_UNITS);
+    }
+
     // First, check for explicit compute budget instructions
     let totalReservedUnits = 0;
     for (const instruction of tx.transaction.message.compiledInstructions) {

--- a/app/providers/block.tsx
+++ b/app/providers/block.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { type BlockWithV1, fetchBlock as fetchBlockBySlot } from '@entities/block-data';
 import * as Cache from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, PublicKey, VersionedBlockResponse } from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
@@ -20,7 +21,7 @@ export enum ActionType {
 }
 
 type Block = {
-    block?: VersionedBlockResponse;
+    block?: BlockWithV1;
     blockLeader?: PublicKey;
     childSlot?: number;
     childLeader?: PublicKey;
@@ -73,9 +74,7 @@ export async function fetchBlock(dispatch: Dispatch, url: string, cluster: Clust
 
     try {
         const connection = new Connection(url, 'confirmed');
-        const block = await connection.getBlock(slot, {
-            maxSupportedTransactionVersion: 0,
-        });
+        const block = await fetchBlockBySlot(url, slot);
         if (block === null) {
             data = {};
             status = FetchStatus.Fetched;

--- a/openspec/changes/read-v1-blocks-with-kit/proposal.md
+++ b/openspec/changes/read-v1-blocks-with-kit/proposal.md
@@ -1,0 +1,18 @@
+# Proposal: Read v1 blocks with kit
+
+## Why
+
+Block pages pin `maxSupportedTransactionVersion: 0`. `getBlock` has no partial mode, so one v1 transaction fails the whole block. Pinning to `1` fails at runtime on web3.js 1.98.4, whose schema admits only `0`/`legacy` and cannot hold `transactionConfig`. kit is the migration direction, so blocks follow the transaction and inspector paths.
+
+Two non-obvious choices:
+
+- **`base64` over `json`** — kit's RPC types don't model `transactionConfig`, so the wire bytes are its only source, and they reuse `bridgeV1MessageBytes`.
+- **The estimator gates on `version === 1`, not on a config existing** — an absent v1 config means zero, not a default.
+
+## What Changes
+
+New `app/entities/block-data`, fetched from `app/providers/block.tsx`. `estimateRequestedComputeUnits` reads v1's limit from the message config. The four block cards retype their `block` prop; no logic changes.
+
+## Impact
+
+Legacy/v0 unchanged. Still pinned at `0`: receipt, transaction history, PMP discovery, interactive IDL, `entity-inspector` default. Deferred: moving the cards off web3.js types, which deletes this adapter.

--- a/openspec/changes/read-v1-blocks-with-kit/specs/block-pages/spec.md
+++ b/openspec/changes/read-v1-blocks-with-kit/specs/block-pages/spec.md
@@ -1,0 +1,26 @@
+# Block pages
+
+## ADDED Requirements
+
+### Requirement: Block pages SHALL render blocks containing v1 transactions
+
+The fetch SHALL request transactions at the newest version Explorer renders, so a block is never rejected for holding one. Legacy and v0 SHALL decode as before.
+
+#### Scenario: a block holding a v1 transaction
+
+- **WHEN** a block contains a v1 transaction
+- **THEN** every subpage SHALL render it rather than the fetch-failed state, reading its accounts and instructions from its own wire bytes
+
+### Requirement: Requested compute units SHALL come from the message config for v1
+
+v1 states its compute unit limit in the message config, so instruction scanning SHALL NOT be used to derive it. An absent limit SHALL report zero, not a default.
+
+#### Scenario: a v1 transaction's compute unit limit
+
+- **WHEN** requested units are reported for a v1 transaction
+- **THEN** they SHALL be the config's limit, or zero if it sets none, and any ComputeBudget instruction SHALL be ignored
+
+#### Scenario: a legacy or v0 transaction
+
+- **WHEN** the transaction is legacy or v0
+- **THEN** requested units SHALL continue to come from ComputeBudget instructions and per-program reserves


### PR DESCRIPTION
Closes HOO-1186

Block pages sent `maxSupportedTransactionVersion: 0`. `getBlock` has no partial mode, so one v1 transaction failed the whole block and all four subpages showed the error state. Reproduced against a v1 transaction landed on the SIMD-296 surfnet.

Pinning to `1` fails at runtime on our 1.98.4: web3.js types the option as `number`, but its schema admits only `0`/`legacy` and has nowhere to put `transactionConfig`. kit is the migration direction, so blocks follow the transaction and inspector paths (#1192, #1204) and reuse that v1 message bridge. The four cards change types only.

Second, silent fix: `estimateRequestedComputeUnits` scanned for ComputeBudget instructions, which v1 doesn't carry, so it reported 200k for a transaction that requested 10,000 — wrong Reserved CUs, sort, and block total, no error.


Steps to test: 
- Open [Preview](https://explorer-git-refactor-hoo-1186-read-v1-ef230d-solana-foundation.vercel.app/)
- Run Local test validator (v4.2.1+)
- Change network to local
- Run a V1 transaction ([example](https://gist.github.com/amilz/832fb14baf7dc2bdc5ec2f42d7c3f280))
- Open the block the transaction was set in on block explorer
- It should render (run the same test on production explorer site, and it should crash the block page) 