### PR TITLE
feat(search): match feature gates by SIMD number

### DIFF
--- a/app/features/search/lib/__tests__/parse-simd-number.test.ts
+++ b/app/features/search/lib/__tests__/parse-simd-number.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSimdNumber, parseSimdQuery } from '../parse-simd-number';
+
+describe('parseSimdQuery', () => {
+    it.each([
+        ['148', 148],
+        ['0148', 148],
+        ['00148', 148],
+        ['simd148', 148],
+        ['SIMD0148', 148],
+        ['simd 148', 148],
+        ['SIMD-0148', 148],
+        ['simd - 148', 148],
+        ['  simd 148  ', 148],
+        ['  148  ', 148],
+        ['0', 0],
+    ])('should parse "%s" as SIMD %i', (input, expected) => {
+        expect(parseSimdQuery(input)).toBe(expected);
+    });
+
+    it.each([
+        ['empty string', ''],
+        ['whitespace', '  '],
+        ['the bare prefix', 'simd'],
+        ['the prefix and a separator', 'simd-'],
+        ['non-numeric', 'simd-abc'],
+        ['a title', 'MoveStake'],
+        ['a negative number', '-148'],
+        ['a float', '148.5'],
+        ['a hex literal', '0x10'],
+        ['exponent notation', '1e3'],
+        ['digits split by a space', '14 8'],
+    ])('should return undefined for %s', (_label, input) => {
+        expect(parseSimdQuery(input)).toBeUndefined();
+    });
+});
+
+describe('parseSimdNumber', () => {
+    it.each([
+        ['148', 148],
+        ['0148', 148],
+        [' 0189', 189],
+        ['0337 ', 337],
+    ])('should parse the registry entry "%s" as SIMD %i', (input, expected) => {
+        expect(parseSimdNumber(input)).toBe(expected);
+    });
+
+    it.each([
+        ['an empty entry', ''],
+        ['a whitespace-only entry', ' '],
+        ['a prefixed entry', 'simd148'],
+        ['a range', '148-149'],
+    ])('should return undefined for %s', (_label, input) => {
+        expect(parseSimdNumber(input)).toBeUndefined();
+    });
+
+    it('should compare the padded and unpadded spellings equal', () => {
+        expect(parseSimdNumber('0337')).toBe(parseSimdNumber('337'));
+        expect(parseSimdNumber(' 0189')).toBe(parseSimdQuery('SIMD-189'));
+    });
+});

--- a/app/features/search/lib/parse-simd-number.ts
+++ b/app/features/search/lib/parse-simd-number.ts
@@ -1,0 +1,17 @@
+const SIMD_PREFIX = 'simd';
+
+export function parseSimdQuery(query: string): number | undefined {
+    const lower = query.trim().toLowerCase();
+    if (!lower.startsWith(SIMD_PREFIX)) return parseSimdNumber(lower);
+
+    const rest = lower.slice(SIMD_PREFIX.length).trimStart();
+    return parseSimdNumber(rest.startsWith('-') ? rest.slice(1) : rest);
+}
+
+/** Registry entries are zero-padded and may carry upstream whitespace, so both sides parse to a number. */
+export function parseSimdNumber(value: string): number | undefined {
+    const digits = value.trim();
+    // eslint-disable-next-line no-restricted-syntax -- Number() alone accepts 1e3, 0x10, 1.0
+    if (!/^\d+$/.test(digits)) return undefined;
+    return Number(digits);
+}

--- a/app/features/search/model/__tests__/feature-gate-search-provider.test.ts
+++ b/app/features/search/model/__tests__/feature-gate-search-provider.test.ts
@@ -1,0 +1,115 @@
+import type { FeatureGate } from '@entities/feature-gate';
+import { FEATURE_GATES } from '@entities/feature-gate';
+import { describe, expect, it } from 'vitest';
+
+import { parseSimdNumber } from '../../lib/parse-simd-number';
+import { featureGateSearchProvider } from '../feature-gate-search-provider';
+import { createSearchContext } from './provider-test-utils';
+
+const ctx = createSearchContext();
+
+// A script regenerates the registry from upstream, so these cases are derived
+// from the data rather than naming gates that may move.
+const gatesBySimd = new Map<number, FeatureGate[]>();
+for (const gate of FEATURE_GATES) {
+    for (const entry of gate.simds) {
+        const simd = parseSimdNumber(entry);
+        if (simd === undefined) continue;
+        gatesBySimd.set(simd, [...(gatesBySimd.get(simd) ?? []), gate]);
+    }
+}
+
+/**
+ * A SIMD number carried by at least `minimumGates` gates and absent from every
+ * title, so the title branch cannot add rows and an exact assertion holds.
+ */
+function simdReachableOnlyByNumber(minimumGates: number): [number, FeatureGate[]] {
+    const found = [...gatesBySimd].find(
+        ([simd, gates]) => gates.length >= minimumGates && !titleContains(String(simd)),
+    );
+    if (!found) throw new Error(`no SIMD number on ${minimumGates}+ gates is absent from every title`);
+    return found;
+}
+
+function titleContains(text: string): boolean {
+    return FEATURE_GATES.some(gate => gate.title.includes(text));
+}
+
+function titlesFor(query: string): string[] {
+    const results = featureGateSearchProvider.search(query, ctx);
+    if (!Array.isArray(results)) throw new Error('a local provider must return synchronously');
+    return results.flatMap(group => group.options.map(option => option.label));
+}
+
+describe('featureGateSearchProvider', () => {
+    it('should match a title substring', () => {
+        const [gate] = FEATURE_GATES;
+        expect(titlesFor(gate.title)).toContain(gate.title);
+    });
+
+    it('should reach a gate whose title omits its SIMD number', () => {
+        const [simd, gates] = simdReachableOnlyByNumber(1);
+        expect(titlesFor(String(simd))).toEqual(gates.map(gate => gate.title));
+    });
+
+    it('should return the Feature Gates group with an address option per gate', () => {
+        const [simd, gates] = simdReachableOnlyByNumber(1);
+        expect(featureGateSearchProvider.search(String(simd), ctx)).toEqual([
+            {
+                label: 'Feature Gates',
+                options: gates.map(gate => ({
+                    label: gate.title,
+                    pathname: `/address/${gate.key}`,
+                    sublabel: gate.key,
+                    type: 'address',
+                    value: [gate.key],
+                })),
+            },
+        ]);
+    });
+
+    it('should list every gate that shares a SIMD number', () => {
+        const [simd, gates] = simdReachableOnlyByNumber(2);
+        expect(gates.length).toBeGreaterThan(1);
+        expect(titlesFor(String(simd))).toEqual(gates.map(gate => gate.title));
+    });
+
+    it('should accept every spelling of a SIMD number the registry carries', () => {
+        const [simd, gates] = simdReachableOnlyByNumber(1);
+        const expected = gates.map(gate => gate.title);
+        for (const query of [`0${simd}`, `simd${simd}`, `simd ${simd}`, `SIMD-${simd}`, `simd - ${simd}`]) {
+            expect(titlesFor(query)).toEqual(expected);
+        }
+    });
+
+    it('should not match a SIMD number as a prefix', () => {
+        const [simd] = simdReachableOnlyByNumber(1);
+
+        const shorter = Math.floor(simd / 10);
+        if (!gatesBySimd.has(shorter) && !titleContains(String(shorter))) {
+            expect(titlesFor(`simd${shorter}`)).toEqual([]);
+        }
+
+        let longer = simd * 10;
+        while (gatesBySimd.has(longer)) longer++;
+        expect(titlesFor(`simd${longer}`)).toEqual([]);
+    });
+
+    it('should return empty for a SIMD number no gate carries', () => {
+        const absent = Math.max(...gatesBySimd.keys()) + 1;
+        expect(titlesFor(`simd${absent}`)).toEqual([]);
+    });
+
+    it('should return empty for a block-sized number', () => {
+        expect(titlesFor('355000000')).toEqual([]);
+    });
+
+    it('should not match the empty SIMD entries the registry carries', () => {
+        expect(FEATURE_GATES.some(gate => gate.simds.some(entry => parseSimdNumber(entry) === undefined))).toBe(true);
+        expect(titlesFor('simd 0')).toEqual([]);
+    });
+
+    it('should ignore a non-numeric SIMD query', () => {
+        expect(titlesFor('simd-abc')).toEqual([]);
+    });
+});

--- a/app/features/search/model/__tests__/registry.test.ts
+++ b/app/features/search/model/__tests__/registry.test.ts
@@ -33,4 +33,12 @@ describe('searchProviders registry', () => {
             expect(new Set(priorities).size).toBe(priorities.length);
         },
     );
+
+    // A SIMD number is often an epoch or block number too, and the epoch or
+    // block is the likelier intent.
+    it('should rank feature gates below blocks and epochs', () => {
+        const names = searchProviders.local.map(p => p.name);
+        expect(names.indexOf('feature-gate')).toBeGreaterThan(names.indexOf('block'));
+        expect(names.indexOf('feature-gate')).toBeGreaterThan(names.indexOf('epoch'));
+    });
 });

--- a/app/features/search/model/feature-gate-search-provider.ts
+++ b/app/features/search/model/feature-gate-search-provider.ts
@@ -1,14 +1,19 @@
 import { FEATURE_GATES } from '@entities/feature-gate';
 
 import { SearchGroup } from '../lib/filter-tabs';
+import { parseSimdNumber, parseSimdQuery } from '../lib/parse-simd-number';
 import type { SearchOptions, SearchProvider } from '../lib/types';
 
 /**
- * Local search provider that matches Solana feature gates by title.
+ * Local search provider that matches Solana feature gates by title or by SIMD
+ * number.
  *
  * Feature gates control the activation of runtime features across the
  * cluster. This provider searches the static `feature-gates.json` registry
  * and links to each gate's account page.
+ *
+ * Older gates carry no SIMD in their title, so the number is the only route to
+ * them.
  *
  * @example
  * // Type a feature gate name into the search bar:
@@ -17,13 +22,18 @@ import type { SearchOptions, SearchProvider } from '../lib/types';
 export const featureGateSearchProvider: SearchProvider = {
     kind: 'local',
     name: 'feature-gate',
-    priority: 30,
+    // A SIMD number is often an epoch number too, and the epoch is the likelier intent.
+    priority: 5,
     search(query: string): SearchOptions[] {
         if (query.length < 2) return [];
 
-        const features = FEATURE_GATES.filter(
-            feature => feature.key && feature.title.toUpperCase().includes(query.toUpperCase()),
-        );
+        const queriedSimd = parseSimdQuery(query);
+        const upperQuery = query.toUpperCase();
+
+        const features = FEATURE_GATES.filter(feature => {
+            if (feature.title.toUpperCase().includes(upperQuery)) return true;
+            return queriedSimd !== undefined && feature.simds.some(entry => parseSimdNumber(entry) === queriedSimd);
+        });
 
         if (features.length === 0) return [];
 

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -25,7 +25,7 @@
 | Dynamic | `/address/[address]/security` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/slot-hashes` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/stake-history` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/subscriptions` | 470 kB | 860 kB |
+| Dynamic | `/address/[address]/subscriptions` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/token-extensions` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/tokens` | 480 kB | 880 kB |
 | Dynamic | `/address/[address]/transfers` | 480 kB | 880 kB |
@@ -60,7 +60,7 @@
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 890 B | 410 kB |
+| Static | `/tos` | 880 B | 410 kB |
 | Dynamic | `/tx/[signature]` | 510 kB | 910 kB |
 | Dynamic | `/tx/[signature]/inspect` | 450 kB | 850 kB |
 | Static | `/tx/inspector` | 450 kB | 850 kB |


### PR DESCRIPTION
## Description

Feature gates registered before the SIMD process carry no SIMD number in their title — `MoveStake and MoveLamports` is SIMD 148 — so the search bar could not reach them at all. This matches the registry's `simds` field alongside the title.

Accepted spellings: `148`, `0148`, `simd148`, `simd 148`, `SIMD-0148`. Registry entries are zero-padded and carry stray upstream whitespace (`['0178', ' 0189', ' 0377']`), so both sides of the comparison parse to a decimal number.

A SIMD number matches exactly, not as a prefix, because it is frequently a valid epoch or block number too — 35 of the numbers now reachable are past Solana epochs. For the same reason the provider's priority drops below the block and epoch providers in the local tier, so typing `219` still lists `Epoch #219` above the feature gate.

Query parsing lives in `app/features/search/lib/parse-simd-number.ts`, beside the existing `parse-natural-number.ts`, where it is covered without touching the registry. `parseNaturalNumber` itself cannot serve here: it rejects zero-padding, which the registry stores.

## Type of change

-   [x] New feature

## Testing

Manual testing on the preview deployment — open the search bar and type the query:

- [`148` — a gate reachable only by its number](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → Feature Gates group with `MoveStake and MoveLamports`, whose title never mentions 148
- [`0148`, `simd148`, `simd 148`, `SIMD-0148` — every spelling](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → each returns that same single row
- [`162` — one number, two gates](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → two rows, both titled `Remove accounts executable flag checks`, on different addresses
- [`219` — a SIMD number that is also an epoch](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → `Epoch #219` listed above the Feature Gates group
- [`simd17` — a prefix, not a number](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → nothing. SIMD 173 and 174 both exist, but a prefix of a SIMD number must not reach them
- [`17` — the title path is untouched](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → still finds `SIMD-0178/0189/0377: Enables deployment and execution of SBPFv3 programs`, matched on the digits inside its title exactly as before this PR
- [`355000000` — a block number](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → block result only, no Feature Gates group
- [`MoveStake` — the title path still works](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/) → unchanged behaviour from before this PR

Destination pages the rows above navigate to:

- [SIMD 148 — MoveStake and MoveLamports](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/address/7bTK6Jis8Xpfrs8ZoUfiMDPazTcdPcTWheZFJTA5Z6X4)
- [SIMD 162 — first of the two gates](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/address/FfgtauHUWKeXTzjXkua9Px4tNGBFHKZ9WaigM5VbbzFx)
- [SIMD 162 — second of the two gates](https://explorer-git-fork-hoodieshq-feat-featu-aaf29e-solana-foundation.vercel.app/address/FXs1zh47QbNnhXcnB6YiAQoJ4sGB91tKF3UFHLcKT7PM)

## Related Issues

Closes [HOO-1185](https://linear.app/solana-fndn/issue/HOO-1185/support-simd-number-searches-in-feature-gate-search)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

Two things worth a reviewer's eye:

- The registry carries SIMD 0162 twice, on two keys, under the identical title `Remove accounts executable flag checks`. Querying `162` therefore returns two rows that only the address sublabel distinguishes. Both rows are legitimate accounts, so this PR leaves them as-is.
- The provider tests derive their cases from the committed `feature-gates.json` rather than from fixtures, since `scripts/feature-gates/` regenerates that file from upstream. Each derivation throws with a specific message if the registry stops carrying the shape it needs, so a regeneration that invalidates a case fails loudly instead of passing silently.


