### PR TITLE
refactor(providers): move epoch, block and transaction providers off web3.js Connection

### DIFF
--- a/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
+++ b/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
@@ -8,6 +8,8 @@ import {
     type TransactionError,
 } from '@solana/web3.js';
 
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
+
 import type { TransactionWithMeta } from '../model/types';
 
 type RpcAccountKey = Readonly<{
@@ -194,29 +196,4 @@ function toNullableNumber(value: number | bigint | null): number | null {
     // web3.js types `uiAmount` as `number | null`, so null is the contract here.
     // eslint-disable-next-line unicorn/no-null
     return value === null ? null : Number(value);
-}
-
-/**
- * Recursively replaces bigints with numbers.
- *
- * kit upcasts every integral value in an RPC response to a bigint unless its key path is on an
- * allow-list, and that list covers nothing inside a parsed instruction or a transaction error.
- * web3.js delivered plain numbers throughout, and consumers `JSON.stringify` these payloads —
- * which throws on a bigint — and validate them against superstruct `number()` schemas.
- *
- * Precision above 2^53 is lost, exactly as it was when web3.js parsed the same response.
- */
-function withNumbersInsteadOfBigInts<T>(value: T): T {
-    if (typeof value === 'bigint') {
-        return Number(value) as T;
-    }
-    if (Array.isArray(value)) {
-        return value.map(withNumbersInsteadOfBigInts) as T;
-    }
-    if (typeof value === 'object' && value !== null) {
-        return Object.fromEntries(
-            Object.entries(value).map(([key, item]) => [key, withNumbersInsteadOfBigInts(item)]),
-        ) as T;
-    }
-    return value;
 }

--- a/app/providers/__tests__/block.test.tsx
+++ b/app/providers/__tests__/block.test.tsx
@@ -1,0 +1,115 @@
+import { gen } from '@__fixtures__/gen';
+import { Cluster } from '@utils/cluster';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchBlock, FetchStatus } from '../block';
+
+const MOCK_URL = 'https://api.mainnet-beta.solana.com';
+const SLOT = 100;
+const PARENT_SLOT = 99;
+
+const getBlocks = vi.fn();
+const getSlotLeaders = vi.fn();
+const getRpc = vi.fn((_url: string) => ({
+    getBlocks: (...args: unknown[]) => ({ send: () => getBlocks(...args) }),
+    getSlotLeaders: (...args: unknown[]) => ({ send: () => getSlotLeaders(...args) }),
+}));
+
+vi.mock('@entities/cluster', async importOriginal => ({
+    ...((await importOriginal()) as Record<string, unknown>),
+    getRpc: (...args: [string]) => getRpc(...args),
+}));
+
+const fetchBlockBySlot = vi.fn();
+vi.mock('@entities/block-data', () => ({
+    fetchBlock: (...args: unknown[]) => fetchBlockBySlot(...args),
+}));
+
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+
+const LEADERS = [gen.address(1), gen.address(2), gen.address(3)];
+
+const dispatch = vi.fn();
+
+function lastUpdate() {
+    const calls = dispatch.mock.calls;
+    return calls[calls.length - 1][0] as {
+        data?: {
+            blockLeader?: { toBase58(): string };
+            childLeader?: { toBase58(): string };
+            childSlot?: number;
+            parentLeader?: { toBase58(): string };
+        };
+        status: FetchStatus;
+    };
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    getRpc.mockReturnValue({
+        getBlocks: (...args: unknown[]) => ({ send: () => getBlocks(...args) }),
+        getSlotLeaders: (...args: unknown[]) => ({ send: () => getSlotLeaders(...args) }),
+    });
+    fetchBlockBySlot.mockResolvedValue({ parentSlot: PARENT_SLOT });
+});
+
+describe('fetchBlock', () => {
+    it('should convert the child slot from a bigint and resolve leaders positionally', async () => {
+        getBlocks.mockResolvedValue([101n, 102n]);
+        getSlotLeaders.mockResolvedValue(LEADERS);
+
+        await fetchBlock(dispatch, MOCK_URL, Cluster.MainnetBeta, SLOT);
+
+        expect(getRpc).toHaveBeenCalledWith(MOCK_URL);
+        expect(getBlocks).toHaveBeenCalledWith(101n, 200n);
+        // parentSlot..childSlot inclusive
+        expect(getSlotLeaders).toHaveBeenCalledWith(99n, 3);
+
+        const data = lastUpdate().data;
+        expect(lastUpdate().status).toBe(FetchStatus.Fetched);
+        expect(data?.childSlot).toBe(101);
+        expect(data?.parentLeader?.toBase58()).toBe(LEADERS[0]);
+        expect(data?.blockLeader?.toBase58()).toBe(LEADERS[1]);
+        expect(data?.childLeader?.toBase58()).toBe(LEADERS[2]);
+    });
+
+    it('should leave the child slot and child leader undefined when no later block exists', async () => {
+        getBlocks.mockResolvedValue([]);
+        getSlotLeaders.mockResolvedValue(LEADERS);
+
+        await fetchBlock(dispatch, MOCK_URL, Cluster.MainnetBeta, SLOT);
+
+        expect(getSlotLeaders).toHaveBeenCalledWith(99n, 2);
+        const data = lastUpdate().data;
+        expect(data?.childSlot).toBeUndefined();
+        expect(data?.childLeader).toBeUndefined();
+        expect(data?.blockLeader?.toBase58()).toBe(LEADERS[1]);
+    });
+
+    it('should still report the block when the leader lookup fails', async () => {
+        getBlocks.mockResolvedValue([101n]);
+        getSlotLeaders.mockRejectedValue(new Error('leader schedule unavailable'));
+
+        await fetchBlock(dispatch, MOCK_URL, Cluster.MainnetBeta, SLOT);
+
+        expect(lastUpdate().status).toBe(FetchStatus.Fetched);
+        expect(lastUpdate().data?.blockLeader).toBeUndefined();
+    });
+
+    it('should report an empty block when the slot was skipped', async () => {
+        fetchBlockBySlot.mockResolvedValue(null);
+
+        await fetchBlock(dispatch, MOCK_URL, Cluster.MainnetBeta, SLOT);
+
+        expect(getBlocks).not.toHaveBeenCalled();
+        expect(lastUpdate()).toMatchObject({ data: {}, status: FetchStatus.Fetched });
+    });
+
+    it('should dispatch FetchFailed when the block fetch throws', async () => {
+        fetchBlockBySlot.mockRejectedValue(new Error('rpc boom'));
+
+        await fetchBlock(dispatch, MOCK_URL, Cluster.MainnetBeta, SLOT);
+
+        expect(lastUpdate()).toMatchObject({ data: undefined, status: FetchStatus.FetchFailed });
+    });
+});

--- a/app/providers/__tests__/epoch.test.tsx
+++ b/app/providers/__tests__/epoch.test.tsx
@@ -1,0 +1,107 @@
+import { Cluster } from '@utils/cluster';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EpochSchedule } from '../../utils/epoch-schedule';
+import { fetchEpoch, FetchStatus } from '../epoch';
+
+const MOCK_URL = 'https://api.mainnet-beta.solana.com';
+
+const SCHEDULE: EpochSchedule = { firstNormalEpoch: 0n, firstNormalSlot: 0n, slotsPerEpoch: 432000n };
+const EPOCH = 10;
+const FIRST_SLOT = 4320000n;
+const LAST_SLOT = 4751999n;
+
+const getBlocks = vi.fn();
+const getBlockTime = vi.fn();
+const getRpc = vi.fn((_url: string) => ({
+    getBlockTime: (...args: unknown[]) => ({ send: () => getBlockTime(...args) }),
+    getBlocks: (...args: unknown[]) => ({ send: () => getBlocks(...args) }),
+}));
+
+vi.mock('@entities/cluster', async importOriginal => ({
+    ...((await importOriginal()) as Record<string, unknown>),
+    getRpc: (...args: [string]) => getRpc(...args),
+}));
+
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+
+const dispatch = vi.fn();
+
+function lastUpdate() {
+    const calls = dispatch.mock.calls;
+    return calls[calls.length - 1][0] as {
+        data?: { firstBlock: number; firstTimestamp: number | null; lastBlock?: number; lastTimestamp: number | null };
+        status: FetchStatus;
+    };
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    getRpc.mockReturnValue({
+        getBlockTime: (...args: unknown[]) => ({ send: () => getBlockTime(...args) }),
+        getBlocks: (...args: unknown[]) => ({ send: () => getBlocks(...args) }),
+    });
+});
+
+describe('fetchEpoch', () => {
+    it('should narrow the epoch boundary slots and timestamps to numbers', async () => {
+        getBlocks
+            .mockResolvedValueOnce([FIRST_SLOT, FIRST_SLOT + 1n])
+            .mockResolvedValueOnce([LAST_SLOT - 1n, LAST_SLOT]);
+        getBlockTime.mockResolvedValueOnce(1700000000n).mockResolvedValueOnce(1700100000n);
+
+        await fetchEpoch(dispatch, MOCK_URL, Cluster.MainnetBeta, SCHEDULE, 20n, EPOCH);
+
+        expect(getRpc).toHaveBeenCalledWith(MOCK_URL);
+        expect(getBlocks).toHaveBeenNthCalledWith(1, FIRST_SLOT, FIRST_SLOT + 100n);
+        expect(getBlocks).toHaveBeenNthCalledWith(2, LAST_SLOT - 100n, LAST_SLOT);
+        expect(lastUpdate()).toMatchObject({
+            data: {
+                firstBlock: Number(FIRST_SLOT),
+                firstTimestamp: 1700000000,
+                lastBlock: Number(LAST_SLOT),
+                lastTimestamp: 1700100000,
+            },
+            status: FetchStatus.Fetched,
+        });
+    });
+
+    it('should clamp the trailing getBlocks range at slot 0 for epoch 0', async () => {
+        const tinySchedule: EpochSchedule = { firstNormalEpoch: 0n, firstNormalSlot: 0n, slotsPerEpoch: 32n };
+        getBlocks.mockResolvedValueOnce([0n]).mockResolvedValueOnce([31n]);
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchEpoch(dispatch, MOCK_URL, Cluster.MainnetBeta, tinySchedule, 20n, 0);
+
+        expect(getBlocks).toHaveBeenNthCalledWith(2, 0n, 31n);
+        expect(lastUpdate().status).toBe(FetchStatus.Fetched);
+    });
+
+    it('should preserve a null timestamp for a block with no recorded time', async () => {
+        getBlocks.mockResolvedValueOnce([FIRST_SLOT]).mockResolvedValueOnce([LAST_SLOT]);
+        getBlockTime.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+        await fetchEpoch(dispatch, MOCK_URL, Cluster.MainnetBeta, SCHEDULE, 20n, EPOCH);
+
+        expect(lastUpdate().data).toMatchObject({ firstTimestamp: null, lastTimestamp: null });
+    });
+
+    it('should request a timestamp for a last block at slot 0 rather than skipping it', async () => {
+        const tinySchedule: EpochSchedule = { firstNormalEpoch: 0n, firstNormalSlot: 0n, slotsPerEpoch: 32n };
+        getBlocks.mockResolvedValueOnce([0n]).mockResolvedValueOnce([0n]);
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchEpoch(dispatch, MOCK_URL, Cluster.MainnetBeta, tinySchedule, 20n, 0);
+
+        expect(getBlockTime).toHaveBeenCalledTimes(2);
+        expect(lastUpdate().data).toMatchObject({ lastBlock: 0, lastTimestamp: 1700000000 });
+    });
+
+    it('should dispatch FetchFailed when no block is found at the start of the epoch', async () => {
+        getBlocks.mockResolvedValue([]);
+
+        await fetchEpoch(dispatch, MOCK_URL, Cluster.MainnetBeta, SCHEDULE, 20n, EPOCH);
+
+        expect(lastUpdate()).toMatchObject({ data: undefined, status: FetchStatus.FetchFailed });
+    });
+});

--- a/app/providers/block.tsx
+++ b/app/providers/block.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { type BlockWithV1, fetchBlock as fetchBlockBySlot } from '@entities/block-data';
+import { getRpc } from '@entities/cluster';
 import * as Cache from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, PublicKey } from '@solana/web3.js';
+import type { Address } from '@solana/kit';
+import type { PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
+import { toLegacyPublicKey } from '@/app/shared/lib/web3js-compat';
 
 export enum FetchStatus {
     Fetching,
@@ -73,26 +76,28 @@ export async function fetchBlock(dispatch: Dispatch, url: string, cluster: Clust
     let data: Block | undefined = undefined;
 
     try {
-        const connection = new Connection(url, 'confirmed');
+        const rpc = getRpc(url);
         const block = await fetchBlockBySlot(url, slot);
         if (block === null) {
             data = {};
             status = FetchStatus.Fetched;
         } else {
-            const childSlot = (await connection.getBlocks(slot + 1, slot + 100)).shift();
+            const childSlotBigint = (await rpc.getBlocks(BigInt(slot + 1), BigInt(slot + 100)).send()).at(0);
+            const childSlot = childSlotBigint === undefined ? undefined : Number(childSlotBigint);
             const firstLeaderSlot = block.parentSlot;
 
-            let leaders: PublicKey[] = [];
+            let leaders: Address[] = [];
             try {
                 const lastLeaderSlot = childSlot !== undefined ? childSlot : slot;
                 const slotLeadersLimit = lastLeaderSlot - block.parentSlot + 1;
-                leaders = await connection.getSlotLeaders(firstLeaderSlot, slotLeadersLimit);
+                leaders = await rpc.getSlotLeaders(BigInt(firstLeaderSlot), slotLeadersLimit).send();
             } catch (_err) {
                 // ignore errors
             }
 
-            const getLeader = (slot: number) => {
-                return leaders.at(slot - firstLeaderSlot);
+            const getLeader = (slot: number): PublicKey | undefined => {
+                const leader = leaders.at(slot - firstLeaderSlot);
+                return leader === undefined ? undefined : toLegacyPublicKey(leader);
             };
 
             data = {

--- a/app/providers/epoch.tsx
+++ b/app/providers/epoch.tsx
@@ -103,7 +103,7 @@ export async function fetchEpoch(
 
         const [firstTimestamp, lastTimestamp] = await Promise.all<UnixTimestamp | null>([
             rpc.getBlockTime(firstBlock).send(),
-            lastBlock ? rpc.getBlockTime(lastBlock).send() : null,
+            lastBlock === undefined ? null : rpc.getBlockTime(lastBlock).send(),
         ]);
 
         data = {

--- a/app/providers/epoch.tsx
+++ b/app/providers/epoch.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { getRpc } from '@entities/cluster';
 import * as Cache from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection } from '@solana/web3.js';
+import type { UnixTimestamp } from '@solana/kit';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
@@ -80,17 +81,17 @@ export async function fetchEpoch(
     let data: Epoch | undefined = undefined;
 
     try {
-        const connection = new Connection(url, 'confirmed');
+        const rpc = getRpc(url);
         const firstSlot = getFirstSlotInEpoch(epochSchedule, BigInt(epoch));
         const lastSlot = getLastSlotInEpoch(epochSchedule, BigInt(epoch));
         const [firstBlock, lastBlock] = await Promise.all([
             (async () => {
-                const firstBlocks = await connection.getBlocks(Number(firstSlot), Number(firstSlot + 100n));
-                return firstBlocks.shift();
+                const firstBlocks = await rpc.getBlocks(firstSlot, firstSlot + 100n).send();
+                return firstBlocks.at(0);
             })(),
             (async () => {
-                const lastBlocks = await connection.getBlocks(Math.max(0, Number(lastSlot - 100n)), Number(lastSlot));
-                return lastBlocks.pop();
+                const lastBlocks = await rpc.getBlocks(lastSlot > 100n ? lastSlot - 100n : 0n, lastSlot).send();
+                return lastBlocks.at(-1);
             })(),
         ]);
 
@@ -100,16 +101,16 @@ export async function fetchEpoch(
             throw new Error(`failed to find confirmed block at end of epoch ${epoch}`);
         }
 
-        const [firstTimestamp, lastTimestamp] = await Promise.all([
-            connection.getBlockTime(firstBlock),
-            lastBlock ? connection.getBlockTime(lastBlock) : null,
+        const [firstTimestamp, lastTimestamp] = await Promise.all<UnixTimestamp | null>([
+            rpc.getBlockTime(firstBlock).send(),
+            lastBlock ? rpc.getBlockTime(lastBlock).send() : null,
         ]);
 
         data = {
-            firstBlock,
-            firstTimestamp,
-            lastBlock,
-            lastTimestamp,
+            firstBlock: Number(firstBlock),
+            firstTimestamp: firstTimestamp === null ? null : Number(firstTimestamp),
+            lastBlock: lastBlock === undefined ? undefined : Number(lastBlock),
+            lastTimestamp: lastTimestamp === null ? null : Number(lastTimestamp),
         };
         status = FetchStatus.Fetched;
     } catch (err) {

--- a/app/providers/transactions/__tests__/index.test.tsx
+++ b/app/providers/transactions/__tests__/index.test.tsx
@@ -1,0 +1,136 @@
+import { DEFAULT_SIGNATURE } from '@__fixtures__/gen';
+import { ActionType, type Dispatch, FetchStatus } from '@providers/cache';
+import { Cluster } from '@utils/cluster';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchTransactionStatus, type TransactionStatus } from '../index';
+
+const MOCK_URL = 'https://api.mainnet-beta.solana.com';
+
+const getSignatureStatuses = vi.fn();
+const getBlockTime = vi.fn();
+const getRpc = vi.fn((_url: string) => ({
+    getBlockTime: (...args: unknown[]) => ({ send: () => getBlockTime(...args) }),
+    getSignatureStatuses: (...args: unknown[]) => ({ send: () => getSignatureStatuses(...args) }),
+}));
+vi.mock('@entities/cluster', async importOriginal => ({
+    ...((await importOriginal()) as Record<string, unknown>),
+    getRpc: (...args: [string]) => getRpc(...args),
+}));
+
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+
+function status(overrides: Record<string, unknown> = {}) {
+    return {
+        confirmationStatus: 'confirmed',
+        confirmations: 7n,
+        err: null,
+        slot: 1234n,
+        ...overrides,
+    };
+}
+
+const dispatch = vi.fn() as unknown as Dispatch<TransactionStatus>;
+
+function lastUpdate() {
+    const calls = vi.mocked(dispatch).mock.calls;
+    return calls[calls.length - 1][0] as { data?: TransactionStatus; status: FetchStatus; type: ActionType };
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    getRpc.mockReturnValue({
+        getBlockTime: (...args: unknown[]) => ({ send: () => getBlockTime(...args) }),
+        getSignatureStatuses: (...args: unknown[]) => ({ send: () => getSignatureStatuses(...args) }),
+    });
+});
+
+describe('fetchTransactionStatus', () => {
+    it('should convert kit bigints to numbers', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [status()] });
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(getRpc).toHaveBeenCalledWith(MOCK_URL);
+        expect(getSignatureStatuses).toHaveBeenCalledWith([DEFAULT_SIGNATURE], { searchTransactionHistory: true });
+        expect(getBlockTime).toHaveBeenCalledWith(1234n);
+        expect(lastUpdate()).toMatchObject({
+            data: {
+                info: {
+                    confirmationStatus: 'confirmed',
+                    confirmations: 7,
+                    result: { err: null },
+                    slot: 1234,
+                    timestamp: 1700000000,
+                },
+                signature: DEFAULT_SIGNATURE,
+            },
+            status: FetchStatus.Fetched,
+        });
+    });
+
+    it('should report max confirmations for a rooted signature', async () => {
+        getSignatureStatuses.mockResolvedValue({
+            value: [status({ confirmationStatus: 'finalized', confirmations: null })],
+        });
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(lastUpdate().data?.info?.confirmations).toBe('max');
+    });
+
+    it('should mark the timestamp unavailable when getBlockTime throws', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [status()] });
+        getBlockTime.mockRejectedValue(new Error('slot skipped'));
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(lastUpdate()).toMatchObject({
+            data: { info: { timestamp: 'unavailable' } },
+            status: FetchStatus.Fetched,
+        });
+    });
+
+    it('should treat a null status entry as a fetched-but-missing signature', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [null] });
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(getBlockTime).not.toHaveBeenCalled();
+        expect(lastUpdate()).toMatchObject({
+            data: { info: null, signature: DEFAULT_SIGNATURE },
+            status: FetchStatus.Fetched,
+        });
+    });
+
+    it('should strip bigints out of the transaction error', async () => {
+        getSignatureStatuses.mockResolvedValue({
+            value: [status({ err: { InstructionError: [2n, { Custom: 6001n }] } })],
+        });
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        const err = lastUpdate().data?.info?.result.err;
+        expect(err).toStrictEqual({ InstructionError: [2, { Custom: 6001 }] });
+        expect(() => JSON.stringify(err)).not.toThrow();
+    });
+
+    it('should dispatch FetchFailed when the response carries the wrong number of statuses', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [] });
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(lastUpdate()).toMatchObject({ data: undefined, status: FetchStatus.FetchFailed });
+    });
+
+    it('should dispatch FetchFailed when the status request throws', async () => {
+        getSignatureStatuses.mockRejectedValue(new Error('rpc boom'));
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(lastUpdate()).toMatchObject({ data: undefined, status: FetchStatus.FetchFailed });
+    });
+});

--- a/app/providers/transactions/__tests__/index.test.tsx
+++ b/app/providers/transactions/__tests__/index.test.tsx
@@ -18,7 +18,9 @@ vi.mock('@entities/cluster', async importOriginal => ({
     getRpc: (...args: [string]) => getRpc(...args),
 }));
 
-vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+// Silence Sentry, and keep a handle on it: the catch block only reports rooted mainnet slots.
+const loggerError = vi.fn();
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: (...args: unknown[]) => loggerError(...args) } }));
 
 function status(overrides: Record<string, unknown> = {}) {
     return {
@@ -79,6 +81,50 @@ describe('fetchTransactionStatus', () => {
         await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
 
         expect(lastUpdate().data?.info?.confirmations).toBe('max');
+    });
+
+    it('should mark the timestamp unavailable when the block has no recorded time', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [status()] });
+        getBlockTime.mockResolvedValue(null);
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(lastUpdate()).toMatchObject({
+            data: { info: { timestamp: 'unavailable' } },
+            status: FetchStatus.Fetched,
+        });
+    });
+
+    it('should drop a null confirmationStatus rather than leaking it downstream', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [status({ confirmationStatus: null })] });
+        getBlockTime.mockResolvedValue(1700000000n);
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        const info = lastUpdate().data?.info;
+        expect(info?.confirmationStatus).toBeUndefined();
+        expect(info && 'confirmationStatus' in info).toBe(true);
+    });
+
+    it('should report a rooted mainnet block with no time to Sentry', async () => {
+        getSignatureStatuses.mockResolvedValue({
+            value: [status({ confirmationStatus: 'finalized', confirmations: null })],
+        });
+        getBlockTime.mockRejectedValue(new Error('slot skipped'));
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(loggerError).toHaveBeenCalledTimes(1);
+        expect(loggerError.mock.calls[0][1]).toStrictEqual({ slot: '1234' });
+    });
+
+    it('should not report an unrooted block with no time to Sentry', async () => {
+        getSignatureStatuses.mockResolvedValue({ value: [status()] });
+        getBlockTime.mockRejectedValue(new Error('slot skipped'));
+
+        await fetchTransactionStatus(dispatch, DEFAULT_SIGNATURE, Cluster.MainnetBeta, MOCK_URL);
+
+        expect(loggerError).not.toHaveBeenCalled();
     });
 
     it('should mark the timestamp unavailable when getBlockTime throws', async () => {

--- a/app/providers/transactions/index.tsx
+++ b/app/providers/transactions/index.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import { getRpc } from '@entities/cluster';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, SignatureResult, TransactionConfirmationStatus, TransactionSignature } from '@solana/web3.js';
+import { signature as createSignature } from '@solana/kit';
+import type { SignatureResult, TransactionConfirmationStatus, TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
 import { Logger } from '@/app/shared/lib/logger';
 
 import { DetailsProvider } from './parsed';
@@ -76,35 +79,36 @@ export async function fetchTransactionStatus(
     let fetchStatus;
     let data;
     try {
-        const connection = new Connection(url);
-        const { value } = await connection.getSignatureStatus(signature, {
-            searchTransactionHistory: true,
-        });
+        const rpc = getRpc(url);
+        const { value: statuses } = await rpc
+            .getSignatureStatuses([createSignature(signature)], {
+                searchTransactionHistory: true,
+            })
+            .send();
+        if (statuses.length !== 1) {
+            throw new Error(`expected 1 signature status, received ${statuses.length}`);
+        }
+        const value = statuses[0] ?? null;
 
         let info = null;
         if (value !== null) {
-            let confirmations: Confirmations;
-            if (typeof value.confirmations === 'number') {
-                confirmations = value.confirmations;
-            } else {
-                confirmations = 'max';
-            }
-
-            let blockTime = null;
+            const confirmations: Confirmations =
+                typeof value.confirmations === 'bigint' ? Number(value.confirmations) : 'max';
+            let blockTime: bigint | null = null;
             try {
-                blockTime = await connection.getBlockTime(value.slot);
+                blockTime = await rpc.getBlockTime(value.slot).send();
             } catch (error) {
                 if (cluster === Cluster.MainnetBeta && confirmations === 'max') {
                     Logger.error(error, { slot: `${value.slot}` });
                 }
             }
-            const timestamp: Timestamp = blockTime !== null ? blockTime : 'unavailable';
+            const timestamp: Timestamp = blockTime !== null ? Number(blockTime) : 'unavailable';
 
             info = {
-                confirmationStatus: value.confirmationStatus,
+                confirmationStatus: value.confirmationStatus ?? undefined,
                 confirmations,
-                result: { err: value.err },
-                slot: value.slot,
+                result: { err: withNumbersInsteadOfBigInts(value.err) },
+                slot: Number(value.slot),
                 timestamp,
             };
         }

--- a/app/shared/lib/__tests__/bigint-to-number.spec.ts
+++ b/app/shared/lib/__tests__/bigint-to-number.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { withNumbersInsteadOfBigInts } from '../bigint-to-number';
+
+describe('withNumbersInsteadOfBigInts', () => {
+    it('should convert a bare bigint', () => {
+        expect(withNumbersInsteadOfBigInts(7n)).toBe(7);
+    });
+
+    it('should leave other primitives untouched', () => {
+        expect(withNumbersInsteadOfBigInts('AccountNotFound')).toBe('AccountNotFound');
+        expect(withNumbersInsteadOfBigInts(3)).toBe(3);
+        expect(withNumbersInsteadOfBigInts(true)).toBe(true);
+        expect(withNumbersInsteadOfBigInts(null)).toBeNull();
+        expect(withNumbersInsteadOfBigInts(undefined)).toBeUndefined();
+    });
+
+    it('should recurse through nested arrays and objects', () => {
+        const err = { InstructionError: [2n, { Custom: 6001n }] };
+
+        expect(withNumbersInsteadOfBigInts(err)).toStrictEqual({ InstructionError: [2, { Custom: 6001 }] });
+    });
+
+    it('should preserve nulls nested inside a payload', () => {
+        expect(withNumbersInsteadOfBigInts({ confirmations: null, slot: 12n })).toStrictEqual({
+            confirmations: null,
+            slot: 12,
+        });
+    });
+
+    it('should produce a JSON-serializable payload', () => {
+        const converted = withNumbersInsteadOfBigInts({ InstructionError: [0n, { Custom: 1n }] });
+
+        expect(() => JSON.stringify(converted)).not.toThrow();
+    });
+
+    it('should not be pointed at binary data: byte arrays are flattened into plain objects', () => {
+        // Documents the plain-JSON-only restriction in the helper's docblock rather than endorsing it.
+        expect(withNumbersInsteadOfBigInts(Uint8Array.from([1, 2]))).toStrictEqual({ 0: 1, 1: 2 });
+    });
+});

--- a/app/shared/lib/bigint-to-number.ts
+++ b/app/shared/lib/bigint-to-number.ts
@@ -1,0 +1,19 @@
+/**
+ * Recursively replaces bigints with numbers for web3.js -> Kit migration
+ *
+ * Precision above 2^53 is lost, exactly as it was when web3.js parsed the same response.
+ */
+export function withNumbersInsteadOfBigInts<T>(value: T): T {
+    if (typeof value === 'bigint') {
+        return Number(value) as T;
+    }
+    if (Array.isArray(value)) {
+        return value.map(withNumbersInsteadOfBigInts) as T;
+    }
+    if (typeof value === 'object' && value !== null) {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, item]) => [key, withNumbersInsteadOfBigInts(item)]),
+        ) as T;
+    }
+    return value;
+}

--- a/app/shared/lib/bigint-to-number.ts
+++ b/app/shared/lib/bigint-to-number.ts
@@ -1,7 +1,15 @@
 /**
- * Recursively replaces bigints with numbers for web3.js -> Kit migration
+ * Recursively replaces bigints with numbers in a JSON-RPC response payload.
  *
- * Precision above 2^53 is lost, exactly as it was when web3.js parsed the same response.
+ * kit upcasts every integral value in an RPC response to a bigint unless its key path is on an
+ * allow-list, and that list covers nothing inside a parsed instruction or a transaction error.
+ * Numbers are mandatory downstream: consumers `JSON.stringify` these payloads, which throws on a
+ * bigint, and validate them against superstruct `number()` schemas. Precision above 2^53 is lost,
+ * which is acceptable because no field reached by this helper — instruction indices, program error
+ * codes, account indices — comes close to that bound.
+ *
+ * Only plain JSON values are supported. `Uint8Array`, `Map`, `Set` and `Date` fail the array check
+ * and would be flattened into plain objects, so do not point this at decoded account data.
  */
 export function withNumbersInsteadOfBigInts<T>(value: T): T {
     if (typeof value === 'bigint') {


### PR DESCRIPTION

kit migration tasks 1.1 + 1.2 — the epoch, block and transaction providers no longer construct `new Connection`. all three now go through the central `getRpc(url)` accessor from #1199.

| provider                 | calls moved to kit                                            |
| ------------------------ | ------------------------------------------------------------- |
| `epoch.tsx`              | `getBlocks` (epoch boundary discovery), `getBlockTime`        |
| `block.tsx`              | `getBlocks` (child slot), `getSlotLeaders`                    |
| `transactions/index.tsx` | `getSignatureStatus` → `getSignatureStatuses`, `getBlockTime` |

kit upcasts every integer in an RPC response to a bigint so we map those where needed

closes HOO-1220
closes HOO-1222