### PR TITLE
refactor(providers): move tokens and rewards providers off web3.js Connection

### DIFF
--- a/app/providers/accounts/__tests__/rewards.spec.tsx
+++ b/app/providers/accounts/__tests__/rewards.spec.tsx
@@ -1,0 +1,131 @@
+import { FetchStatus } from '@providers/cache';
+import { PublicKey } from '@solana/web3.js';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Cluster, clusterSelection, clusterUrl } from '@utils/cluster';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { useClusterMock, getEpochInfo, getInflationReward, getRpc } = vi.hoisted(() => {
+    const getEpochInfo = vi.fn();
+    const getInflationReward = vi.fn();
+    return {
+        getEpochInfo,
+        getInflationReward,
+        getRpc: vi.fn((_url: string) => ({
+            getEpochInfo: (...args: unknown[]) => ({ send: () => getEpochInfo(...args) }),
+            getInflationReward: (...args: unknown[]) => ({ send: () => getInflationReward(...args) }),
+        })),
+        useClusterMock: vi.fn(),
+    };
+});
+
+vi.mock('@providers/cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('@providers/cluster')>();
+    return { ...actual, useCluster: useClusterMock };
+});
+
+vi.mock('@entities/cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('@entities/cluster')>();
+    return { ...actual, getRpc };
+});
+
+vi.mock('@/app/shared/lib/logger', () => ({
+    Logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { RewardsProvider, useFetchRewards, useRewards } from '../rewards';
+
+const ADDRESS = PublicKey.default.toBase58();
+const CURRENT_EPOCH = 10n;
+
+/** The shape kit returns for a single inflation reward: every integral field is a bigint. */
+function makeInflationReward(epoch: bigint) {
+    return {
+        amount: 12345n,
+        commission: 5,
+        effectiveSlot: epoch * 100n,
+        epoch,
+        postBalance: 999999n,
+    };
+}
+
+function TestComponent() {
+    const entry = useRewards(ADDRESS);
+    const fetchRewards = useFetchRewards();
+    // `useFetchRewards` closes over the cache state, so its identity changes on every dispatch;
+    // firing it unguarded would re-enter on its own result.
+    const fetched = React.useRef(false);
+    React.useEffect(() => {
+        if (fetched.current) return;
+        fetched.current = true;
+        fetchRewards(new PublicKey(ADDRESS));
+    }, [fetchRewards]);
+
+    if (!entry) return null;
+    return (
+        <div>
+            <span data-testid="fetch-status">{entry.status}</span>
+            <span data-testid="reward-count">{entry.data?.rewards?.length ?? 0}</span>
+            <span data-testid="highest-epoch">{String(entry.data?.highestFetchedEpoch)}</span>
+            <span data-testid="reward-json">{JSON.stringify(entry.data?.rewards?.[0] ?? null)}</span>
+        </div>
+    );
+}
+
+function renderRewards() {
+    render(
+        <RewardsProvider>
+            <TestComponent />
+        </RewardsProvider>,
+    );
+    return waitFor(() => expect(screen.getByTestId('fetch-status').textContent).toBe(String(FetchStatus.Fetched)));
+}
+
+describe('RewardsProvider', () => {
+    beforeEach(() => {
+        const selection = clusterSelection(Cluster.Devnet);
+        useClusterMock.mockReturnValue({ ...selection, selection, url: clusterUrl(selection) });
+        getEpochInfo.mockResolvedValue({ epoch: CURRENT_EPOCH });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+    });
+
+    it('should expose rewards as numbers so they survive JSON serialization', async () => {
+        getInflationReward.mockImplementation((_addresses, config) => [makeInflationReward(config.epoch)]);
+
+        await renderRewards();
+
+        // A bigint anywhere in the payload would have thrown inside JSON.stringify.
+        expect(JSON.parse(screen.getByTestId('reward-json').textContent ?? 'null')).toEqual({
+            amount: 12345,
+            commission: 5,
+            effectiveSlot: 900,
+            epoch: 9,
+            postBalance: 999999,
+        });
+        expect(screen.getByTestId('highest-epoch').textContent).toBe('9');
+    });
+
+    it('should key rewards by epoch, one entry per epoch back to genesis', async () => {
+        getInflationReward.mockImplementation((_addresses, config) => [makeInflationReward(config.epoch)]);
+
+        await renderRewards();
+
+        // Epoch 9 down to 0 — the page size is 15, but there are no negative epochs to request.
+        expect(screen.getByTestId('reward-count').textContent).toBe('10');
+    });
+
+    it('should drop a single failed epoch without failing the whole page', async () => {
+        getInflationReward.mockImplementation((_addresses, config) => {
+            if (config.epoch === 5n) throw new Error('node refused this epoch');
+            return [makeInflationReward(config.epoch)];
+        });
+
+        await renderRewards();
+
+        expect(screen.getByTestId('reward-count').textContent).toBe('9');
+    });
+});

--- a/app/providers/accounts/__tests__/tokens.spec.tsx
+++ b/app/providers/accounts/__tests__/tokens.spec.tsx
@@ -1,33 +1,63 @@
 import { FetchStatus } from '@providers/cache';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Cluster, clusterSelection, clusterUrl } from '@utils/cluster';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { useClusterMock } = vi.hoisted(() => ({ useClusterMock: vi.fn() }));
+const { useClusterMock, getTokenAccountsByOwner, getRpc } = vi.hoisted(() => {
+    const getTokenAccountsByOwner = vi.fn();
+    return {
+        getRpc: vi.fn((_url: string) => ({
+            getTokenAccountsByOwner: (...args: unknown[]) => ({ send: () => getTokenAccountsByOwner(...args) }),
+        })),
+        getTokenAccountsByOwner,
+        useClusterMock: vi.fn(),
+    };
+});
+
 vi.mock('@providers/cluster', async importOriginal => {
     const actual = await importOriginal<typeof import('@providers/cluster')>();
     return { ...actual, useCluster: useClusterMock };
+});
+
+vi.mock('@entities/cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('@entities/cluster')>();
+    return { ...actual, getRpc };
 });
 
 vi.mock('@/app/shared/lib/logger', () => ({
     Logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
-import { TokensProvider, useAccountOwnedTokens, useFetchAccountOwnedTokens } from '../tokens';
+import {
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    TokensProvider,
+    useAccountOwnedTokens,
+    useFetchAccountOwnedTokens,
+} from '../tokens';
 
 const OWNER = PublicKey.default.toBase58();
 const MINT = new PublicKey('So11111111111111111111111111111111111111112').toBase58();
 const TOKEN_ACCOUNT_PUBKEY = new PublicKey('SysvarC1ock11111111111111111111111111111111');
 
-// Minimal shape that satisfies the TokenAccountInfo superstruct schema (mint/owner coerced from base58).
+/**
+ * Minimal shape that satisfies the TokenAccountInfo superstruct schema (mint/owner coerced from
+ * base58), plus a token-2022 extension.
+ *
+ * kit upcasts every integral field of a jsonParsed response to a bigint unless its key path is
+ * allow-listed. `tokenAmount.decimals` is on that list and stays a number; nothing under
+ * `extensions[].state` is, so `withheldAmount` arrives as a bigint even though the extension
+ * schemas type it as `number()`.
+ */
 function makeParsedTokenAccount(pubkey: PublicKey) {
     return {
         account: {
             data: {
                 parsed: {
                     info: {
+                        extensions: [{ extension: 'transferFeeAmount', state: { withheldAmount: 42n } }],
                         isNative: false,
                         mint: MINT,
                         owner: OWNER,
@@ -37,7 +67,7 @@ function makeParsedTokenAccount(pubkey: PublicKey) {
                 },
             },
         },
-        pubkey,
+        pubkey: pubkey.toBase58(),
     };
 }
 
@@ -58,6 +88,9 @@ function TestComponent() {
                     {t.info.mint.toBase58()}
                 </span>
             ))}
+            <span data-testid="first-extensions">
+                {JSON.stringify(entry.data?.tokens?.[0]?.info.extensions ?? null)}
+            </span>
         </div>
     );
 }
@@ -74,13 +107,10 @@ describe('should fetch account token holdings without enrichment', () => {
     });
 
     it('should return every token account without enriching metadata', async () => {
-        vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
-            // Legacy SPL program -> one holding. Token-2022 -> none.
-            .mockResolvedValueOnce({
-                context: { slot: 0 },
-                value: [makeParsedTokenAccount(TOKEN_ACCOUNT_PUBKEY)],
-            } as any)
-            .mockResolvedValueOnce({ context: { slot: 0 }, value: [] } as any);
+        // Legacy SPL program -> one holding. Token-2022 -> none.
+        getTokenAccountsByOwner
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [makeParsedTokenAccount(TOKEN_ACCOUNT_PUBKEY)] })
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [] });
 
         render(
             <TokensProvider>
@@ -93,13 +123,53 @@ describe('should fetch account token holdings without enrichment', () => {
         expect(screen.getByTestId('token-row').textContent).toBe(MINT);
     });
 
+    it('should hand extension state to consumers as numbers, not bigints', async () => {
+        getTokenAccountsByOwner
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [makeParsedTokenAccount(TOKEN_ACCOUNT_PUBKEY)] })
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [] });
+
+        render(
+            <TokensProvider>
+                <TestComponent />
+            </TokensProvider>,
+        );
+
+        await waitFor(() => expect(screen.getByTestId('fetch-status').textContent).toBe(String(FetchStatus.Fetched)));
+        // A bigint anywhere in the payload would have thrown inside JSON.stringify.
+        expect(JSON.parse(screen.getByTestId('first-extensions').textContent ?? 'null')).toEqual([
+            { extension: 'transferFeeAmount', state: { withheldAmount: 42 } },
+        ]);
+    });
+
+    it('should query both token programs and merge the holdings', async () => {
+        getTokenAccountsByOwner
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [makeParsedTokenAccount(TOKEN_ACCOUNT_PUBKEY)] })
+            .mockResolvedValueOnce({
+                context: { slot: 0n },
+                value: [makeParsedTokenAccount(new PublicKey(new Uint8Array(32).fill(7)))],
+            });
+
+        render(
+            <TokensProvider>
+                <TestComponent />
+            </TokensProvider>,
+        );
+
+        await waitFor(() => expect(screen.getByTestId('fetch-status').textContent).toBe(String(FetchStatus.Fetched)));
+        expect(screen.getByTestId('token-count').textContent).toBe('2');
+        expect(getTokenAccountsByOwner.mock.calls.map(call => call[1].programId)).toEqual([
+            TOKEN_PROGRAM_ID.toBase58(),
+            TOKEN_2022_PROGRAM_ID.toBase58(),
+        ]);
+    });
+
     it('should not cap the number of holdings at 101', async () => {
         const many = Array.from({ length: 150 }, (_, i) =>
             makeParsedTokenAccount(new PublicKey(new Uint8Array(32).fill((i % 254) + 1))),
         );
-        vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
-            .mockResolvedValueOnce({ context: { slot: 0 }, value: many } as any)
-            .mockResolvedValueOnce({ context: { slot: 0 }, value: [] } as any);
+        getTokenAccountsByOwner
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: many })
+            .mockResolvedValueOnce({ context: { slot: 0n }, value: [] });
 
         render(
             <TokensProvider>

--- a/app/providers/accounts/rewards.tsx
+++ b/app/providers/accounts/rewards.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import { getRpc } from '@entities/cluster';
 import { ActionType } from '@providers/block';
 import * as Cache from '@providers/cache';
 import { FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, InflationReward, PublicKey } from '@solana/web3.js';
+import { InflationReward, PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
+import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 
 const REWARDS_AVAILABLE_EPOCH = new Map<Cluster, number>([
     [Cluster.MainnetBeta, 132],
@@ -89,12 +91,13 @@ async function fetchRewards(
     });
 
     const lowestAvailableEpoch = REWARDS_AVAILABLE_EPOCH.get(cluster) || 0;
-    const connection = new Connection(url);
+    const rpc = getRpc(url);
+    const address = toKitAddress(pubkey);
 
     if (!fromEpoch) {
         try {
-            const epochInfo = await connection.getEpochInfo();
-            fromEpoch = epochInfo.epoch - 1;
+            const epochInfo = await rpc.getEpochInfo().send();
+            fromEpoch = Number(epochInfo.epoch) - 1;
         } catch (error) {
             if (cluster !== Cluster.Custom) {
                 Logger.error(error, { url });
@@ -113,10 +116,20 @@ async function fetchRewards(
         }
     }
 
-    const getInflationReward = async (epoch: number) => {
+    const getInflationReward = async (epoch: number): Promise<InflationReward | null> => {
         try {
-            const result = await connection.getInflationReward([pubkey], epoch);
-            return result[0];
+            const [reward] = await rpc.getInflationReward([address], { epoch: BigInt(epoch) }).send();
+            // kit returns lamports, slots and epochs as bigints; the cached `Rewards` shape and
+            // `reconcile`'s epoch-keyed Map are numbers, as the RPC's own JSON is.
+            return reward
+                ? {
+                      amount: Number(reward.amount),
+                      commission: reward.commission,
+                      effectiveSlot: Number(reward.effectiveSlot),
+                      epoch: Number(reward.epoch),
+                      postBalance: Number(reward.postBalance),
+                  }
+                : null;
         } catch (error) {
             if (cluster !== Cluster.Custom) {
                 Logger.error(error, { url });

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -1,16 +1,19 @@
 'use client';
 
+import { getRpc } from '@entities/cluster';
 import { useAccountInfo, useFetchAccountInfo } from '@providers/accounts';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { TokenAccountInfo } from '@validators/accounts/token';
 import React from 'react';
 import { create } from 'superstruct';
 
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
 import { Logger } from '@/app/shared/lib/logger';
+import { toKitAddress, toLegacyPublicKey } from '@/app/shared/lib/web3js-compat';
 import { getCurrentTokenScaledUiAmountMultiplier } from '@/app/utils/token-info';
 import { MintAccountInfo } from '@/app/validators/accounts/token';
 
@@ -63,22 +66,27 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
     let status;
     let data;
     try {
-        const { value: tokenAccounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
-            programId: TOKEN_PROGRAM_ID,
-        });
-        const { value: token2022Accounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(
-            pubkey,
-            {
-                programId: TOKEN_2022_PROGRAM_ID,
-            },
-        );
+        const rpc = getRpc(url);
+        const owner = toKitAddress(pubkey);
+        const fetchByProgram = (programId: PublicKey) =>
+            rpc
+                .getTokenAccountsByOwner(
+                    owner,
+                    { programId: toKitAddress(programId) },
+                    { commitment: 'processed', encoding: 'jsonParsed' },
+                )
+                .send();
+
+        const [{ value: tokenAccounts }, { value: token2022Accounts }] = await Promise.all([
+            fetchByProgram(TOKEN_PROGRAM_ID),
+            fetchByProgram(TOKEN_2022_PROGRAM_ID),
+        ]);
 
         // Return raw holdings only. Symbol/logo/name are enriched lazily per visible row via useTokenInfo
         // (the app-wide batched token-info provider), so there is no upfront bulk metadata fetch and no cap.
-        const tokens: TokenInfoWithPubkey[] = tokenAccounts.concat(token2022Accounts).map(accountInfo => {
-            const parsedInfo = accountInfo.account.data.parsed.info;
-            const info = create(parsedInfo, TokenAccountInfo);
-            return { info, pubkey: accountInfo.pubkey };
+        const tokens: TokenInfoWithPubkey[] = [...tokenAccounts, ...token2022Accounts].map(accountInfo => {
+            const info = create(withNumbersInsteadOfBigInts(accountInfo.account.data.parsed.info), TokenAccountInfo);
+            return { info, pubkey: toLegacyPublicKey(accountInfo.pubkey) };
         });
 
         data = {


### PR DESCRIPTION
Replaces the `new Connection(...)` constructions in the tokens and rewards account sub-providers with the central kit RPC accessor, swapping the transport while leaving the providers' public APIs and cache semantics unchanged.

Token holdings now query both token programs concurrently rather than sequentially. kit upcasts integral fields of a jsonParsed response to bigint unless the key path is allow-listed, so token-2022 extension state runs through `withNumbersInsteadOfBigInts` and inflation rewards are mapped field by field.

Closes: HOO-1318