### PR TITLE
fix(compute-unit): break activation-epoch ties toward the newest config

### DIFF
--- a/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
+++ b/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
@@ -157,6 +157,36 @@ describe('getReservedComputeUnits', () => {
         });
     });
 
+    describe('simd296 cluster', () => {
+        it('should use the most recent configuration, whose activation epoch is also 0', () => {
+            // Every config activates at epoch 0 on this cluster, so the tie has
+            // to resolve to the newest one rather than the initial one.
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Simd296,
+                    epoch: 0n,
+                    programId: '11111111111111111111111111111111',
+                }),
+            ).toEqual(3_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Simd296,
+                    epoch: 1000n,
+                    programId: '11111111111111111111111111111111',
+                }),
+            ).toEqual(3_000);
+
+            expect(
+                getReservedComputeUnits({
+                    cluster: Cluster.Simd296,
+                    epoch: 1000n,
+                    programId: 'Feature111111111111111111111111111111111111',
+                }),
+            ).toEqual(200_000);
+        });
+    });
+
     describe('edge cases', () => {
         it('should handle undefined epoch', () => {
             expect(

--- a/app/entities/compute-unit/lib/compute-units-schedule.ts
+++ b/app/entities/compute-unit/lib/compute-units-schedule.ts
@@ -126,7 +126,11 @@ export function getReservedComputeUnits({
 
     for (const config of COMPUTE_UNIT_RESERVE_CONFIGS) {
         const activationEpoch = config.activations[cluster];
-        if (activationEpoch <= epochNumber && activationEpoch > highestActivationEpoch) {
+        // `>=`, not `>`: configs are listed oldest first, so when two share an
+        // activation epoch the later one is the current behaviour. Simd296
+        // activates every config at epoch 0, and a strict `>` left it pinned to
+        // the initial config forever.
+        if (activationEpoch <= epochNumber && activationEpoch >= highestActivationEpoch) {
             applicableConfig = config;
             highestActivationEpoch = activationEpoch;
         }


### PR DESCRIPTION
### What

`getReservedComputeUnits` walks `COMPUTE_UNIT_RESERVE_CONFIGS` keeping the one with the highest activation epoch at or below the requested epoch, but compares with a strict `>`:

```ts
if (activationEpoch <= epochNumber && activationEpoch > highestActivationEpoch) {
```

The configs are listed oldest first, so when two share an activation epoch the **first** one wins and every later one is unreachable.

### Why it matters

`Simd296` activates every config at epoch 0:

```ts
activations: { [Cluster.MainnetBeta]: 759, [Cluster.Devnet]: 842, [Cluster.Testnet]: 750, [Cluster.Simd296]: 0 }
```

The initial config also sits at 0, wins the tie, and pins the cluster to "no built-in program optimization" forever. Built-in programs report **200,000** reserved compute units there instead of **3,000**, at every epoch:

```ts
getReservedComputeUnits({ cluster: Cluster.Simd296, epoch: 1000n, programId: '11111111111111111111111111111111' })
// => 200_000, expected 3_000
```

`Cluster.Simd296` is in `CLUSTERS`, so this is reachable from the cluster picker rather than theoretical.

### The change

`>=` instead of `>`. That gives the same "most recent configuration" rule the custom-cluster branch already applies explicitly a few lines above, which I read as the intended semantics for the whole function.

No other cluster has two configs sharing an activation epoch, so no other behaviour changes. Negative and undefined epochs still fall through to the initial config, since the `activationEpoch <= epochNumber` guard is untouched.

### Verification

Added a `simd296 cluster` block to the existing spec, covering epoch 0, a later epoch, and a non-builtin program. I confirmed it fails without the source change and passes with it, and that the 31 existing tests pass either way, so the new test isolates the change. 32 passing, no type errors, ESLint and Prettier clean.

The existing spec covers mainnet, devnet, testnet, custom and edge cases but had no Simd296 case, which is why this went unnoticed.