### PR TITLE
fix(inspector): resolve a looked-up program id against the right array

### DIFF
--- a/app/components/inspector/__tests__/utils.spec.ts
+++ b/app/components/inspector/__tests__/utils.spec.ts
@@ -1,0 +1,64 @@
+import { MessageV0, PublicKey } from '@solana/web3.js';
+import { describe, expect, test } from 'vitest';
+
+import { intoTransactionInstructionFromVersionedMessage } from '../utils';
+
+const key = (n: number) => new PublicKey(new Uint8Array(32).fill(n));
+
+const STATIC_KEYS = [key(1), key(2)];
+
+function messageWithLookups(
+    programIdIndex: number,
+    addressTableLookups: { accountKey: PublicKey; readonlyIndexes: number[]; writableIndexes: number[] }[],
+) {
+    return new MessageV0({
+        addressTableLookups,
+        compiledInstructions: [{ accountKeyIndexes: [0], data: new Uint8Array([1]), programIdIndex }],
+        header: { numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0, numRequiredSignatures: 1 },
+        recentBlockhash: key(5).toBase58(),
+        staticAccountKeys: STATIC_KEYS,
+    });
+}
+
+describe('intoTransactionInstructionFromVersionedMessage', () => {
+    test('should resolve a static program id', () => {
+        const message = messageWithLookups(1, []);
+        const instruction = intoTransactionInstructionFromVersionedMessage(message.compiledInstructions[0], message);
+        expect(instruction.programId.equals(STATIC_KEYS[1])).toBe(true);
+    });
+
+    test('should resolve a program id from a table that contributes several accounts', () => {
+        // Account key indexes past the static keys address the flattened
+        // writable-then-readonly lookup accounts, not the tables. One table with
+        // two writable indexes yields two accounts, so index 3 is the second of
+        // them even though there is only one table.
+        const table = key(9);
+        const message = messageWithLookups(3, [{ accountKey: table, readonlyIndexes: [], writableIndexes: [7, 8] }]);
+        const instruction = intoTransactionInstructionFromVersionedMessage(message.compiledInstructions[0], message);
+        expect(instruction.programId.equals(table)).toBe(true);
+    });
+
+    test('should resolve a program id to the table that actually owns the account', () => {
+        // First table supplies two writable accounts (indexes 2 and 3), so index
+        // 4 belongs to the second table. Indexing the tables array would return
+        // the second table for index 3 and run off the end at index 4.
+        const first = key(9);
+        const second = key(10);
+        const lookups = [
+            { accountKey: first, readonlyIndexes: [], writableIndexes: [7, 8] },
+            { accountKey: second, readonlyIndexes: [], writableIndexes: [4] },
+        ];
+        expect(
+            intoTransactionInstructionFromVersionedMessage(
+                messageWithLookups(3, lookups).compiledInstructions[0],
+                messageWithLookups(3, lookups),
+            ).programId.equals(first),
+        ).toBe(true);
+        expect(
+            intoTransactionInstructionFromVersionedMessage(
+                messageWithLookups(4, lookups).compiledInstructions[0],
+                messageWithLookups(4, lookups),
+            ).programId.equals(second),
+        ).toBe(true);
+    });
+});

--- a/app/components/inspector/utils.ts
+++ b/app/components/inspector/utils.ts
@@ -100,14 +100,18 @@ export function intoTransactionInstructionFromVersionedMessage(
 
     // When we're deserializing Squads vault transactions, an "outer" programIdIndex can be found in the addressTableLookups
     // (You never need to lookup outer programIds for normal messages)
-    let programId: PublicKey | undefined;
-    if (compiledInstruction.programIdIndex < originalMessage.staticAccountKeys.length) {
-        programId = originalMessage.staticAccountKeys.at(compiledInstruction.programIdIndex);
-    } else {
-        // This is only needed for Squads vault transactions, in normal messages, outer program IDs cannot be in addressTableLookups
-        const lookupIndex = compiledInstruction.programIdIndex - originalMessage.staticAccountKeys.length;
-        programId = addressTableLookups[lookupIndex].accountKey;
-    }
+    //
+    // Resolved through the same helper the account metas use. Indexing
+    // addressTableLookups directly is wrong: an account key index past the
+    // static keys addresses the flattened writable-then-readonly accounts, not
+    // the tables. The two only line up when every table contributes exactly one
+    // index, so a single table with two entries already resolves to the wrong
+    // table or, past the end, throws.
+    const { lookup: programId } = findLookupAddressByIndex(
+        compiledInstruction.programIdIndex,
+        originalMessage,
+        lookupAccounts,
+    );
     if (!programId) throw new Error('Program ID not found');
 
     const accountMetas = fillAccountMetas(accountKeyIndexes, originalMessage, lookupAccounts);


### PR DESCRIPTION
### What

`intoTransactionInstructionFromVersionedMessage` resolves a program id that lives in an address lookup table by indexing `addressTableLookups`:

```ts
const lookupIndex = compiledInstruction.programIdIndex - originalMessage.staticAccountKeys.length;
programId = addressTableLookups[lookupIndex].accountKey;
```

`addressTableLookups` has one entry per **table**. An account key index past the static keys addresses the flattened writable-then-readonly **accounts**, which is exactly what `fillAddressTableLookupsAccounts` builds a few lines above, and what `findLookupAddressByIndex` already uses for the account metas in the same file.

So the two halves of this function disagree: the account metas resolve through the flattened list, the program id resolves through the tables.

### Why it matters

They only agree when every table contributes exactly one index. One table with two writable indexes is enough to break it:

| lookups | `programIdIndex` | today | expected |
| --- | --- | --- | --- |
| 1 table, `writableIndexes: [7, 8]` | 3 | **throws** `Cannot read properties of undefined (reading 'accountKey')` | the table's key |
| 2 tables, `[7, 8]` then `[4]` | 4 | **wrong table's key** | the second table's key |

The first is a hard failure decoding the instruction; the second is silent and worse, since the inspector then shows a program id that never appeared in the transaction. Both are on the Squads vault path the existing comment describes, which is the one case where an outer program id can come from a lookup table at all.

### The change

Resolve through `findLookupAddressByIndex`, the helper the account metas already use, so the program id and the account metas cannot drift apart again. That removes the second, divergent implementation rather than patching it.

### Verification

Three tests added in `app/components/inspector/__tests__/utils.spec.ts`. I confirmed the two lookup cases fail without the source change, with exactly the `TypeError` and the wrong-key mismatch above, and that the static-program-id case passes either way, so they isolate the change.

`pnpm vitest --project specs run` over `app/components/inspector`, `app/features/decode-instruction-associated-token` and `TokenDetailsCard.spec.tsx`: 11 files, 52 tests passing, no type errors. ESLint and Prettier clean.