### PR TITLE
refactor(instruction-card): migrate address lookup table cards to the surface

### DIFF
--- a/app/components/instruction/AddressLookupTableDetailsCard.tsx
+++ b/app/components/instruction/AddressLookupTableDetailsCard.tsx
@@ -1,6 +1,7 @@
+import type { InstructionNode } from '@entities/instruction-card';
 import { InstructionDetailsProps } from '@features/transaction';
 import { useCluster } from '@providers/cluster';
-import React from 'react';
+import { ParsedInfo } from '@validators/index';
 import { create } from 'superstruct';
 
 import { CloseLookupTableDetailsCard } from '@/app/components/instruction/address-lookup-table/CloseLookupTableDetails';
@@ -9,7 +10,6 @@ import { DeactivateLookupTableDetailsCard } from '@/app/components/instruction/a
 import { ExtendLookupTableDetailsCard } from '@/app/components/instruction/address-lookup-table/ExtendLookupTableDetails';
 import { FreezeLookupTableDetailsCard } from '@/app/components/instruction/address-lookup-table/FreezeLookupTableDetails';
 import {
-    AddressLookupTableInstructionInfo,
     CloseLookupTableInfo,
     CreateLookupTableInfo,
     DeactivateLookupTableInfo,
@@ -23,23 +23,36 @@ export function AddressLookupTableDetailsCard(props: InstructionDetailsProps) {
     const { ix } = props;
     const { url } = useCluster();
 
+    const node: InstructionNode = {
+        childIndex: props.childIndex,
+        index: props.index,
+        innerCards: props.innerCards,
+        ix,
+        programId: ix.programId,
+    };
+
     try {
-        const parsed = create(ix.parsed, AddressLookupTableInstructionInfo);
+        const parsed = create(ix.parsed, ParsedInfo);
         switch (parsed.type) {
             case 'createLookupTable': {
-                return <CreateLookupTableDetailsCard {...props} info={parsed.info as CreateLookupTableInfo} />;
+                const info = create(parsed.info, CreateLookupTableInfo);
+                return <CreateLookupTableDetailsCard info={info} node={node} />;
             }
             case 'extendLookupTable': {
-                return <ExtendLookupTableDetailsCard {...props} info={parsed.info as ExtendLookupTableInfo} />;
+                const info = create(parsed.info, ExtendLookupTableInfo);
+                return <ExtendLookupTableDetailsCard info={info} node={node} />;
             }
             case 'freezeLookupTable': {
-                return <FreezeLookupTableDetailsCard {...props} info={parsed.info as FreezeLookupTableInfo} />;
+                const info = create(parsed.info, FreezeLookupTableInfo);
+                return <FreezeLookupTableDetailsCard info={info} node={node} />;
             }
             case 'deactivateLookupTable': {
-                return <DeactivateLookupTableDetailsCard {...props} info={parsed.info as DeactivateLookupTableInfo} />;
+                const info = create(parsed.info, DeactivateLookupTableInfo);
+                return <DeactivateLookupTableDetailsCard info={info} node={node} />;
             }
             case 'closeLookupTable': {
-                return <CloseLookupTableDetailsCard {...props} info={parsed.info as CloseLookupTableInfo} />;
+                const info = create(parsed.info, CloseLookupTableInfo);
+                return <CloseLookupTableDetailsCard info={info} node={node} />;
             }
             default:
                 return <UnknownDetailsCard {...props} />;

--- a/app/components/instruction/__tests__/AddressLookupTableDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/AddressLookupTableDetailsCard.spec.tsx
@@ -1,0 +1,131 @@
+import { TxInstructionSurface } from '@entities/instruction-card';
+import { AddressLookupTableProgram, type ParsedInstruction, type ParsedTransaction } from '@solana/web3.js';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(),
+    useRouter: vi.fn(() => ({ push: vi.fn() })),
+    useSearchParams: vi.fn(() => ({ get: vi.fn(), has: vi.fn(), toString: () => '' })),
+}));
+
+vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: vi.fn() } }));
+
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+import { Logger } from '@/app/shared/lib/logger';
+
+import { AddressLookupTableDetailsCard } from '../AddressLookupTableDetailsCard';
+
+const A = {
+    authority: '3EbFtRfKRMTrhPrRQjxbfWCB6NUyTQxwsWTKQFVKgNbb',
+    entry: '5rATVSqZjaHzMqSJmnbEQNmSJhaKMwsA7Zx2KfBWZBS4',
+    payer: '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM',
+    recipient: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+    system: '11111111111111111111111111111111',
+    table: '7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2',
+} as const;
+
+const TABLE = { lookupTableAccount: A.table, lookupTableAuthority: A.authority };
+
+const CREATE = {
+    ...TABLE,
+    bumpSeed: 255,
+    payerAccount: A.payer,
+    recentSlot: 123_456_789,
+    systemProgram: A.system,
+};
+
+/** Freeze, Deactivate and Close render identical rows, so a mis-routed type still looks plausible. */
+const DISPATCH: Array<{ info: unknown; title: string; type: string }> = [
+    { info: CREATE, title: 'Address Lookup Table: Create Lookup Table', type: 'createLookupTable' },
+    {
+        info: { ...TABLE, newAddresses: [A.entry] },
+        title: 'Address Lookup Table: Extend Lookup Table',
+        type: 'extendLookupTable',
+    },
+    { info: TABLE, title: 'Address Lookup Table: Freeze Lookup Table', type: 'freezeLookupTable' },
+    { info: TABLE, title: 'Address Lookup Table: Deactivate Lookup Table', type: 'deactivateLookupTable' },
+    {
+        info: { ...TABLE, recipient: A.recipient },
+        title: 'Address Lookup Table: Close Lookup Table',
+        type: 'closeLookupTable',
+    },
+];
+
+describe('instruction::AddressLookupTableDetailsCard dispatch', () => {
+    beforeEach(() => {
+        vi.mocked(Logger.error).mockClear();
+    });
+
+    it.each(DISPATCH)('should render $title for $type', async ({ info, title, type }) => {
+        renderCard(info, type);
+
+        await waitFor(() => {
+            expect(screen.getByText(title)).toBeInTheDocument();
+        });
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    // A single union used to validate every type, and `type()` let the loosest member win —
+    // so extend payloads were checked against the freeze schema and `newAddresses` reached
+    // the card as raw strings. Pin the coercion each type's own schema now performs.
+    it('should coerce the extend addresses through the extend schema', async () => {
+        renderCard({ ...TABLE, newAddresses: [A.entry] }, 'extendLookupTable');
+
+        await waitFor(() => {
+            expect(screen.getByText('Address Lookup Table: Extend Lookup Table')).toBeInTheDocument();
+        });
+        // eslint-disable-next-line testing-library/no-node-access -- an address has no role to query by
+        expect(document.querySelector(`[data-address="${A.entry}"]`)).toBeInTheDocument();
+    });
+
+    it('should fall back to the unknown card for an unrecognized type', async () => {
+        renderCard(TABLE, 'resizeLookupTable');
+
+        await waitFor(() => {
+            expect(screen.getByText('Address Lookup Table Program: Unknown Instruction')).toBeInTheDocument();
+        });
+    });
+
+    // Each type is now validated against its own schema, so a payload missing a
+    // field that type requires no longer slips through a looser sibling.
+    it('should fall back and report when a payload misses a required field', async () => {
+        renderCard(TABLE, 'closeLookupTable');
+
+        await waitFor(() => {
+            expect(screen.getByText('Address Lookup Table Program: Unknown Instruction')).toBeInTheDocument();
+        });
+        expect(Logger.error).toHaveBeenCalled();
+    });
+});
+
+function renderCard(info: unknown, type: string) {
+    return render(
+        <ScrollAnchorProvider>
+            <ClusterProvider>
+                <TransactionsProvider>
+                    <AccountsProvider>
+                        <TxInstructionSurface result={{ err: null }}>
+                            <AddressLookupTableDetailsCard
+                                tx={{ signatures: ['sig'] } as ParsedTransaction}
+                                ix={
+                                    {
+                                        parsed: { info, type },
+                                        program: 'address-lookup-table',
+                                        programId: AddressLookupTableProgram.programId,
+                                    } as unknown as ParsedInstruction
+                                }
+                                result={{ err: null }}
+                                index={0}
+                            />
+                        </TxInstructionSurface>
+                    </AccountsProvider>
+                </TransactionsProvider>
+            </ClusterProvider>
+        </ScrollAnchorProvider>,
+    );
+}

--- a/app/components/instruction/__tests__/AddressLookupTableInstructionCards.spec.tsx
+++ b/app/components/instruction/__tests__/AddressLookupTableInstructionCards.spec.tsx
@@ -1,0 +1,256 @@
+import {
+    type InstructionNode,
+    type InstructionSurface,
+    InstructionSurfaceProvider,
+    TxInstructionSurface,
+} from '@entities/instruction-card';
+import { AddressLookupTableProgram, type ParsedInstruction, PublicKey } from '@solana/web3.js';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(),
+    useRouter: vi.fn(() => ({ push: vi.fn() })),
+    useSearchParams: vi.fn(() => ({ get: vi.fn(), has: vi.fn(), toString: () => '' })),
+}));
+
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+
+import { CloseLookupTableDetailsCard } from '../address-lookup-table/CloseLookupTableDetails';
+import { CreateLookupTableDetailsCard } from '../address-lookup-table/CreateLookupTableDetails';
+import { DeactivateLookupTableDetailsCard } from '../address-lookup-table/DeactivateLookupTableDetails';
+import { ExtendLookupTableDetailsCard } from '../address-lookup-table/ExtendLookupTableDetails';
+import { FreezeLookupTableDetailsCard } from '../address-lookup-table/FreezeLookupTableDetails';
+
+const A = {
+    authority: '3EbFtRfKRMTrhPrRQjxbfWCB6NUyTQxwsWTKQFVKgNbb',
+    entryOne: '5rATVSqZjaHzMqSJmnbEQNmSJhaKMwsA7Zx2KfBWZBS4',
+    entryTwo: '6dNUCJLdccKGSSQvQDNvQMKfWiV5j3XSTTGqNsCJ8mSA',
+    payer: '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM',
+    recipient: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+    table: '7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2',
+} as const;
+
+const key = (base58: string) => new PublicKey(base58);
+
+const PROGRAM_ID = AddressLookupTableProgram.programId;
+const PROGRAM: string = PROGRAM_ID.toBase58();
+
+const RECENT_SLOT = 123_456_789;
+const BUMP_SEED = 255;
+
+const node: InstructionNode = {
+    index: 0,
+    // The shell only reads `ix` for the Raw view, which these cards never open.
+    ix: { parsed: {}, program: 'address-lookup-table', programId: PROGRAM_ID } as unknown as ParsedInstruction,
+    programId: PROGRAM_ID,
+};
+
+const TABLE = { lookupTableAccount: key(A.table), lookupTableAuthority: key(A.authority) };
+
+/** Each row as `[label, value]`. An address row carries the untruncated address, not the shortened text. */
+type Row = [string, string];
+
+const LOOKUP_TABLE_ROWS: Row[] = [
+    ['Program', PROGRAM],
+    ['Lookup Table', A.table],
+    ['Lookup Table Authority', A.authority],
+];
+
+/** Freeze, Deactivate and Close render identical rows, so only the title tells them apart. */
+const CASES: Array<{ card: React.ReactElement; rows: Row[]; title: string }> = [
+    {
+        card: <FreezeLookupTableDetailsCard node={node} info={TABLE} />,
+        rows: LOOKUP_TABLE_ROWS,
+        title: 'Address Lookup Table: Freeze Lookup Table',
+    },
+    {
+        card: <DeactivateLookupTableDetailsCard node={node} info={TABLE} />,
+        rows: LOOKUP_TABLE_ROWS,
+        title: 'Address Lookup Table: Deactivate Lookup Table',
+    },
+    {
+        // `recipient` is validated but deliberately unrendered, as on master.
+        card: <CloseLookupTableDetailsCard node={node} info={{ ...TABLE, recipient: key(A.recipient) }} />,
+        rows: LOOKUP_TABLE_ROWS,
+        title: 'Address Lookup Table: Close Lookup Table',
+    },
+    {
+        card: (
+            <CreateLookupTableDetailsCard
+                node={node}
+                info={{
+                    ...TABLE,
+                    bumpSeed: BUMP_SEED,
+                    payerAccount: key(A.payer),
+                    recentSlot: RECENT_SLOT,
+                    // Validated but unrendered, as on master.
+                    systemProgram: key('11111111111111111111111111111111'),
+                }}
+            />
+        ),
+        rows: [
+            ...LOOKUP_TABLE_ROWS,
+            ['Payer Account', A.payer],
+            ['Recent Slot', RECENT_SLOT.toLocaleString('en-US')],
+            ['Bump Seed', String(BUMP_SEED)],
+        ],
+        title: 'Address Lookup Table: Create Lookup Table',
+    },
+    {
+        card: (
+            <ExtendLookupTableDetailsCard
+                node={node}
+                info={{ ...TABLE, newAddresses: [key(A.entryOne), key(A.entryTwo)] }}
+            />
+        ),
+        rows: [...LOOKUP_TABLE_ROWS, ['New Addresses', [A.entryOne, A.entryTwo].join(',')]],
+        title: 'Address Lookup Table: Extend Lookup Table',
+    },
+];
+
+describe('instruction::address-lookup-table cards', () => {
+    /** Pins each card's rows: label, order, count, and the value every row resolves to. */
+    it.each(CASES)('should render the rows of $title', async ({ card, rows, title }) => {
+        renderCard(card);
+
+        // The cluster provider finishes an async fetch after mount, so assert inside waitFor.
+        await waitFor(() => {
+            expect(readRows()).toEqual(rows);
+        });
+
+        expect(screen.getByText(title)).toBeInTheDocument();
+    });
+
+    it('should number the new addresses in extend order', async () => {
+        renderCard(
+            <ExtendLookupTableDetailsCard
+                node={node}
+                info={{ ...TABLE, newAddresses: [key(A.entryOne), key(A.entryTwo)] }}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(readNewAddresses()).toEqual([
+                ['0', A.entryOne],
+                ['1', A.entryTwo],
+            ]);
+        });
+    });
+
+    it('should link the recent slot to its block', async () => {
+        renderCard(
+            <CreateLookupTableDetailsCard
+                node={node}
+                info={{
+                    ...TABLE,
+                    bumpSeed: BUMP_SEED,
+                    payerAccount: key(A.payer),
+                    recentSlot: RECENT_SLOT,
+                    systemProgram: key('11111111111111111111111111111111'),
+                }}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: RECENT_SLOT.toLocaleString('en-US') })).toHaveAttribute(
+                'href',
+                expect.stringContaining(`/block/${RECENT_SLOT}`),
+            );
+        });
+    });
+
+    // Extend draws its own nested markup, so nothing but this stops it from
+    // hardcoding the transaction page's address renderer for the entries.
+    it('should draw every address with the surface address renderer', () => {
+        render(
+            <InstructionSurfaceProvider surface={STUB_SURFACE}>
+                <ExtendLookupTableDetailsCard
+                    node={node}
+                    info={{ ...TABLE, newAddresses: [key(A.entryOne), key(A.entryTwo)] }}
+                />
+            </InstructionSurfaceProvider>,
+        );
+
+        expect(screen.getAllByTestId('surface-address').map(el => el.textContent)).toEqual([
+            A.table,
+            A.authority,
+            A.entryOne,
+            A.entryTwo,
+        ]);
+    });
+
+    // A foreign program id proves the row reads the node rather than an ALT-program constant.
+    it('should render the program row from the node', async () => {
+        renderCard(<FreezeLookupTableDetailsCard node={{ ...node, programId: key(A.authority) }} info={TABLE} />);
+
+        await waitFor(() => {
+            expect(readRows()[0]).toEqual(['Program', A.authority]);
+        });
+    });
+});
+
+/** A surface that renders nothing of its own, so only what a card asks of it shows up. */
+const STUB_SURFACE: InstructionSurface = {
+    Address: ({ pubkey }) => <span data-testid="surface-address">{pubkey.toBase58()}</span>,
+    Shell: ({ children }) => <table>{children}</table>,
+    result: { err: null },
+    showProgramField: false,
+};
+
+function renderCard(card: React.ReactElement) {
+    return render(
+        <ScrollAnchorProvider>
+            <ClusterProvider>
+                <TransactionsProvider>
+                    <AccountsProvider>
+                        <TxInstructionSurface result={{ err: null }}>{card}</TxInstructionSurface>
+                    </AccountsProvider>
+                </TransactionsProvider>
+            </ClusterProvider>
+        </ScrollAnchorProvider>,
+    );
+}
+
+/**
+ * The card's own rows in render order, so the result pins row order as well as content.
+ * Addresses are read from `data-address`, which carries the untruncated value the display
+ * shortens; every other kind falls back to its rendered text, so a wrong value fails rather
+ * than reading as an empty cell.
+ */
+function readRows(): Row[] {
+    const card = cardTable();
+    return within(card)
+        .getAllByRole('row')
+        .filter(row => row.closest('table') === card)
+        .map(row => {
+            const cells = within(row).getAllByRole('cell');
+            return [cells[0].textContent ?? '', readAddresses(cells[1]) ?? cells[1]?.textContent ?? ''];
+        });
+}
+
+/** The nested table Extend draws, as `[index, address]` pairs. */
+function readNewAddresses(): Row[] {
+    const [, nested] = screen.getAllByRole('table');
+    return within(nested)
+        .getAllByRole('row')
+        .map(row => {
+            const cells = within(row).getAllByRole('cell');
+            return [cells[0].textContent ?? '', readAddresses(cells[1]) ?? ''];
+        });
+}
+
+function cardTable(): HTMLElement {
+    return screen.getAllByRole('table')[0];
+}
+
+/** Comma-joined so a multi-address cell pins every entry and their order, not just the first. */
+function readAddresses(cell: HTMLElement | undefined): string | undefined {
+    // eslint-disable-next-line testing-library/no-node-access -- an address has no role to query by
+    const addresses = [...(cell?.querySelectorAll('[data-address]') ?? [])].map(el => el.getAttribute('data-address'));
+    return addresses.length > 0 ? addresses.join(',') : undefined;
+}

--- a/app/components/instruction/address-lookup-table/CloseLookupTableDetails.tsx
+++ b/app/components/instruction/address-lookup-table/CloseLookupTableDetails.tsx
@@ -1,41 +1,11 @@
-import { InstructionDetailsProps } from '@features/transaction';
-import { AddressLookupTableProgram } from '@solana/web3.js';
-
-import { Address } from '@/app/components/common/Address';
-import { InstructionCard } from '@/app/components/instruction/InstructionCard';
-import { BaseTable } from '@/app/shared/ui/Table';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
 import { CloseLookupTableInfo } from './types';
 
-export function CloseLookupTableDetailsCard(props: InstructionDetailsProps & { info: CloseLookupTableInfo }) {
-    const { ix, index, result, innerCards, childIndex, info } = props;
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="Address Lookup Table: Close Lookup Table"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={AddressLookupTableProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table Authority</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const CloseLookupTableDetailsCard = defineInstructionCard<CloseLookupTableInfo>({
+    fields: info => [
+        address('Lookup Table', info.lookupTableAccount),
+        address('Lookup Table Authority', info.lookupTableAuthority),
+    ],
+    title: 'Address Lookup Table: Close Lookup Table',
+});

--- a/app/components/instruction/address-lookup-table/CreateLookupTableDetails.tsx
+++ b/app/components/instruction/address-lookup-table/CreateLookupTableDetails.tsx
@@ -1,58 +1,15 @@
-import { InstructionDetailsProps } from '@features/transaction';
-import { AddressLookupTableProgram } from '@solana/web3.js';
-
-import { Address } from '@/app/components/common/Address';
-import { Slot } from '@/app/components/common/Slot';
-import { InstructionCard } from '@/app/components/instruction/InstructionCard';
-import { BaseTable } from '@/app/shared/ui/Table';
+import { Slot } from '@components/common/Slot';
+import { address, custom, defineInstructionCard, text } from '@entities/instruction-card';
 
 import { CreateLookupTableInfo } from './types';
 
-export function CreateLookupTableDetailsCard(props: InstructionDetailsProps & { info: CreateLookupTableInfo }) {
-    const { ix, index, result, innerCards, childIndex, info } = props;
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="Address Lookup Table: Create Lookup Table"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={AddressLookupTableProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table Authority</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Payer Account</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.payerAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Recent Slot</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Slot slot={info.recentSlot} link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Bump Seed</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">{info.bumpSeed}</BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const CreateLookupTableDetailsCard = defineInstructionCard<CreateLookupTableInfo>({
+    fields: info => [
+        address('Lookup Table', info.lookupTableAccount),
+        address('Lookup Table Authority', info.lookupTableAuthority),
+        address('Payer Account', info.payerAccount),
+        custom('Recent Slot', <Slot slot={info.recentSlot} link />),
+        text('Bump Seed', info.bumpSeed),
+    ],
+    title: 'Address Lookup Table: Create Lookup Table',
+});

--- a/app/components/instruction/address-lookup-table/DeactivateLookupTableDetails.tsx
+++ b/app/components/instruction/address-lookup-table/DeactivateLookupTableDetails.tsx
@@ -1,41 +1,11 @@
-import { InstructionDetailsProps } from '@features/transaction';
-import { AddressLookupTableProgram } from '@solana/web3.js';
-
-import { Address } from '@/app/components/common/Address';
-import { InstructionCard } from '@/app/components/instruction/InstructionCard';
-import { BaseTable } from '@/app/shared/ui/Table';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
 import { DeactivateLookupTableInfo } from './types';
 
-export function DeactivateLookupTableDetailsCard(props: InstructionDetailsProps & { info: DeactivateLookupTableInfo }) {
-    const { ix, index, result, innerCards, childIndex, info } = props;
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="Address Lookup Table: Deactivate Lookup Table"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={AddressLookupTableProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table Authority</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const DeactivateLookupTableDetailsCard = defineInstructionCard<DeactivateLookupTableInfo>({
+    fields: info => [
+        address('Lookup Table', info.lookupTableAccount),
+        address('Lookup Table Authority', info.lookupTableAuthority),
+    ],
+    title: 'Address Lookup Table: Deactivate Lookup Table',
+});

--- a/app/components/instruction/address-lookup-table/ExtendLookupTableDetails.tsx
+++ b/app/components/instruction/address-lookup-table/ExtendLookupTableDetails.tsx
@@ -1,58 +1,42 @@
-import { InstructionDetailsProps } from '@features/transaction';
-import { AddressLookupTableProgram, PublicKey } from '@solana/web3.js';
+import { address, custom, defineInstructionCard, useInstructionSurface } from '@entities/instruction-card';
+import type { PublicKey } from '@solana/web3.js';
 
-import { Address } from '@/app/components/common/Address';
-import { InstructionCard } from '@/app/components/instruction/InstructionCard';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 import { ExtendLookupTableInfo } from './types';
 
-export function ExtendLookupTableDetailsCard(props: InstructionDetailsProps & { info: ExtendLookupTableInfo }) {
-    const { ix, index, result, innerCards, childIndex, info } = props;
+export const ExtendLookupTableDetailsCard = defineInstructionCard<ExtendLookupTableInfo>({
+    fields: info => [
+        address('Lookup Table', info.lookupTableAccount),
+        address('Lookup Table Authority', info.lookupTableAuthority),
+        custom('New Addresses', <NewAddresses addresses={info.newAddresses} />),
+    ],
+    title: 'Address Lookup Table: Extend Lookup Table',
+});
+
+/**
+ * A whole table in one cell, which no field kind describes — so it takes the
+ * `custom` door and reads the address renderer off the surface itself, the way
+ * `InstructionFields` would.
+ */
+function NewAddresses({ addresses }: { addresses: PublicKey[] }) {
+    const { Address } = useInstructionSurface();
+
     return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="Address Lookup Table: Extend Lookup Table"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={AddressLookupTableProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table Authority</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>New Addresses</BaseTable.Cell>
-                <BaseTable.Cell style={{ paddingRight: '1rem' }}>
-                    <table>
-                        <BaseTable.Body>
-                            {info.newAddresses.map((address, index) => (
-                                <BaseTable.Row key={address.toString()}>
-                                    <BaseTable.Cell className="w-px font-mono">{index}</BaseTable.Cell>
-                                    <BaseTable.Cell className="text-right">
-                                        <Address pubkey={new PublicKey(address)} alignRight link />
-                                    </BaseTable.Cell>
-                                </BaseTable.Row>
-                            ))}
-                        </BaseTable.Body>
-                    </table>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
+        // The card table's edge padding reaches these nested cells and insets every
+        // entry from the rows above; only `tbody tr td` outweighs that selector.
+        <BaseTable className="[&_tbody_tr_td:first-child]:pl-0 [&_tbody_tr_td:last-child]:pr-0">
+            <BaseTable.Body>
+                {/* Keyed by position: an extend may list the same address twice, and the list never reorders. */}
+                {addresses.map((pubkey, index) => (
+                    <BaseTable.Row key={index}>
+                        <BaseTable.Cell className="w-px font-mono">{index}</BaseTable.Cell>
+                        <BaseTable.Cell className="text-right">
+                            <Address pubkey={pubkey} />
+                        </BaseTable.Cell>
+                    </BaseTable.Row>
+                ))}
+            </BaseTable.Body>
+        </BaseTable>
     );
 }

--- a/app/components/instruction/address-lookup-table/FreezeLookupTableDetails.tsx
+++ b/app/components/instruction/address-lookup-table/FreezeLookupTableDetails.tsx
@@ -1,49 +1,11 @@
-import { AddressLookupTableProgram, ParsedInstruction, ParsedTransaction, SignatureResult } from '@solana/web3.js';
-
-import { Address } from '@/app/components/common/Address';
-import { InstructionCard } from '@/app/components/instruction/InstructionCard';
-import { BaseTable } from '@/app/shared/ui/Table';
+import { address, defineInstructionCard } from '@entities/instruction-card';
 
 import { FreezeLookupTableInfo } from './types';
 
-type DetailsProps = {
-    ix: ParsedInstruction;
-    index: number;
-    result: SignatureResult;
-    tx: ParsedTransaction;
-    innerCards?: JSX.Element[];
-    childIndex?: number;
-};
-
-export function FreezeLookupTableDetailsCard(props: DetailsProps & { info: FreezeLookupTableInfo }) {
-    const { ix, index, result, innerCards, childIndex, info } = props;
-    return (
-        <InstructionCard
-            ix={ix}
-            index={index}
-            result={result}
-            title="Address Lookup Table: Freeze Lookup Table"
-            innerCards={innerCards}
-            childIndex={childIndex}
-        >
-            <BaseTable.Row>
-                <BaseTable.Cell>Program</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={AddressLookupTableProgram.programId} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAccount} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-            <BaseTable.Row>
-                <BaseTable.Cell>Lookup Table Authority</BaseTable.Cell>
-                <BaseTable.Cell className="text-right">
-                    <Address pubkey={info.lookupTableAuthority} alignRight link />
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
-    );
-}
+export const FreezeLookupTableDetailsCard = defineInstructionCard<FreezeLookupTableInfo>({
+    fields: info => [
+        address('Lookup Table', info.lookupTableAccount),
+        address('Lookup Table Authority', info.lookupTableAuthority),
+    ],
+    title: 'Address Lookup Table: Freeze Lookup Table',
+});

--- a/app/components/instruction/address-lookup-table/types.ts
+++ b/app/components/instruction/address-lookup-table/types.ts
@@ -1,4 +1,4 @@
-import { array, enums, Infer, number, string, type, union } from 'superstruct';
+import { array, Infer, number, type } from 'superstruct';
 
 import { PublicKeyFromString } from '@/app/validators/pubkey';
 
@@ -21,31 +21,10 @@ export type FreezeLookupTableInfo = Infer<typeof FreezeLookupTableInfo>;
 export const FreezeLookupTableInfo = type(LookupTableInfo);
 
 export type ExtendLookupTableInfo = Infer<typeof ExtendLookupTableInfo>;
-export const ExtendLookupTableInfo = type({ ...LookupTableInfo, newAddresses: array(string()) });
+export const ExtendLookupTableInfo = type({ ...LookupTableInfo, newAddresses: array(PublicKeyFromString) });
 
 export type DeactivateLookupTableInfo = Infer<typeof DeactivateLookupTableInfo>;
 export const DeactivateLookupTableInfo = type(LookupTableInfo);
 
 export type CloseLookupTableInfo = Infer<typeof CloseLookupTableInfo>;
 export const CloseLookupTableInfo = type({ ...LookupTableInfo, recipient: PublicKeyFromString });
-
-export type AddressLookupTableInstructionType = Infer<typeof AddressLookupTableInstructionType>;
-export const AddressLookupTableInstructionType = enums([
-    'createLookupTable',
-    'freezeLookupTable',
-    'extendLookupTable',
-    'deactivateLookupTable',
-    'closeLookupTable',
-]);
-
-export type AddressLookupTableInstructionInfo = Infer<typeof AddressLookupTableInstructionInfo>;
-export const AddressLookupTableInstructionInfo = type({
-    info: union([
-        CreateLookupTableInfo,
-        FreezeLookupTableInfo,
-        ExtendLookupTableInfo,
-        DeactivateLookupTableInfo,
-        CloseLookupTableInfo,
-    ]),
-    type: AddressLookupTableInstructionType,
-});


### PR DESCRIPTION
## Description

All five Address Lookup Table instruction cards drew their own rows, each with a hardcoded `Program` row and its own `InstructionCard` import. ALT is tx-page only — the inspector has no ALT case.

Drawing rows by hand also hardcodes the transaction page's address renderer, which keeps these cards out of the inspector. Phase A of #1267, after Stake (#1253).

### The change

-   **Declare rows as descriptors.** All five cards return `InstructionField` lists and take one `InstructionNode`, so the surface owns the frame, the address renderer and the `Program` row.
-   **Validate each type against its own schema.** `type()` ignores unknown keys, so the two-field `Freeze` schema matched every payload and won the union — Create, Extend and Close never ran.
-   **Coerce extend addresses in the schema.** `newAddresses` becomes `array(PublicKeyFromString)`, so the card stops calling `new PublicKey` itself.
-   **Fall back rather than render a half-validated card.** A payload missing a required field now routes to `UnknownDetailsCard`; master rendered a card.
-   **Right-align the nested new-addresses table.** It builds on `BaseTable` so it spans the value cell; a bare `<table>` shrank to its contents and left entries 228px short of the rows above.

## Type of change

-   [x] Other: refactor — carries one validation tightening and one alignment fix, both listed above

## Testing

-   **The new-addresses entries right-align.** Open the extend transaction — [preview](https://explorer-git-fork-hoodieshq-refactor-a-ffc2e0-solana-foundation.vercel.app/tx/2p1wFbeNGDNEDdetzyacZ6tnDtQdL2hNPJ8heP2ss22KH8yBfY6Sx6WURzsSbAh2Azmtav7bDfrtewnE9yvfFtd1) · [production](https://explorer.solana.com/tx/2p1wFbeNGDNEDdetzyacZ6tnDtQdL2hNPJ8heP2ss22KH8yBfY6Sx6WURzsSbAh2Azmtav7bDfrtewnE9yvfFtd1) — and read the `New Addresses` row of instruction `#3`. Expect all 13 entries on the same right edge as the `Lookup Table` and `Lookup Table Authority` rows above them. Production sits them well short of that edge.
-   **Create keeps its payer, recent slot and bump seed.** Open the create transaction — [preview](https://explorer-git-fork-hoodieshq-refactor-a-ffc2e0-solana-foundation.vercel.app/tx/351nK5vkcW7oPvgLMnK437XsvrTxS1REY6PDbeSBu9g3Yrs6Gyc6qZtaS9KGHpdg9dcky3X9CxpqxZjGKBDb5G68) · [production](https://explorer.solana.com/tx/351nK5vkcW7oPvgLMnK437XsvrTxS1REY6PDbeSBu9g3Yrs6Gyc6qZtaS9KGHpdg9dcky3X9CxpqxZjGKBDb5G68) — and compare every row against production. Expect the same labels, values and order, and the recent slot still linking to its block page.
-   **Close still shows the recipient the tightening requires.** Open the close transaction — [preview](https://explorer-git-fork-hoodieshq-refactor-a-ffc2e0-solana-foundation.vercel.app/tx/3ajPHGNTzZKmKBq14Uo4QkTevqyWg6aUrRuhJuZ9qwC3PAjkYCVfMVPxzLR6xsrHrLttAtGf9Awn1qXCGjr1MSDG) · [production](https://explorer.solana.com/tx/3ajPHGNTzZKmKBq14Uo4QkTevqyWg6aUrRuhJuZ9qwC3PAjkYCVfMVPxzLR6xsrHrLttAtGf9Awn1qXCGjr1MSDG) — and read the card. Expect the same three rows as production, not the `Unknown` fallback.
-   **Deactivate renders unchanged.** Open the deactivate transaction — [preview](https://explorer-git-fork-hoodieshq-refactor-a-ffc2e0-solana-foundation.vercel.app/tx/4jW6ZdYSPoQTZS6uswPXkniZR7PSKrn1acPBJwWw6Acy2mWz5gWST7GSsAqrwQcwrNRNSrid23tD49pQhdM4wVux) · [production](https://explorer.solana.com/tx/4jW6ZdYSPoQTZS6uswPXkniZR7PSKrn1acPBJwWw6Acy2mWz5gWST7GSsAqrwQcwrNRNSrid23tD49pQhdM4wVux) — and compare the card against production. Expect identical rows and the same title.

## Related Issues

Closes [HOO-1396](https://linear.app/solana-fndn/issue/HOO-1396/migrate-address-lookup-table-instruction-cards-to-the-instruction-card)

Part of [HOO-1267](https://linear.app/solana-fndn/issue/HOO-1267/epic-unify-instruction-card-rendering-across-the-tx-page-and-inspector)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

Two specs, 17 tests:

-   `__tests__/AddressLookupTableInstructionCards.spec.tsx` pins every row of all five cards — label, order, count and the value each row resolves to. Address rows are read from `data-address`, so truncation cannot hide a wrong value. It also pins the nested table's `[index, address]` pairs, the recent slot's link target, and — rendering Extend under a stub surface — that every address goes through the surface's renderer rather than a hardcoded one.
-   `__tests__/AddressLookupTableDetailsCard.spec.tsx` pins the dispatcher. Freeze, Deactivate and Close render identical rows, so a mis-routed type still produces a plausible card and only the title tells them apart. It covers all five routes, both fallback paths, and the extend coercion the old union skipped.
