### PR TITLE
refactor(inspector): replace tweetnacl with kit verifySignature

### DIFF
--- a/app/components/inspector/SignaturesCard.tsx
+++ b/app/components/inspector/SignaturesCard.tsx
@@ -1,15 +1,41 @@
 import { Address } from '@components/common/Address';
 import { Signature } from '@components/common/Signature';
-import { getBase58Encoder } from '@solana/kit';
+import {
+    getBase58Encoder,
+    getPublicKeyFromAddress,
+    isSolanaError,
+    signatureBytes,
+    SOLANA_ERROR__KEYS__INVALID_SIGNATURE_BYTE_LENGTH,
+    verifySignature,
+} from '@solana/kit';
 import { PublicKey, VersionedMessage } from '@solana/web3.js';
 import React from 'react';
-import * as nacl from 'tweetnacl';
 
 import { Badge } from '@/app/components/shared/ui/badge';
+import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 const BASE58_ENCODER = getBase58Encoder();
+
+async function verifySignatures(
+    signatures: (string | undefined)[],
+    message: VersionedMessage,
+    rawMessage: Uint8Array,
+): Promise<(boolean | undefined)[]> {
+    return await Promise.all(
+        signatures.map(async (signature, index) => {
+            if (!signature) return undefined;
+            try {
+                const publicKey = await getPublicKeyFromAddress(toKitAddress(message.staticAccountKeys[index]));
+                const rawSignature = signatureBytes(new Uint8Array(BASE58_ENCODER.encode(signature)));
+                return await verifySignature(publicKey, rawSignature, rawMessage);
+            } catch (error) {
+                return isSolanaError(error, SOLANA_ERROR__KEYS__INVALID_SIGNATURE_BYTE_LENGTH) ? false : undefined;
+            }
+        }),
+    );
+}
 
 export function TransactionSignatures({
     signatures,
@@ -20,31 +46,44 @@ export function TransactionSignatures({
     message: VersionedMessage;
     rawMessage: Uint8Array;
 }) {
-    const signatureRows = React.useMemo(() => {
-        return signatures.map((signature, index) => {
-            const publicKey = message.staticAccountKeys[index];
+    const [verification, setVerification] = React.useState<{
+        message: VersionedMessage;
+        rawMessage: Uint8Array;
+        results: (boolean | undefined)[];
+        signatures: (string | undefined)[];
+    }>();
 
-            let verified;
-            if (signature) {
-                const key = publicKey.toBytes();
-                const rawSignature = new Uint8Array(BASE58_ENCODER.encode(signature));
-                verified = verifySignature({
-                    key,
-                    message: rawMessage,
-                    signature: rawSignature,
-                });
-            }
-
-            const props = {
-                index,
-                signature,
-                signer: publicKey,
-                verified,
-            };
-
-            return <SignatureRow key={publicKey.toBase58()} {...props} />;
+    React.useEffect(() => {
+        let cancelled = false;
+        verifySignatures(signatures, message, rawMessage).then(results => {
+            if (!cancelled) setVerification({ message, rawMessage, results, signatures });
         });
+        return () => {
+            cancelled = true;
+        };
     }, [signatures, message, rawMessage]);
+
+    const verificationResults =
+        verification &&
+        verification.signatures === signatures &&
+        verification.message === message &&
+        verification.rawMessage === rawMessage
+            ? verification.results
+            : undefined;
+
+    const signatureRows = signatures.map((signature, index) => {
+        const publicKey = message.staticAccountKeys[index];
+
+        const props = {
+            index,
+            pending: verificationResults === undefined,
+            signature,
+            signer: publicKey,
+            verified: verificationResults?.[index],
+        };
+
+        return <SignatureRow key={index} {...props} />;
+    });
 
     return (
         <Card ui="dashkit">
@@ -69,27 +108,36 @@ export function TransactionSignatures({
     );
 }
 
-function verifySignature({
-    message,
-    signature,
-    key,
-}: {
-    message: Uint8Array;
-    signature: Uint8Array;
-    key: Uint8Array;
-}): boolean {
-    return nacl.sign.detached.verify(message, signature, key);
+function renderValidity(
+    signature: string | undefined,
+    verified: boolean | undefined,
+    pending: boolean,
+): React.ReactNode {
+    if (!signature) return 'N/A';
+    if (pending) return undefined;
+    if (verified === undefined) return 'N/A';
+    return verified ? (
+        <Badge ui="dashkit" variant="success" className="mr-[3px]">
+            Valid
+        </Badge>
+    ) : (
+        <Badge ui="dashkit" variant="warning" className="mr-[3px]">
+            Invalid
+        </Badge>
+    );
 }
 
 function SignatureRow({
     signature,
     signer,
     verified,
+    pending,
     index,
 }: {
     signature: string | undefined;
     signer: PublicKey;
     verified?: boolean;
+    pending: boolean;
     index: number;
 }) {
     return (
@@ -103,19 +151,7 @@ function SignatureRow({
             <BaseTable.Cell>
                 <Address pubkey={signer} link />
             </BaseTable.Cell>
-            <BaseTable.Cell>
-                {verified === undefined ? (
-                    'N/A'
-                ) : verified ? (
-                    <Badge ui="dashkit" variant="success" className="mr-[3px]">
-                        Valid
-                    </Badge>
-                ) : (
-                    <Badge ui="dashkit" variant="warning" className="mr-[3px]">
-                        Invalid
-                    </Badge>
-                )}
-            </BaseTable.Cell>
+            <BaseTable.Cell>{renderValidity(signature, verified, pending)}</BaseTable.Cell>
             <BaseTable.Cell>
                 {index === 0 && (
                     <Badge ui="dashkit" variant="info" className="mr-[3px]">

--- a/app/components/inspector/__stories__/SignaturesCard.stories.tsx
+++ b/app/components/inspector/__stories__/SignaturesCard.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Bogus signatures will fail nacl verification → Invalid badges.
+// Bogus signatures fail verification → Invalid badges.
 export const Invalid: Story = {
     args: {
         message: baseMessage,

--- a/app/components/inspector/__tests__/SignaturesCard.spec.tsx
+++ b/app/components/inspector/__tests__/SignaturesCard.spec.tsx
@@ -1,0 +1,79 @@
+import { generateKeyPairSigner, getBase58Decoder, type ReadonlyUint8Array, signBytes } from '@solana/kit';
+import { PublicKey, TransactionInstruction, TransactionMessage } from '@solana/web3.js';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TransactionSignatures } from '../SignaturesCard';
+
+vi.mock('@components/common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: PublicKey }) => <span>{pubkey.toBase58()}</span>,
+}));
+vi.mock('@components/common/Signature', () => ({
+    Signature: ({ signature }: { signature: string }) => <span>{signature}</span>,
+}));
+
+const base58Decoder = getBase58Decoder();
+const { address: signerAddress, keyPair } = await generateKeyPairSigner();
+const signerPublicKey = new PublicKey(signerAddress);
+
+const message = new TransactionMessage({
+    instructions: [new TransactionInstruction({ data: Buffer.from([1]), keys: [], programId: PublicKey.default })],
+    payerKey: signerPublicKey,
+    recentBlockhash: PublicKey.default.toBase58(),
+}).compileToV0Message();
+const rawMessage = message.serialize();
+
+async function signMessage(messageBytes: ReadonlyUint8Array): Promise<string> {
+    return base58Decoder.decode(await signBytes(keyPair.privateKey, messageBytes));
+}
+
+describe('TransactionSignatures', () => {
+    it('should render a Valid badge for a signature covering the message', async () => {
+        render(
+            <TransactionSignatures
+                signatures={[await signMessage(rawMessage)]}
+                message={message}
+                rawMessage={rawMessage}
+            />,
+        );
+
+        expect(await screen.findByText('Valid')).toBeInTheDocument();
+    });
+
+    it('should render an Invalid badge for a signature covering different bytes', async () => {
+        render(
+            <TransactionSignatures
+                signatures={[await signMessage(new Uint8Array(32))]}
+                message={message}
+                rawMessage={rawMessage}
+            />,
+        );
+
+        expect(await screen.findByText('Invalid')).toBeInTheDocument();
+    });
+
+    it('should render an Invalid badge for a malformed signature instead of blanking the column', async () => {
+        render(<TransactionSignatures signatures={['abc']} message={message} rawMessage={rawMessage} />);
+
+        expect(await screen.findByText('Invalid')).toBeInTheDocument();
+    });
+
+    it('should render N/A for a missing signature', async () => {
+        render(<TransactionSignatures signatures={[undefined]} message={message} rawMessage={rawMessage} />);
+
+        expect(await screen.findByText('Missing Signature')).toBeInTheDocument();
+        expect(await screen.findByText('N/A')).toBeInTheDocument();
+    });
+
+    it('should mark the first row as fee payer', async () => {
+        render(
+            <TransactionSignatures
+                signatures={[await signMessage(rawMessage)]}
+                message={message}
+                rawMessage={rawMessage}
+            />,
+        );
+
+        expect(await screen.findByText('Fee Payer')).toBeInTheDocument();
+    });
+});

--- a/app/providers/wallet/__tests__/sign-web3js-transaction.spec.ts
+++ b/app/providers/wallet/__tests__/sign-web3js-transaction.spec.ts
@@ -1,26 +1,27 @@
 import {
-    address,
+    generateKeyPairSigner,
     getTransactionCodec,
     type ReadonlyUint8Array,
     type SignatureBytes,
+    signatureBytes,
+    signBytes,
     type Transaction as KitTransaction,
+    verifySignature,
 } from '@solana/kit';
 import type { WalletSigner } from '@solana/kit-plugin-wallet';
 import {
-    Keypair,
     PublicKey,
     Transaction,
     TransactionInstruction,
     TransactionMessage,
     VersionedTransaction,
 } from '@solana/web3.js';
-import nacl from 'tweetnacl';
 import { describe, expect, it } from 'vitest';
 
 import { signWeb3jsTransaction, signWeb3jsTransactions } from '../sign-web3js-transaction';
 
-const keypair = Keypair.generate();
-const signerAddress = address(keypair.publicKey.toBase58());
+const { address: signerAddress, keyPair } = await generateKeyPairSigner();
+const signerPublicKey = new PublicKey(signerAddress);
 const blockhash = PublicKey.default.toBase58();
 const transactionCodec = getTransactionCodec();
 
@@ -33,7 +34,7 @@ function makeInstruction(data: Uint8Array = Uint8Array.from([1])): TransactionIn
 
 function makeLegacyTransaction(): Transaction {
     const transaction = new Transaction();
-    transaction.feePayer = keypair.publicKey;
+    transaction.feePayer = signerPublicKey;
     transaction.recentBlockhash = blockhash;
     transaction.add(makeInstruction());
     return transaction;
@@ -42,14 +43,21 @@ function makeLegacyTransaction(): Transaction {
 function makeVersionedTransaction(): VersionedTransaction {
     const message = new TransactionMessage({
         instructions: [makeInstruction()],
-        payerKey: keypair.publicKey,
+        payerKey: signerPublicKey,
         recentBlockhash: blockhash,
     }).compileToV0Message();
     return new VersionedTransaction(message);
 }
 
-function sign(messageBytes: ReadonlyUint8Array): SignatureBytes {
-    return nacl.sign.detached(new Uint8Array(messageBytes), keypair.secretKey) as SignatureBytes;
+function sign(messageBytes: ReadonlyUint8Array): Promise<SignatureBytes> {
+    return signBytes(keyPair.privateKey, messageBytes);
+}
+
+async function attachSignature(transaction: KitTransaction): Promise<KitTransaction> {
+    return {
+        ...transaction,
+        signatures: { ...transaction.signatures, [signerAddress]: await sign(transaction.messageBytes) },
+    };
 }
 
 /**
@@ -71,26 +79,13 @@ function prependWalletInstruction(transaction: KitTransaction): KitTransaction {
 const modifyingSigner = {
     address: signerAddress,
     modifyAndSignTransactions: (transactions: readonly KitTransaction[]) =>
-        Promise.resolve(
-            transactions.map(transaction => {
-                const modified = prependWalletInstruction(transaction);
-                return {
-                    ...modified,
-                    signatures: { ...modified.signatures, [signerAddress]: sign(modified.messageBytes) },
-                };
-            }),
-        ),
+        Promise.all(transactions.map(transaction => attachSignature(prependWalletInstruction(transaction)))),
 } as unknown as WalletSigner;
 
 const signOnlySigner = {
     address: signerAddress,
     modifyAndSignTransactions: (transactions: readonly KitTransaction[]) =>
-        Promise.resolve(
-            transactions.map(transaction => ({
-                ...transaction,
-                signatures: { ...transaction.signatures, [signerAddress]: sign(transaction.messageBytes) },
-            })),
-        ),
+        Promise.all(transactions.map(attachSignature)),
 } as unknown as WalletSigner;
 
 const sendingOnlySigner = {
@@ -104,7 +99,7 @@ describe('signWeb3jsTransaction', () => {
 
         expect(signed).toBeInstanceOf(Transaction);
         expect(signed.verifySignatures()).toBe(true);
-        expect(signed.signatures[0]?.publicKey.equals(keypair.publicKey)).toBe(true);
+        expect(signed.signatures[0]?.publicKey.equals(signerPublicKey)).toBe(true);
         // The execution path broadcasts `signed.serialize()`, which throws unless every required
         // signature is present.
         expect(() => signed.serialize()).not.toThrow();
@@ -129,7 +124,7 @@ describe('signWeb3jsTransaction', () => {
         const [signature = new Uint8Array()] = signed.signatures;
 
         expect(signed).toBeInstanceOf(VersionedTransaction);
-        expect(nacl.sign.detached.verify(signed.message.serialize(), signature, keypair.publicKey.toBytes())).toBe(
+        expect(await verifySignature(keyPair.publicKey, signatureBytes(signature), signed.message.serialize())).toBe(
             true,
         );
     });

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
         "superstruct": "0.15.3",
         "swr": "2.2.0",
         "tailwind-merge": "2.6.1",
-        "tweetnacl": "1.0.3",
         "undici": "6.28.0",
         "use-async-effect": "2.2.7"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,9 +390,6 @@ importers:
       tailwind-merge:
         specifier: 2.6.1
         version: 2.6.1
-      tweetnacl:
-        specifier: 1.0.3
-        version: 1.0.3
       undici:
         specifier: 6.28.0
         version: 6.28.0
@@ -10055,9 +10052,6 @@ packages:
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
-
-  tweetnacl@1.0.3:
-    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
@@ -21137,8 +21131,6 @@ snapshots:
       fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
-
-  tweetnacl@1.0.3: {}
 
   type-check@0.3.2:
     dependencies:


### PR DESCRIPTION
Migrate signature verification from tweetnacl to WebCrypto via @solana/kit.

- `SignaturesCard`: verification moves from nacl's sync `sign.detached.verify` to kit's async `verifySignature` (WebCrypto). Results are identity-guarded against the props they were computed from, so a new transaction never renders the previous transaction's verdicts. A wrong-length signature renders Invalid; an environment without WebCrypto Ed25519 renders N/A rather than a false verdict.
- `sign-web3js-transaction.spec.ts`: wallet-fake signing/verification moves to kit (`generateKeyPairSigner`, `signBytes`, `verifySignature`).
- New `SignaturesCard.spec.tsx` covering valid, invalid, malformed, and missing signatures.

[Test preview
](https://explorer-git-refactor-hoo-1167-tweetna-a89eb5-solana-foundation.vercel.app/)`/tx/inspector` with a signed transaction: Valid badge per verified signer; mess up a signature should be Invalid;

Closes: HOO-1167 (Task 0.9)