### PR TITLE
refactor(providers): move accounts provider off web3.js Connection

### DIFF
--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -1,18 +1,32 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { act, render, waitFor } from '@testing-library/react';
 import { Cluster, clusterSelection, clusterUrl } from '@utils/cluster';
 import React from 'react';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Logger } from '@/app/shared/lib/logger';
 
 vi.mock('next/navigation');
 
-const { useClusterMock } = vi.hoisted(() => ({ useClusterMock: vi.fn() }));
+const { useClusterMock, getMultipleAccounts, getRpc } = vi.hoisted(() => {
+    const getMultipleAccounts = vi.fn();
+    return {
+        getMultipleAccounts,
+        getRpc: vi.fn((_url: string) => ({
+            getMultipleAccounts: (...args: unknown[]) => ({ send: () => getMultipleAccounts(...args) }),
+        })),
+        useClusterMock: vi.fn(),
+    };
+});
 
 vi.mock('../../cluster', async importOriginal => {
     const actual = await importOriginal<typeof import('../../cluster')>();
     return { ...actual, useCluster: useClusterMock };
+});
+
+vi.mock('@entities/cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('@entities/cluster')>();
+    return { ...actual, getRpc };
 });
 
 import { AccountsProvider, FetchersContext, useFetchAccountInfo } from '..';
@@ -106,8 +120,6 @@ describe('AccountsProvider', () => {
 });
 
 describe('AccountsProvider: fetch and mount', () => {
-    let getMultipleAccountsInfo: MockInstance<typeof Connection.prototype.getMultipleAccountsInfo>;
-
     /**
      * Fetches from a mount effect, the shape real consumers use (the inspector's `AccountInfo`,
      * `usePmpAccountPayload`). React flushes effects bottom-up, so this runs BEFORE the provider's own effect
@@ -138,12 +150,11 @@ describe('AccountsProvider: fetch and mount', () => {
         mockCluster(Cluster.Devnet, DEVNET_ENDPOINT);
         // Every 'skip' batch lands here. Stubbing it keeps these assertions off the network and lets each test
         // read back the batch the provider actually sent.
-        getMultipleAccountsInfo = vi.spyOn(Connection.prototype, 'getMultipleAccountsInfo').mockResolvedValue([null]);
+        getMultipleAccounts.mockResolvedValue({ value: [null] });
     });
 
     afterEach(() => {
         vi.useRealTimers();
-        vi.restoreAllMocks();
     });
 
     it('should not fetch a first-commit request after the provider unmounts', async () => {
@@ -153,7 +164,7 @@ describe('AccountsProvider: fetch and mount', () => {
         await flushDebounce();
 
         // Without the cancel this batch fired into a torn-down tree and rejected with "window is not defined".
-        expect(getMultipleAccountsInfo).not.toHaveBeenCalled();
+        expect(getMultipleAccounts).not.toHaveBeenCalled();
     });
 
     it('should fetch a first-commit request once while the provider stays mounted', async () => {
@@ -161,9 +172,12 @@ describe('AccountsProvider: fetch and mount', () => {
 
         await flushDebounce();
 
-        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
-        const [batch] = getMultipleAccountsInfo.mock.calls[0];
-        expect(batch.map(pubkey => pubkey.toBase58())).toEqual([TEST_PUBKEY.toBase58()]);
+        expect(getRpc).toHaveBeenCalledWith(DEVNET_ENDPOINT);
+        expect(getMultipleAccounts).toHaveBeenCalledTimes(1);
+        const [addresses, config] = getMultipleAccounts.mock.calls[0];
+        expect(addresses).toEqual([TEST_PUBKEY.toBase58()]);
+        // 'skip' mode must never download account data.
+        expect(config).toEqual({ dataSlice: { length: 0, offset: 0 }, encoding: 'base64' });
     });
 
     it('should not drop a first-commit fetch when React.StrictMode remounts the tree', async () => {
@@ -180,7 +194,7 @@ describe('AccountsProvider: fetch and mount', () => {
         // that second run has to re-arm the debounce. If it does not, a dev page sits on "Loading" forever.
         await flushDebounce();
 
-        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
+        expect(getMultipleAccounts).toHaveBeenCalledTimes(1);
     });
 
     it('should keep a pending batch when the cluster changes but the url does not', async () => {
@@ -196,11 +210,11 @@ describe('AccountsProvider: fetch and mount', () => {
         );
         await flushDebounce();
 
-        expect(getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
+        expect(getMultipleAccounts).toHaveBeenCalledTimes(1);
     });
 
     it('should report a failed batch on a preset cluster', async () => {
-        getMultipleAccountsInfo.mockRejectedValue(new Error('rpc unreachable'));
+        getMultipleAccounts.mockRejectedValue(new Error('rpc unreachable'));
 
         renderProvider();
         await flushDebounce();
@@ -210,7 +224,7 @@ describe('AccountsProvider: fetch and mount', () => {
 
     it('should stay quiet about a failed batch on a custom cluster', async () => {
         mockCluster(Cluster.Custom, DEVNET_ENDPOINT);
-        getMultipleAccountsInfo.mockRejectedValue(new Error('rpc unreachable'));
+        getMultipleAccounts.mockRejectedValue(new Error('rpc unreachable'));
 
         renderProvider();
         await flushDebounce();

--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -177,7 +177,7 @@ describe('AccountsProvider: fetch and mount', () => {
         const [addresses, config] = getMultipleAccounts.mock.calls[0];
         expect(addresses).toEqual([TEST_PUBKEY.toBase58()]);
         // 'skip' mode must never download account data.
-        expect(config).toEqual({ dataSlice: { length: 0, offset: 0 }, encoding: 'base64' });
+        expect(config).toEqual({ commitment: 'confirmed', dataSlice: { length: 0, offset: 0 }, encoding: 'base64' });
     });
 
     it('should not drop a first-commit fetch when React.StrictMode remounts the tree', async () => {

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getRpc, type SolanaRpc } from '@entities/cluster';
 import { fetchNftData } from '@entities/nft';
 import {
     ADDRESS_LOOKUP_TABLE_PROGRAM_LABEL,
@@ -24,12 +25,10 @@ import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCacheEntries, useCacheEntry } from '@providers/cache-entry';
 import { useCluster } from '@providers/cluster';
-import { createSolanaRpc } from '@solana/kit';
+import type { AccountInfoWithJsonData } from '@solana/kit';
 import {
     AddressLookupTableAccount,
     AddressLookupTableProgram,
-    Connection,
-    ParsedAccountData,
     PublicKey,
     StakeActivationData,
     SystemProgram,
@@ -49,8 +48,10 @@ import { ParsedInfo } from '@validators/index';
 import React from 'react';
 import { create } from 'superstruct';
 
-import { alloc } from '@/app/shared/lib/bytes';
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
+import { alloc, fromBase64 } from '@/app/shared/lib/bytes';
 import { Logger } from '@/app/shared/lib/logger';
+import { toKitAddress, toLegacyPublicKey } from '@/app/shared/lib/web3js-compat';
 
 import { RewardsProvider } from './rewards';
 import { TokensProvider } from './tokens';
@@ -261,7 +262,7 @@ async function fetchMultipleAccounts({
     }
 
     const BATCH_SIZE = 100;
-    const connection = new Connection(url, 'confirmed');
+    const rpc = getRpc(url);
 
     let nextBatchStart = 0;
     while (nextBatchStart < pubkeys.length) {
@@ -269,16 +270,16 @@ async function fetchMultipleAccounts({
         nextBatchStart += BATCH_SIZE;
 
         try {
-            let results;
-            if (dataMode === 'parsed') {
-                results = (await connection.getMultipleParsedAccounts(batch)).value;
-            } else if (dataMode === 'raw') {
-                results = await connection.getMultipleAccountsInfo(batch);
-            } else {
-                results = await connection.getMultipleAccountsInfo(batch, {
-                    dataSlice: { length: 0, offset: 0 },
-                });
-            }
+            const addresses = batch.map(toKitAddress);
+            const { value: results } =
+                dataMode === 'parsed'
+                    ? await rpc.getMultipleAccounts(addresses, { encoding: 'jsonParsed' }).send()
+                    : await rpc
+                          .getMultipleAccounts(addresses, {
+                              encoding: 'base64',
+                              ...(dataMode === 'skip' && { dataSlice: { length: 0, offset: 0 } }),
+                          })
+                          .send();
 
             for (let i = 0; i < batch.length; i++) {
                 const pubkey = batch[i];
@@ -297,17 +298,12 @@ async function fetchMultipleAccounts({
                 } else {
                     let space: number | undefined = undefined;
                     let parsedData: ParsedData | undefined;
-                    if ('parsed' in result.data) {
-                        const accountData: ParsedAccountData = result.data;
-                        space = result.data.space;
+                    // jsonParsed answers with base64 data for any account its parsers don't cover,
+                    // so an array here means "no parsed representation", not "raw mode".
+                    if (!Array.isArray(result.data)) {
+                        space = Number(result.data.space);
                         try {
-                            parsedData = await handleParsedAccountData(
-                                connection,
-                                pubkey,
-                                accountData,
-                                url,
-                                result.lamports,
-                            );
+                            parsedData = await handleParsedAccountData(rpc, pubkey, result.data, url, result.lamports);
                         } catch (error) {
                             Logger.error(error, {
                                 address: pubkey.toBase58(),
@@ -319,9 +315,9 @@ async function fetchMultipleAccounts({
                     // If we cannot parse account layout as native spl account
                     // then keep raw data for other components to decode
                     let rawData: Uint8Array | undefined;
-                    if (!parsedData && !('parsed' in result.data) && dataMode !== 'skip') {
-                        space = result.data.length;
-                        rawData = result.data;
+                    if (!parsedData && Array.isArray(result.data) && dataMode !== 'skip') {
+                        rawData = fromBase64(result.data[0]);
+                        space = rawData.length;
                     }
 
                     account = {
@@ -330,8 +326,8 @@ async function fetchMultipleAccounts({
                             raw: rawData,
                         },
                         executable: result.executable,
-                        lamports: result.lamports,
-                        owner: result.owner,
+                        lamports: Number(result.lamports),
+                        owner: toLegacyPublicKey(result.owner),
                         pubkey,
                         space,
                     };
@@ -360,14 +356,20 @@ async function fetchMultipleAccounts({
     }
 }
 
+// The kit-typed shape of a jsonParsed account's `data` when the RPC could parse it — the
+// `[base64, 'base64']` tuple fallback is excluded (callers branch on `Array.isArray` first).
+type ParsedAccountData = Exclude<AccountInfoWithJsonData['data'], readonly [string, string]>;
+
 async function handleParsedAccountData(
-    connection: Connection,
+    rpc: SolanaRpc,
     accountKey: PublicKey,
     accountData: ParsedAccountData,
     url: string,
-    lamports: number,
+    lamports: bigint,
 ): Promise<ParsedData | undefined> {
-    const info = create(accountData.parsed, ParsedInfo);
+    // kit upcasts every integral value in the jsonParsed payload to a bigint; the superstruct
+    // validators below expect plain-JSON numbers.
+    const info = create(withNumbersInsteadOfBigInts(accountData.parsed), ParsedInfo);
     // TODO: adopt @explorer/entity-inspector's accounts module (src/accounts: classifyAccountKindBase + kinds.ts; needs a browser-safe ./accounts subpath) instead of this inline kind switch
     switch (accountData.program) {
         case BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL: {
@@ -376,9 +378,15 @@ async function handleParsedAccountData(
             // Fetch program data to get program upgradeability info
             let programData: ProgramDataAccountInfo | undefined;
             if (parsed.type === 'program') {
-                const result = (await connection.getParsedAccountInfo(parsed.info.programData)).value;
-                if (result && 'parsed' in result.data && result.data.program === BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL) {
-                    const info = create(result.data.parsed, ParsedInfo);
+                const { value: result } = await rpc
+                    .getAccountInfo(toKitAddress(parsed.info.programData), { encoding: 'jsonParsed' })
+                    .send();
+                if (
+                    result &&
+                    !Array.isArray(result.data) &&
+                    result.data.program === BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL
+                ) {
+                    const info = create(withNumbersInsteadOfBigInts(result.data.parsed), ParsedInfo);
                     programData = create(info, ProgramDataAccount).info;
                 }
             }
@@ -396,9 +404,9 @@ async function handleParsedAccountData(
 
             const activation =
                 parsed.type === 'delegated' && stakeInfo.stake !== null
-                    ? await getStakeActivation(createSolanaRpc(url), {
+                    ? await getStakeActivation(rpc, {
                           delegation: stakeInfo.stake.delegation,
-                          lamports: BigInt(lamports),
+                          lamports,
                           rentExemptReserve: stakeInfo.meta.rentExemptReserve,
                       })
                     : undefined;

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -273,9 +273,12 @@ async function fetchMultipleAccounts({
             const addresses = batch.map(toKitAddress);
             const { value: results } =
                 dataMode === 'parsed'
-                    ? await rpc.getMultipleAccounts(addresses, { encoding: 'jsonParsed' }).send()
+                    ? await rpc
+                          .getMultipleAccounts(addresses, { commitment: 'confirmed', encoding: 'jsonParsed' })
+                          .send()
                     : await rpc
                           .getMultipleAccounts(addresses, {
+                              commitment: 'confirmed',
                               encoding: 'base64',
                               ...(dataMode === 'skip' && { dataSlice: { length: 0, offset: 0 } }),
                           })
@@ -379,7 +382,10 @@ async function handleParsedAccountData(
             let programData: ProgramDataAccountInfo | undefined;
             if (parsed.type === 'program') {
                 const { value: result } = await rpc
-                    .getAccountInfo(toKitAddress(parsed.info.programData), { encoding: 'jsonParsed' })
+                    .getAccountInfo(toKitAddress(parsed.info.programData), {
+                        commitment: 'confirmed',
+                        encoding: 'jsonParsed',
+                    })
                     .send();
                 if (
                     result &&


### PR DESCRIPTION


Replace the accounts provider's `web3.js` `Connection` usage with the Kit RPC client, including parsed, raw, and skip account fetch modes. Preserve legacy account shapes through explicit conversions and update tests to mock the RPC interface.

- Updated `AccountsProvider` tests to mock Kit RPC account fetching.
- Covered batching, unmount cancellation, React StrictMode remounts, cluster changes, skip-mode data slicing, and RPC failures.

Closes HOO-1264 (Refactor provider RPC usage (Kit MIgration))


