### PR TITLE
chore: update dependency policy & fix templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 ## Related Issues
 
 <!-- Link to any related issues this PR addresses -->
-<!-- Example: Fixes #123, Addresses #456 -->
+<!-- Example: Fixes #<issue-number>, Addresses #<issue-number> -->
 
 ## Checklist
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ version: 2
 updates:
   # GitHub Actions used across .github/workflows/*. Once action refs are pinned to commit
   # SHAs, this is what keeps those pins from rotting — it bumps them to newer released SHAs.
-  # All bumps are grouped into a single PR to keep review overhead low.
+  # Minor and patch bumps are grouped into one PR; majors are split out so each can be
+  # reviewed on its own, the same split the npm entry below uses.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -15,6 +16,9 @@ updates:
       github-actions:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
 
   # npm/pnpm workspace (root package.json + packages/*). Minor and patch bumps are grouped
   # into one PR; majors are split out so each can be reviewed on its own. `cooldown` mirrors

--- a/openspec/changes/separate-freshness-from-compatibility-gates/proposal.md
+++ b/openspec/changes/separate-freshness-from-compatibility-gates/proposal.md
@@ -1,0 +1,41 @@
+# Proposal: Separate the freshness gate from the compatibility gate
+
+## Context
+
+Two gates stand between a published release and `master`, and they were being asked to do each other's job.
+
+**Freshness is a supply-chain control.** `pnpm-workspace.yaml` holds most of it — `ignoreScripts` removes install-time execution, `registries.default` pins resolution to public npm, and `minimumReleaseAge` refuses anything published in the last 14 days — with `pnpm audit:ci` as its own CI job. `.github/dependabot.yml` mirrors the age window via `cooldown`, so the bot does not propose what the resolver would refuse.
+
+**Compatibility asks a different question: does this version still work here.** `frozenLockfile`, exact pins and the catalogs make resolution deterministic, but none of that evaluates a breaking change. Review, typecheck and tests do.
+
+The trigger was a grouped `github-actions` update that proposed four major bumps in one pull request. Every one was between 19 and 57 days old — well clear of the window — and one still had to be held back by hand.
+
+## Why
+
+**Freshness is a function of elapsed time. Compatibility is not.**
+
+The age gate models compromise of the supply chain — a hijacked maintainer token, a typosquat, a malicious dependency swapped in upstream. Time is the right mitigation because detection and yanking take days, so waiting buys real information. It pairs with `ignoreScripts`, which already removes the install-time execution path: what the window actually buys is detection time against malicious code that runs at _runtime_, which nothing else in the stack catches.
+
+A breaking release has no such property. It is as breaking after a month as on the day it shipped, so waiting produces no new signal and no cooldown value gates it. Review does — and review needs the major to arrive in a pull request of its own. The `npm` entry already worked this way, its group scoped to minor and patch so majors fall out and get individual PRs. The `github-actions` entry grouped everything, which is why four majors arrived together.
+
+The corollary is that the two gates must not be traded against each other. A major that is unsafe to adopt is held where it is declared, not by widening the age window — which could not have stopped it anyway.
+
+### Alternatives considered
+
+**A longer cooldown for majors (`semver-major-days`)** — rejected. Cooldown measures the candidate's publish date, and when the newest version is filtered it falls back to the next eligible one. A longer major window therefore selects an _older_ major rather than preventing one: it shifts which major you adopt, never whether you review it first.
+
+**`ignore` on major update-types** — rejected as too blunt. It is a permanent opt-out: majors stop being proposed at all, and pinned action SHAs rot silently until someone notices by hand. Keeping those pins from rotting is the whole reason Dependabot watches this ecosystem. The group split keeps every major visible, one PR at a time.
+
+**Dropping or lowering `minimumReleaseAge` workspace-wide** — rejected. It removes a supply-chain control from every dependency in order to solve a scheduling problem, and it addresses the wrong gate: the problem was unreviewed majors, not fresh releases.
+
+## What Changes
+
+- **`.github/dependabot.yml`** — the `github-actions` group gains `update-types: [minor, patch]`, matching the `npm` group. Majors are proposed as individual pull requests.
+- Ships alongside a chore: `minimumReleaseAgeExclude` is removed from `pnpm-workspace.yaml` entirely, so every dependency sits behind the same window. Both carve-outs had expired, so nothing re-resolves. This discharges the follow-up recorded in `adopt-kit-7-transaction-introspection`.
+
+## Impact
+
+- **Config lands before it applies.** Dependabot reads `.github/dependabot.yml` from the default branch, so the group split takes effect only after merge.
+- **The open grouped PR is recreated.** Changing a group's membership makes Dependabot rebuild the grouped pull request rather than update it.
+- **More PRs, by design.** The `github-actions` entry sets no `open-pull-requests-limit`, so it inherits the default of five. A week with several majors will consume that budget where it previously produced one PR. Accepted: the alternative is majors that are never individually reviewed.
+- **Unverified, and worth confirming once:** whether Dependabot honours `cooldown` for the `github-actions` ecosystem at all. Cooldown is implemented per-ecosystem inside each `UpdateChecker` in `dependabot-core`, and the triggering update settles nothing either way — nothing on offer was fresh enough for the gate to filter. The repository's Dependabot update logs name what a run filtered out.

--- a/openspec/changes/separate-freshness-from-compatibility-gates/proposal.md
+++ b/openspec/changes/separate-freshness-from-compatibility-gates/proposal.md
@@ -2,40 +2,19 @@
 
 ## Context
 
-Two gates stand between a published release and `master`, and they were being asked to do each other's job.
-
-**Freshness is a supply-chain control.** `pnpm-workspace.yaml` holds most of it — `ignoreScripts` removes install-time execution, `registries.default` pins resolution to public npm, and `minimumReleaseAge` refuses anything published in the last 14 days — with `pnpm audit:ci` as its own CI job. `.github/dependabot.yml` mirrors the age window via `cooldown`, so the bot does not propose what the resolver would refuse.
-
-**Compatibility asks a different question: does this version still work here.** `frozenLockfile`, exact pins and the catalogs make resolution deterministic, but none of that evaluates a breaking change. Review, typecheck and tests do.
-
-The trigger was a grouped `github-actions` update that proposed four major bumps in one pull request. Every one was between 19 and 57 days old — well clear of the window — and one still had to be held back by hand.
+`minimumReleaseAge` and Dependabot `cooldown` hold every dependency for 14 days as a supply-chain control. A grouped `github-actions` update then proposed four majors in one pull request — every one well clear of that window, and one still had to be held back by hand.
 
 ## Why
 
-**Freshness is a function of elapsed time. Compatibility is not.**
-
-The age gate models compromise of the supply chain — a hijacked maintainer token, a typosquat, a malicious dependency swapped in upstream. Time is the right mitigation because detection and yanking take days, so waiting buys real information. It pairs with `ignoreScripts`, which already removes the install-time execution path: what the window actually buys is detection time against malicious code that runs at _runtime_, which nothing else in the stack catches.
-
-A breaking release has no such property. It is as breaking after a month as on the day it shipped, so waiting produces no new signal and no cooldown value gates it. Review does — and review needs the major to arrive in a pull request of its own. The `npm` entry already worked this way, its group scoped to minor and patch so majors fall out and get individual PRs. The `github-actions` entry grouped everything, which is why four majors arrived together.
-
-The corollary is that the two gates must not be traded against each other. A major that is unsafe to adopt is held where it is declared, not by widening the age window — which could not have stopped it anyway.
-
-### Alternatives considered
-
-**A longer cooldown for majors (`semver-major-days`)** — rejected. Cooldown measures the candidate's publish date, and when the newest version is filtered it falls back to the next eligible one. A longer major window therefore selects an _older_ major rather than preventing one: it shifts which major you adopt, never whether you review it first.
-
-**`ignore` on major update-types** — rejected as too blunt. It is a permanent opt-out: majors stop being proposed at all, and pinned action SHAs rot silently until someone notices by hand. Keeping those pins from rotting is the whole reason Dependabot watches this ecosystem. The group split keeps every major visible, one PR at a time.
-
-**Dropping or lowering `minimumReleaseAge` workspace-wide** — rejected. It removes a supply-chain control from every dependency in order to solve a scheduling problem, and it addresses the wrong gate: the problem was unreviewed majors, not fresh releases.
+The window gates compromise, not breakage: a release is as breaking after a month as on the day it shipped, so no cooldown value substitutes for proposing majors one at a time. Rejected alternatives: `semver-major-days`, which falls back to the next eligible version and so selects an _older_ major rather than preventing one; and `ignore` on major update-types, a permanent opt-out that lets pinned action SHAs rot silently.
 
 ## What Changes
 
-- **`.github/dependabot.yml`** — the `github-actions` group gains `update-types: [minor, patch]`, matching the `npm` group. Majors are proposed as individual pull requests.
-- Ships alongside a chore: `minimumReleaseAgeExclude` is removed from `pnpm-workspace.yaml` entirely, so every dependency sits behind the same window. Both carve-outs had expired, so nothing re-resolves. This discharges the follow-up recorded in `adopt-kit-7-transaction-introspection`.
+- `github-actions` group scoped to `update-types: [minor, patch]`, matching `npm`. Majors are proposed individually.
+- `minimumReleaseAgeExclude` removed — both carve-outs had expired, so nothing re-resolves. Discharges the follow-up recorded in `adopt-kit-7-transaction-introspection`.
 
 ## Impact
 
-- **Config lands before it applies.** Dependabot reads `.github/dependabot.yml` from the default branch, so the group split takes effect only after merge.
-- **The open grouped PR is recreated.** Changing a group's membership makes Dependabot rebuild the grouped pull request rather than update it.
-- **More PRs, by design.** The `github-actions` entry sets no `open-pull-requests-limit`, so it inherits the default of five. A week with several majors will consume that budget where it previously produced one PR. Accepted: the alternative is majors that are never individually reviewed.
-- **Unverified, and worth confirming once:** whether Dependabot honours `cooldown` for the `github-actions` ecosystem at all. Cooldown is implemented per-ecosystem inside each `UpdateChecker` in `dependabot-core`, and the triggering update settles nothing either way — nothing on offer was fresh enough for the gate to filter. The repository's Dependabot update logs name what a run filtered out.
+- Dependabot reads config from the default branch, so the split takes effect only after merge, and changing group membership rebuilds the grouped PR rather than updating it.
+- The `github-actions` entry sets no `open-pull-requests-limit`, so majors now draw on the default of five.
+- Unverified: whether Dependabot honours `cooldown` for the `github-actions` ecosystem at all.

--- a/openspec/changes/separate-freshness-from-compatibility-gates/specs/dependency-updates/spec.md
+++ b/openspec/changes/separate-freshness-from-compatibility-gates/specs/dependency-updates/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: A dependency version SHALL age before it can be installed or proposed
+
+A published version SHALL NOT enter the tree until it has been publicly available for a fixed minimum period, currently 14 days. The window is a supply-chain control: it buys time for a compromised release to be noticed and yanked. It says nothing about whether the version works, and MUST NOT be treated as a compatibility check.
+
+#### Scenario: A version is published inside the window
+
+- **WHEN** a release is younger than the window
+- **THEN** the resolver SHALL refuse to install it
+- **AND** the update bot SHALL NOT propose it
+
+#### Scenario: The window is changed
+
+- **WHEN** the window is changed for one tool that selects versions
+- **THEN** it SHALL be changed for every other such tool
+- **AND** a disagreement SHALL be treated as a defect, because it either proposes versions the resolver refuses or withholds versions the resolver would accept
+
+### Requirement: Breaking updates SHALL be proposed one at a time
+
+An update group SHALL cover only non-breaking updates, so a major version bump arrives on its own rather than bundled with unrelated bumps. Age is not evidence of compatibility — a breaking release is as breaking after a month as on the day it shipped — so the age window neither holds a major back nor stands in for looking at one.
+
+#### Scenario: Several breaking updates become available at once
+
+- **WHEN** more than one grouped dependency has a major update available
+- **THEN** each SHALL be proposed separately
+- **AND** the grouped proposal SHALL carry only the non-breaking updates

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,14 +29,6 @@ ignoreScripts: true
 
 minimumReleaseAge: 20160
 
-# @solana/subscriptions 0.5.0 is the first release built against @solana/kit 7; every older release
-# imports `getMinimumBalanceForRentExemption`, which kit 7 removed, and fails at import time. Drop
-# this exclusion once 0.5.0 is older than `minimumReleaseAge`.
-minimumReleaseAgeExclude:
-  - '@solana/subscriptions'
-  - '@codama/*'
-  - codama
-
 # Pin resolution to the public npm registry so it can't silently inherit a
 # global/org .npmrc mirror. Scoped keys (e.g. '@my-org') can be added here.
 registries:


### PR DESCRIPTION

Two gates were being asked to do each other's job:

-   _Freshness_ — supply-chain risk, mitigated by time (`minimumReleaseAge` + Dependabot `cooldown`, both 14 days).
-   _Compatibility_ — a breaking release is as breaking after a month as on the day it shipped. No cooldown value gates it; only review does.

A grouped `github-actions` update proposed four majors at once, all well clear of the window, one still needing a hand-written hold. Review needs the major in a PR of its own, so the group is now scoped to `update-types: [minor, patch]` — what the `npm` entry already did.

Riding along: `minimumReleaseAgeExclude` deleted, both carve-outs having expired.

Rationale and rejected alternatives: `openspec/changes/separate-freshness-from-compatibility-gates/`.

Second, unrelated commit: the PR template's `Fixes #123` example is live to GitHub's closing-keyword parser. It survives squash-merge into the commit body, and any fork that later syncs that commit closes its own item numbered 123 — attributed to whoever pushed. Replaced with `#<issue-number>`, which cannot resolve. Split out so it can be cherry-picked ahead of this review.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [x] Documentation update
-   [x] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

No UI changes.

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

-   `pnpm typecheck` — pass.
-   `pnpm lint` — pass.
-   `pnpm test` — 391 files, 4304 passed, 28 skipped.
-   `pnpm openspec:validate` — 22 passed, 0 failed.
-   `pnpm i --frozen-lockfile` — no re-resolution; the affected versions are pinned and already eligible.

`dependabot.yml` can't be exercised locally: Dependabot reads config from the default branch, so the split applies only after merge.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #<issue-number>, Addresses #<issue-number> -->

[HOO-1035](https://linear.app/solana-fndn/issue/HOO-1035)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   ~~[ ] I have added tests that prove my fix/feature works~~
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   ~~[ ] I have run `build:info` script to update build information~~
-   [x] CI/CD checks pass on the PR
-   ~~[ ] Screenshots included — required for protocol screens, recommended for other UI changes~~
-   ~~[ ] For security-related features, I have included links to related information~~

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

-   "Other" = dependency-update policy; CI/dependency config, no application code.
-   Changing a group's membership makes Dependabot rebuild the grouped PR rather than update it.
-   No `open-pull-requests-limit` on that entry, so it inherits the default of five — a week with several majors will consume it.
-   Marked unverified in the proposal: whether Dependabot honours `cooldown` for `github-actions` at all. The triggering update settles nothing — nothing on offer was fresh enough to filter.
-   The template fix stops new commits joining the set; already-merged commits carrying live closing keywords stay dangerous for forks that have not synced past them. Upstream serves the template to PRs opened against it, so the fork-side fix does not cover those.
