### PR TITLE
fix(cluster): report a failed connection instead of loading forever

### DIFF
--- a/.storybook/__mocks__/MockSupplyProvider.tsx
+++ b/.storybook/__mocks__/MockSupplyProvider.tsx
@@ -18,7 +18,7 @@ type Props = {
  */
 export function MockSupplyProvider({ children, supply = defaultSupply }: Props) {
     return (
-        <StateContext.Provider value={supply}>
+        <StateContext.Provider value={{ kind: 'ready', supply }}>
             <DispatchContext.Provider value={() => {}}>{children}</DispatchContext.Provider>
         </StateContext.Provider>
     );

--- a/app/entities/cluster/index.ts
+++ b/app/entities/cluster/index.ts
@@ -8,6 +8,7 @@ export { approvedOriginsAtom, approveRpcOriginAtom } from './model/approved-orig
 export { ClusterProvider, type ClusterState, StateContext } from './model/cluster-provider';
 export { customUrlEnabledAtom } from './model/custom-url-enabled';
 export { useCluster } from './model/use-cluster';
+export { useClusterConnectionFailed } from './model/use-cluster-connection-failed';
 export { useClusterInfo } from './model/use-cluster-info';
 export { clusterModalOpenAtom, useClusterModal } from './model/use-cluster-modal';
 export {

--- a/app/entities/cluster/model/__tests__/use-cluster-connection-failed.spec.tsx
+++ b/app/entities/cluster/model/__tests__/use-cluster-connection-failed.spec.tsx
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Cluster, clusterSelection, ClusterStatus } from '../../lib/cluster';
+import { type ClusterState, StateContext } from '../cluster-provider';
+import { useClusterConnectionFailed } from '../use-cluster-connection-failed';
+
+describe('useClusterConnectionFailed', () => {
+    it('should report a failed connection', () => {
+        const { result } = renderHook(() => useClusterConnectionFailed(), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('should not report a failed connection once connected', () => {
+        const { result } = renderHook(() => useClusterConnectionFailed(), {
+            wrapper: makeWrapper(ClusterStatus.Connected),
+        });
+
+        expect(result.current).toBe(false);
+    });
+
+    // Connecting covers the pending-consent state too, where nothing has been asked of the endpoint
+    // yet. A page must keep loading there, not claim the endpoint is down.
+    it('should not report a failed connection while connecting', () => {
+        const { result } = renderHook(() => useClusterConnectionFailed(), {
+            wrapper: makeWrapper(ClusterStatus.Connecting),
+        });
+
+        expect(result.current).toBe(false);
+    });
+});
+
+function makeWrapper(status: ClusterStatus) {
+    const state: ClusterState = { selection: clusterSelection(Cluster.MainnetBeta), status };
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return createElement(StateContext.Provider, { value: state }, children);
+    };
+}

--- a/app/entities/cluster/model/cluster-provider.tsx
+++ b/app/entities/cluster/model/cluster-provider.tsx
@@ -57,12 +57,17 @@ export function ClusterProvider({ searchParams, onReplaceSearchParams, children 
     // loading card that self-heals via SWR retry — it does not fail the whole cluster.
     // eslint-disable-next-line unicorn/no-null -- SWR treats a null key, and only null, as "do not fetch"
     const connectionKey = pendingCustomUrl === undefined && customUrlDecided ? ['cluster-connection', url] : null;
+    // Revalidating on focus and on reconnect is what lets a failed connection recover: nothing in the UI
+    // retries the check, and a reachable endpoint answers from cache, so the cost falls on the failed case.
+    // `shouldRetryOnError` stays off — a down endpoint must not be hammered while the tab sits open.
     const { data: genesisHash, error } = useSWRImmutable(connectionKey, () => fetchGenesisHash(url), {
         onError: connectionError => {
             if (cluster !== Cluster.Custom) {
                 Logger.error(connectionError, { clusterUrl: url });
             }
         },
+        revalidateOnFocus: true,
+        revalidateOnReconnect: true,
         shouldRetryOnError: false,
     });
 

--- a/app/entities/cluster/model/use-cluster-connection-failed.ts
+++ b/app/entities/cluster/model/use-cluster-connection-failed.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { ClusterStatus } from '../lib/cluster';
+import { useCluster } from './use-cluster';
+
+/**
+ * True when the connection health check failed. Every provider gates its fetch on a connected cluster,
+ * so on failure nothing is ever requested and no fetch state arrives to end a loading card. Consumers
+ * use this to report the failure the caller can already render — see `providers/cache-entry`.
+ */
+export function useClusterConnectionFailed(): boolean {
+    const { status } = useCluster();
+    return status === ClusterStatus.Failure;
+}

--- a/app/epoch/[epoch]/__tests__/page-client.spec.tsx
+++ b/app/epoch/[epoch]/__tests__/page-client.spec.tsx
@@ -1,0 +1,46 @@
+import { FetchStatus } from '@providers/cache';
+import { render, screen } from '@testing-library/react';
+import { ClusterStatus } from '@utils/cluster';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let epochState: { status: FetchStatus } | undefined;
+
+vi.mock('@providers/cluster', () => ({
+    useCluster: () => ({ status: ClusterStatus.Failure }),
+    // Only fetches once the cluster is connected, so it stays undefined on a failed connection.
+    useClusterInfo: () => undefined,
+}));
+vi.mock('@providers/epoch', () => ({
+    useEpoch: () => epochState,
+    useFetchEpoch: () => vi.fn(),
+}));
+
+import EpochDetailsPageClient from '../page-client';
+
+beforeEach(() => {
+    epochState = undefined;
+});
+
+describe('EpochDetailsPageClient', () => {
+    it('should report the failure instead of loading forever when the epoch entry failed', () => {
+        // What `useEpoch` reports on a dead connection: the cache turns a never-requested entry into a
+        // failure (see providers/cache-entry). `clusterInfo` is unresolved too, so branch order decides.
+        epochState = { status: FetchStatus.FetchFailed };
+
+        renderPage();
+
+        expect(screen.getByText('Failed to fetch details for epoch 520')).toBeInTheDocument();
+        expect(screen.queryByText('Connecting to cluster')).not.toBeInTheDocument();
+    });
+
+    it('should keep loading while nothing has failed yet', () => {
+        renderPage();
+
+        expect(screen.getByText('Connecting to cluster')).toBeInTheDocument();
+        expect(screen.queryByText('Failed to fetch details for epoch 520')).not.toBeInTheDocument();
+    });
+});
+
+function renderPage() {
+    return render(<EpochDetailsPageClient params={{ epoch: '520' }} />);
+}

--- a/app/epoch/[epoch]/page-client.tsx
+++ b/app/epoch/[epoch]/page-client.tsx
@@ -61,6 +61,12 @@ function EpochOverviewCard({ epoch }: OverviewProps) {
             fetchEpoch(epoch, currentEpoch, epochSchedule);
     }, [epoch, epochState, clusterInfo, status, fetchEpoch]);
 
+    // Ahead of the `clusterInfo` check, which is also unresolved on a failed connection: the epoch entry
+    // only reports a failure once something has actually failed, so it is the more specific answer.
+    if (epochState?.status === FetchStatus.FetchFailed) {
+        return <ErrorCard text={`Failed to fetch details for epoch ${epoch}`} />;
+    }
+
     if (!clusterInfo) {
         return <LoadingCard message="Connecting to cluster" />;
     }
@@ -70,9 +76,6 @@ function EpochOverviewCard({ epoch }: OverviewProps) {
     if (epoch > currentEpoch) {
         return <ErrorCard text={`Epoch ${epoch} hasn't started yet`} />;
     } else if (!epochState?.data) {
-        if (epochState?.status === FetchStatus.FetchFailed) {
-            return <ErrorCard text={`Failed to fetch details for epoch ${epoch}`} />;
-        }
         return <LoadingCard message="Loading epoch" />;
     }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ import {
     usePerformanceInfo,
     useStatsProvider,
 } from '@providers/stats/solanaClusterStats';
-import { Status, SupplyProvider, useFetchSupply, useSupply } from '@providers/supply';
+import { SupplyProvider, useFetchSupply, useSupply } from '@providers/supply';
 import { ClusterStatus } from '@utils/cluster';
 import { abbreviatedNumber, lamportsToSol, slotsToHumanString } from '@utils/index';
 import { percentage } from '@utils/math';
@@ -65,7 +65,7 @@ const LoadingStatsCard = ({ title }: { title: string }) => {
 
 function StakingComponent() {
     const { status } = useCluster();
-    const supply = useSupply();
+    const supplyState = useSupply();
     const fetchSupply = useFetchSupply();
     const { fetchVoteAccounts, voteAccounts } = useVoteAccounts();
 
@@ -95,21 +95,23 @@ function StakingComponent() {
         }
     }, [voteAccounts, delinquentStake]);
 
-    if (supply === Status.Disconnected) {
+    if (supplyState.kind === 'disconnected') {
         // we'll return here to prevent flicker
         return null;
     }
 
-    if (supply === Status.Idle || supply === Status.Connecting) {
+    if (supplyState.kind === 'idle' || supplyState.kind === 'loading') {
         return (
             <div className="flex flex-col md:flex-row md:gap-6">
                 <SimpleCardSkeleton title={<LoadingStatsCard title="Loading supply data" />} />
                 <SimpleCardSkeleton title={<LoadingStatsCard title="Loading staking data" />} />
             </div>
         );
-    } else if (typeof supply === 'string') {
-        return <ErrorCard text={supply} retry={fetchData} />;
+    } else if (supplyState.kind === 'failed') {
+        return <ErrorCard text={supplyState.message} retry={fetchData} />;
     }
+
+    const { supply } = supplyState;
 
     // Don't display the staking card if the supply is 0
     if (supply.circulating === BigInt(0) && supply.total === BigInt(0)) {

--- a/app/providers/__tests__/cache-entry.spec.tsx
+++ b/app/providers/__tests__/cache-entry.spec.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Cluster, clusterSelection, ClusterStatus } from '@/app/entities/cluster/lib/cluster';
+import { type ClusterState, StateContext } from '@/app/entities/cluster/model/cluster-provider';
+import { type CacheEntry, FetchStatus } from '@/app/providers/cache';
+import { useCacheEntries, useCacheEntry } from '@/app/providers/cache-entry';
+
+vi.mock('@solana/kit', () => ({ createSolanaRpc: vi.fn() }));
+
+describe('useCacheEntry', () => {
+    it('should report a missing entry as failed once the connection failed', () => {
+        // Every provider gates its fetch on a connected cluster, so a missing entry here is not
+        // "pending" — nothing will ever be requested. Callers must reach their FetchFailed branch.
+        const { result } = renderHook(() => useCacheEntry(ENTRIES, 'absent'), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+
+        expect(result.current).toEqual({ status: FetchStatus.FetchFailed });
+    });
+
+    it('should leave a missing entry undefined while the cluster is healthy', () => {
+        for (const status of [ClusterStatus.Connected, ClusterStatus.Connecting]) {
+            const { result } = renderHook(() => useCacheEntry(ENTRIES, 'absent'), {
+                wrapper: makeWrapper(status),
+            });
+
+            expect(result.current).toBeUndefined();
+        }
+    });
+
+    it('should never overwrite an entry the cache already holds', () => {
+        // Stale data beats a synthesized failure: the page keeps showing what it fetched before the
+        // endpoint went down.
+        const { result } = renderHook(() => useCacheEntry(ENTRIES, 'present'), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+
+        expect(result.current).toBe(FETCHED);
+    });
+
+    it('should return undefined for an absent key even on failure', () => {
+        // Callers with nothing to look up pass undefined to keep their hook order stable; that is not a
+        // request, so it is not a failure either.
+        const { result } = renderHook(() => useCacheEntry(ENTRIES, undefined), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should hand back a stable object across renders', () => {
+        // The entry is a render dep for consumers, so a new object each render would churn their memos.
+        const { result, rerender } = renderHook(() => useCacheEntry(ENTRIES, 'absent'), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+        const first = result.current;
+        rerender();
+
+        expect(result.current).toBe(first);
+    });
+});
+
+describe('useCacheEntries', () => {
+    it('should apply the same rule per key', () => {
+        const { result } = renderHook(() => useCacheEntries(ENTRIES, ['present', 'absent']), {
+            wrapper: makeWrapper(ClusterStatus.Failure),
+        });
+
+        expect(result.current).toEqual([FETCHED, { status: FetchStatus.FetchFailed }]);
+    });
+});
+
+function makeWrapper(status: ClusterStatus) {
+    const state: ClusterState = { selection: clusterSelection(Cluster.MainnetBeta), status };
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return createElement(StateContext.Provider, { value: state }, children);
+    };
+}
+
+const FETCHED: CacheEntry<string> = { data: 'account', status: FetchStatus.Fetched };
+const ENTRIES = { present: FETCHED };

--- a/app/providers/__tests__/supply.spec.tsx
+++ b/app/providers/__tests__/supply.spec.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { ClusterStatus } from '@utils/cluster';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Cluster } from '@/app/entities/cluster/lib/cluster';
+
+const getSupply = vi.fn();
+let clusterStatus: ClusterStatus = ClusterStatus.Connected;
+
+vi.mock('@providers/cluster', () => ({
+    getRpc: () => ({ getSupply }),
+    useCluster: () => ({ cluster: Cluster.MainnetBeta, status: clusterStatus, url: 'https://rpc.test' }),
+}));
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+
+import { SupplyProvider, useFetchSupply, useSupply } from '../supply';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    clusterStatus = ClusterStatus.Connected;
+    getSupply.mockReturnValue({
+        send: () => Promise.resolve({ value: { circulating: 1n, nonCirculating: 2n, total: 3n } }),
+    });
+});
+
+describe('SupplyProvider', () => {
+    it('should report a failure when the cluster connection failed', async () => {
+        // Nothing fetches on a failed connection, so without this the state would sit at idle and the
+        // home page would render its skeletons forever.
+        clusterStatus = ClusterStatus.Failure;
+
+        renderProvider();
+
+        await waitFor(() => expect(stateText()).toBe('failed: Failed to fetch supply'));
+        expect(getSupply).not.toHaveBeenCalled();
+    });
+
+    it('should stay idle until a consumer asks, even when connected', () => {
+        renderProvider();
+
+        expect(stateText()).toBe('idle');
+        expect(getSupply).not.toHaveBeenCalled();
+    });
+
+    it('should reach ready once a consumer asks', async () => {
+        renderProvider({ fetchOnMount: true });
+
+        await waitFor(() => expect(stateText()).toBe('ready'));
+    });
+
+    it('should report a failure when the supply request rejects', async () => {
+        getSupply.mockReturnValue({ send: () => Promise.reject(new Error('rpc down')) });
+
+        renderProvider({ fetchOnMount: true });
+
+        await waitFor(() => expect(stateText()).toBe('failed: Failed to fetch supply'));
+    });
+});
+
+function renderProvider({ fetchOnMount = false } = {}) {
+    return render(
+        <SupplyProvider>
+            {fetchOnMount && <FetchOnMount />}
+            <StateProbe />
+        </SupplyProvider>,
+    );
+}
+
+const stateText = () => screen.getByTestId('state').textContent;
+
+function StateProbe() {
+    const state = useSupply();
+    return <div data-testid="state">{state.kind === 'failed' ? `failed: ${state.message}` : state.kind}</div>;
+}
+
+// The provider leaves the first fetch to a consumer, which is what StakingComponent does on mount.
+function FetchOnMount() {
+    const fetchSupply = useFetchSupply();
+    useEffect(() => fetchSupply(), [fetchSupply]);
+    return undefined;
+}

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -22,6 +22,7 @@ import { HistoryProvider } from '@features/transaction-history/model/history-pro
 import { VoteAccount } from '@features/vote/lib/validators'; // deep import on purpose: this provider only needs the account schema, not the vote UI the barrel re-exports
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
+import { useCacheEntries, useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { createSolanaRpc } from '@solana/kit';
 import {
@@ -466,16 +467,17 @@ export function useAccountInfo(address: string | undefined): Cache.CacheEntry<Ac
     if (!context) {
         throw new Error(`useAccountInfo must be used within a AccountsProvider`);
     }
-    if (address === undefined) return;
-    return context.entries[address];
+    return useCacheEntry(context.entries, address);
 }
 
-export function useAccountInfos(addresses: string[]): Cache.CacheEntry<Account>[] {
+// An address with nothing in the cache yields undefined, as it always did — the old signature just did
+// not say so.
+export function useAccountInfos(addresses: string[]): (Cache.CacheEntry<Account> | undefined)[] {
     const context = React.useContext(StateContext);
     if (!context) {
         throw new Error(`useAccountInfos must be used within a AccountsProvider`);
     }
-    return addresses.map(address => context.entries[address]);
+    return useCacheEntries(context.entries, addresses);
 }
 
 export function useMintAccountInfo(address: string | undefined): MintAccountInfo | undefined {

--- a/app/providers/block.tsx
+++ b/app/providers/block.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as Cache from '@providers/cache';
+import { useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { Connection, PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
@@ -57,7 +58,7 @@ export function useBlock(key: number): Cache.CacheEntry<Block> | undefined {
         throw new Error(`useBlock must be used within a BlockProvider`);
     }
 
-    return context.entries[key];
+    return useCacheEntry(context.entries, key);
 }
 
 export async function fetchBlock(dispatch: Dispatch, url: string, cluster: Cluster, slot: number) {

--- a/app/providers/cache-entry.ts
+++ b/app/providers/cache-entry.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useClusterConnectionFailed } from '@entities/cluster';
+
+import { type CacheEntry, FetchStatus, type State } from './cache';
+
+/**
+ * Reads one entry from a fetch cache.
+ *
+ * A missing entry normally means "not requested yet", which callers render as a loading state. That
+ * reading is wrong once the cluster connection has failed: every provider gates its fetch on a connected
+ * cluster, so nothing is ever requested and the loading state would never end. Report the failure
+ * instead, so the caller's existing `FetchFailed` branch renders with its retry.
+ *
+ * Recovery needs no extra wiring: when the connection comes back the entry is missing again, which
+ * re-arms the caller's fetch-on-mount effect.
+ */
+export function useCacheEntry<T>(
+    entries: State<T>['entries'],
+    // Accepts undefined so callers with nothing to look up still call this unconditionally, keeping the
+    // hook order stable.
+    key: string | number | undefined,
+): CacheEntry<T> | undefined {
+    const connectionFailed = useClusterConnectionFailed();
+
+    if (key === undefined) return undefined;
+
+    return entries[key] ?? (connectionFailed ? CONNECTION_FAILED : undefined);
+}
+
+/** `useCacheEntry` for a set of keys. One hook call, so the key list may vary between renders. */
+export function useCacheEntries<T>(
+    entries: State<T>['entries'],
+    keys: readonly (string | number)[],
+): (CacheEntry<T> | undefined)[] {
+    const connectionFailed = useClusterConnectionFailed();
+
+    return keys.map(key => entries[key] ?? (connectionFailed ? CONNECTION_FAILED : undefined));
+}
+
+// Stable identity, so a failed connection does not hand consumers a new object on every render.
+const CONNECTION_FAILED: CacheEntry<never> = { status: FetchStatus.FetchFailed };

--- a/app/providers/cluster.tsx
+++ b/app/providers/cluster.tsx
@@ -45,6 +45,7 @@ export {
     type SolanaRpc,
     StateContext,
     useCluster,
+    useClusterConnectionFailed,
     useClusterInfo,
     useClusterModal,
     useSolanaRpc,

--- a/app/providers/epoch.tsx
+++ b/app/providers/epoch.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as Cache from '@providers/cache';
+import { useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { Connection } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
@@ -58,7 +59,7 @@ export function useEpoch(key: number): Cache.CacheEntry<Epoch> | undefined {
         throw new Error(`useEpoch must be used within a EpochProvider`);
     }
 
-    return context.entries[key];
+    return useCacheEntry(context.entries, key);
 }
 
 export async function fetchEpoch(

--- a/app/providers/supply.tsx
+++ b/app/providers/supply.tsx
@@ -6,12 +6,6 @@ import React from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-export enum Status {
-    Idle,
-    Disconnected,
-    Connecting,
-}
-
 type Lamports = bigint;
 
 type Supply = Readonly<{
@@ -20,25 +14,46 @@ type Supply = Readonly<{
     total: Lamports;
 }>;
 
-export type State = Supply | Status | string;
+/**
+ * One variant per case a consumer has to tell apart, so none of them infers the state from the shape of
+ * the value. `idle` and `loading` render the same, but only `idle` means nothing has been asked for yet:
+ * the provider leaves the first fetch to whichever consumer mounts.
+ */
+export type SupplyState =
+    | { kind: 'idle' }
+    | { kind: 'disconnected' }
+    | { kind: 'loading' }
+    | { kind: 'failed'; message: string }
+    | { kind: 'ready'; supply: Supply };
+
 export type { Supply };
 
-type Dispatch = React.Dispatch<React.SetStateAction<State>>;
-export const StateContext: React.Context<State | undefined> = React.createContext<State | undefined>(undefined);
+// Both failure paths report the same thing, so the message has one home.
+const FAILED_TO_FETCH: SupplyState = { kind: 'failed', message: 'Failed to fetch supply' };
+
+type Dispatch = React.Dispatch<React.SetStateAction<SupplyState>>;
+export const StateContext: React.Context<SupplyState | undefined> = React.createContext<SupplyState | undefined>(
+    undefined,
+);
 export const DispatchContext: React.Context<Dispatch | undefined> = React.createContext<Dispatch | undefined>(
     undefined,
 );
 
 type Props = { children: React.ReactNode };
 export function SupplyProvider({ children }: Props) {
-    const [state, setState] = React.useState<State>(Status.Idle);
+    const [state, setState] = React.useState<SupplyState>({ kind: 'idle' });
     const { status: clusterStatus, cluster, url } = useCluster();
 
     React.useEffect(() => {
-        if (state !== Status.Idle) {
-            if (clusterStatus === ClusterStatus.Connecting) setState(Status.Disconnected);
-            if (clusterStatus === ClusterStatus.Connected) fetch(setState, cluster, url);
+        // Reported even from idle, unlike the transitions below: `fetch` only runs on a connected cluster,
+        // so a failed connection would otherwise leave consumers on a loading state forever.
+        if (clusterStatus === ClusterStatus.Failure) {
+            setState(FAILED_TO_FETCH);
+            return;
         }
+        if (state.kind === 'idle') return;
+        if (clusterStatus === ClusterStatus.Connecting) setState({ kind: 'disconnected' });
+        if (clusterStatus === ClusterStatus.Connected) fetch(setState, cluster, url);
     }, [clusterStatus, cluster, url]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
@@ -49,7 +64,7 @@ export function SupplyProvider({ children }: Props) {
 }
 
 async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
-    dispatch(Status.Connecting);
+    dispatch({ kind: 'loading' });
 
     try {
         const rpc = getRpc(url);
@@ -63,16 +78,13 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
             total: supplyResponse.value.total,
         };
 
-        // Update state if still connecting
-        dispatch(state => {
-            if (state !== Status.Connecting) return state;
-            return supply;
-        });
+        // Land the result only if nothing moved the state on in the meantime.
+        dispatch(current => (current.kind === 'loading' ? { kind: 'ready', supply } : current));
     } catch (err) {
         if (cluster !== Cluster.Custom) {
             Logger.error(err, { url });
         }
-        dispatch('Failed to fetch supply');
+        dispatch(FAILED_TO_FETCH);
     }
 }
 

--- a/app/providers/transactions/index.tsx
+++ b/app/providers/transactions/index.tsx
@@ -2,6 +2,7 @@
 
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
+import { useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { Connection, SignatureResult, TransactionConfirmationStatus, TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
@@ -135,11 +136,7 @@ export function useTransactionStatus(
         throw new Error(`useTransactionStatus must be used within a TransactionsProvider`);
     }
 
-    if (signature === undefined) {
-        return undefined;
-    }
-
-    return context.entries[signature];
+    return useCacheEntry(context.entries, signature);
 }
 
 export function useFetchTransactionStatus() {

--- a/app/providers/transactions/parsed.tsx
+++ b/app/providers/transactions/parsed.tsx
@@ -3,6 +3,7 @@
 import { fetchTransactionDetails, type TransactionWithMeta } from '@entities/transaction-data';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
+import { useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
@@ -86,7 +87,7 @@ export function useTransactionDetails(signature: TransactionSignature): Cache.Ca
         throw new Error(`useTransactionDetails must be used within a TransactionsProvider`);
     }
 
-    return context.entries[signature];
+    return useCacheEntry(context.entries, signature);
 }
 
 export type TransactionDetailsCache = {

--- a/app/providers/transactions/raw.tsx
+++ b/app/providers/transactions/raw.tsx
@@ -3,6 +3,7 @@
 import { fetchRawTransaction, type RawTransaction } from '@entities/transaction-data';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
+import { useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
 import { type Finality, type TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
@@ -43,7 +44,7 @@ export function useRawTransactionDetails(signature: TransactionSignature): Cache
         throw new Error(`useRawTransactionDetails must be used within a TransactionsProvider`);
     }
 
-    return context.entries[signature];
+    return useCacheEntry(context.entries, signature);
 }
 
 async function loadRawTransaction(

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -2,35 +2,35 @@
 
 | Type | Route | Size | First Load JS |
 |------|-------|------|---------------|
-| Static | `/` | 120 kB | 520 kB |
+| Static | `/` | 130 kB | 520 kB |
 | Static | `/_not-found` | 0 B | 400 kB |
-| Dynamic | `/address/[address]` | 510 kB | 910 kB |
-| Dynamic | `/address/[address]/account-data` | 520 kB | 920 kB |
-| Dynamic | `/address/[address]/anchor-account` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/anchor-program` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/attestation` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/attributes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/blockhashes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/compression` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/concurrent-merkle-tree` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/domains` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/entries` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/feature-gate` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/idl` | 610 kB | 0.98 MB |
-| Dynamic | `/address/[address]/instructions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/metadata` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/program-multisig` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/rewards` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/security` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/slot-hashes` | 480 kB | 870 kB |
-| Dynamic | `/address/[address]/stake-history` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/subscriptions` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/token-extensions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/tokens` | 490 kB | 890 kB |
-| Dynamic | `/address/[address]/transfers` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/verified-build` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/vote-history` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/account-data` | 500 kB | 900 kB |
+| Dynamic | `/address/[address]/anchor-account` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/anchor-program` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/attestation` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/attributes` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/blockhashes` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/compression` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/concurrent-merkle-tree` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/domains` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/entries` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/feature-gate` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/idl` | 580 kB | 980 kB |
+| Dynamic | `/address/[address]/instructions` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/metadata` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/program-multisig` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/rewards` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/security` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/slot-hashes` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/stake-history` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/subscriptions` | 450 kB | 850 kB |
+| Dynamic | `/address/[address]/token-extensions` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/tokens` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]/transfers` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/verified-build` | 460 kB | 860 kB |
+| Dynamic | `/address/[address]/vote-history` | 450 kB | 850 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
 | Dynamic | `/api/geo-location` | — | — |
@@ -49,10 +49,10 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 280 kB | 680 kB |
-| Dynamic | `/block/[slot]/accounts` | 280 kB | 670 kB |
-| Dynamic | `/block/[slot]/programs` | 280 kB | 670 kB |
-| Dynamic | `/block/[slot]/rewards` | 280 kB | 670 kB |
+| Dynamic | `/block/[slot]` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/accounts` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/programs` | 260 kB | 660 kB |
+| Dynamic | `/block/[slot]/rewards` | 260 kB | 660 kB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
 | Static | `/feature-gates` | 40 kB | 440 kB |
 | Dynamic | `/mcp` | — | — |
@@ -60,7 +60,7 @@
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 400 kB |
-| Dynamic | `/tx/[signature]` | 670 kB | 1.04 MB |
-| Dynamic | `/tx/[signature]/inspect` | 470 kB | 870 kB |
-| Static | `/tx/inspector` | 470 kB | 870 kB |
+| Static | `/tos` | 880 B | 410 kB |
+| Dynamic | `/tx/[signature]` | 530 kB | 930 kB |
+| Dynamic | `/tx/[signature]/inspect` | 450 kB | 850 kB |
+| Static | `/tx/inspector` | 450 kB | 850 kB |


### PR DESCRIPTION
## Description

Point the Explorer at an unreachable RPC endpoint and the account page spins on "Loading" forever. The
address, block, transaction, receipt and inspector pages all did the same.

**Cause.** A page that needs the cluster gates its fetch on `ClusterStatus.Connected` — deliberately, so
the first render doesn't fire against the default mainnet URL before `?cluster=` settles. On a failed
connection that gate never opens, so nothing is ever requested. The cache then answers "no entry", which
every consumer reads as *not requested yet* and renders as a loading card. Nothing can ever resolve it:
the health check runs with `shouldRetryOnError: false` through `useSWRImmutable`, so no fetch state
arrives, ever. Each page's `FetchStatus.FetchFailed` branch — message and retry button already written —
sat unreachable, because nothing had failed; nothing had been *tried*.

**Fix.** Teach the cache read to tell those two cases apart. A missing entry plus a failed connection is a
failure, not a pending fetch:

```ts
// app/providers/cache-entry.ts
return entries[key] ?? (connectionFailed ? CONNECTION_FAILED : undefined);
```

Consumers then reach the branch they already had, so **no page needs a cluster-specific branch** and a
new RPC-backed page is correct without doing anything. Six provider read hooks change one line each
(`context.entries[key]` → `useCacheEntry(...)`); `app/address`, `app/block`, `app/tx`,
`app/components/inspector` and `app/features/receipt` are untouched.

Recovery needs no extra wiring: when the connection returns, the entry is missing again, which re-arms
each page's fetch-on-mount effect. Stale data still wins over a synthesized failure, so a page keeps
showing what it fetched before the endpoint died.

**Two surfaces aren't fed by that cache**, and are fixed at their own source rather than in the page:

- `providers/supply.tsx` reports its existing failure state on a dead connection, so `app/page.tsx`'s
  render is untouched.
- `epoch/[epoch]/page-client.tsx` checks its entry's failure ahead of `clusterInfo`, which is also
  unresolved on a dead connection. The now-duplicate branch below it is removed.

**Health check.** It now revalidates on window focus and on network reconnect, so a recovered endpoint
heals itself instead of needing a button. `shouldRetryOnError` stays off, so a down endpoint isn't
hammered while a tab sits open. A healthy endpoint answers from cache, so the cost falls on the failing
case.

### Drive-by: the supply provider's state type

`SupplyProvider` modelled its state as `Supply | Status | string`, where a bare string meant "failed" *and
carried the message*, so `app/page.tsx` detected failure with `typeof supply === 'string'`. Adding the
connection-failure path would have given that magic string a second write site, so it is now a
discriminated union (`idle | disconnected | loading | failed | ready`, keyed on `kind` like
`ReceiptResult` and `CustomUrlDecision`). `Status` is gone, the message has one home, and TypeScript
narrows it. The provider also gains its first tests.

## Type of change

-   [x] Bug fix

## Testing

Manual testing on the preview deployment. Every link below points the Explorer at an unreachable endpoint
(`example.com/rpc`, the one from the report) — **accept the consent prompt** when it appears, then the page
should show its error card with a retry instead of spinning:

-   [Account page — the reported bug: "Loading" forever, now "Fetch Failed"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Block page — was "Loading block"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/block/440659488?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Transaction page — was "Loading"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/tx/5tpak4YC5Sm1mc1qNhuvDEQTDLcZZKoDH1B39oP9P63NxqYBQvUCwqpMvvaVd4T2sjpQ76qECcm7vVR9UeH7A7HF?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Receipt view — was "Loading transaction details"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/tx/5tpak4YC5Sm1mc1qNhuvDEQTDLcZZKoDH1B39oP9P63NxqYBQvUCwqpMvvaVd4T2sjpQ76qECcm7vVR9UeH7A7HF?view=receipt&cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Inspector permalink — was "Loading"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/tx/5tpak4YC5Sm1mc1qNhuvDEQTDLcZZKoDH1B39oP9P63NxqYBQvUCwqpMvvaVd4T2sjpQ76qECcm7vVR9UeH7A7HF/inspect?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Epoch page — was "Connecting to cluster"](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/epoch/1000?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Home page — was two "Loading … data" skeletons](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)

Two things that must **not** change:

-   [Inspector paste mode — still usable with no RPC, no error card](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/tx/inspector?cluster=custom&customUrl=https%3A%2F%2Fexample.com%2Frpc)
-   [Account page on mainnet — normal path unaffected, no premature error](https://explorer-git-fork-hoodieshq-alexanders-0f0585-solana-foundation.vercel.app/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)

## Related Issues

Closes [HOO-1126](https://linear.app/solana-fndn/issue/HOO-1126/fix-endless-loading-on-cluster-connection-error)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit`)
-   [x] I have run `build:info` script to update build information

