### PR TITLE
feat: integrate Explorer MCP into the page header

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -22,6 +22,7 @@ export function Navbar({ children }: INavbarProps) {
     const [navOpened, navHandlers] = useDisclosure(false);
     const homePath = useClusterPath({ pathname: '/' });
     const featureGatesPath = useClusterPath({ pathname: '/feature-gates' });
+    const mcpDocsPath = useClusterPath({ pathname: '/mcp/docs' });
     const inspectorPath = useClusterPath({ pathname: '/tx/inspector' });
     const selectedLayoutSegment = useSelectedLayoutSegment();
     const selectedLayoutSegments = useSelectedLayoutSegments();
@@ -59,6 +60,12 @@ export function Navbar({ children }: INavbarProps) {
                         <NavbarItem>
                             <NavbarLink asChild active={selectedLayoutSegment === 'feature-gates'}>
                                 <Link href={featureGatesPath}>Feature Gates</Link>
+                            </NavbarLink>
+                        </NavbarItem>
+                        <NavbarItem>
+                            {/* `/mcp` itself is the MCP endpoint (route.ts), so the only page under the segment is the docs. */}
+                            <NavbarLink asChild active={selectedLayoutSegment === 'mcp'}>
+                                <Link href={mcpDocsPath}>MCP</Link>
                             </NavbarLink>
                         </NavbarItem>
                         <NavbarItem>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -22,7 +22,6 @@ export function Navbar({ children }: INavbarProps) {
     const [navOpened, navHandlers] = useDisclosure(false);
     const homePath = useClusterPath({ pathname: '/' });
     const featureGatesPath = useClusterPath({ pathname: '/feature-gates' });
-    const mcpDocsPath = useClusterPath({ pathname: '/mcp/docs' });
     const inspectorPath = useClusterPath({ pathname: '/tx/inspector' });
     const selectedLayoutSegment = useSelectedLayoutSegment();
     const selectedLayoutSegments = useSelectedLayoutSegments();
@@ -60,12 +59,6 @@ export function Navbar({ children }: INavbarProps) {
                         <NavbarItem>
                             <NavbarLink asChild active={selectedLayoutSegment === 'feature-gates'}>
                                 <Link href={featureGatesPath}>Feature Gates</Link>
-                            </NavbarLink>
-                        </NavbarItem>
-                        <NavbarItem>
-                            {/* `/mcp` itself is the MCP endpoint (route.ts), so the only page under the segment is the docs. */}
-                            <NavbarLink asChild active={selectedLayoutSegment === 'mcp'}>
-                                <Link href={mcpDocsPath}>MCP</Link>
                             </NavbarLink>
                         </NavbarItem>
                         <NavbarItem>

--- a/app/features/mcp-docs/index.ts
+++ b/app/features/mcp-docs/index.ts
@@ -1,0 +1,1 @@
+export { McpDocsOverviewView } from './ui/McpDocsOverviewView';

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -43,6 +43,15 @@ function mcpJsonConfig(origin: string, isRestricted: boolean): string {
     );
 }
 
+// `codex mcp add` has no header flag; a gated deployment is configured via config.toml `http_headers`.
+function codexTomlConfig(origin: string): string {
+    return [
+        '[mcp_servers.solana-explorer]',
+        `url = "${origin}/mcp"`,
+        `http_headers = { "Authorization" = "Bearer ${ACCESS_KEY_PLACEHOLDER}" }`,
+    ].join('\n');
+}
+
 // VS Code's `mcp.json` keys servers under `servers` (not `mcpServers`).
 function vsCodeJsonConfig(origin: string): string {
     return JSON.stringify(
@@ -86,8 +95,11 @@ export const SETUP_CLIENTS: SetupClient[] = [
     {
         id: 'codex',
         label: 'Codex',
+        // `codex mcp add` only takes --bearer-token-env-var (no --header), so a gated deployment
+        // uses the config-file form with a literal header instead.
+        restrictedWhere: 'Add to ~/.codex/config.toml (project-scoped .codex/config.toml also works):',
         snippet: (origin, isRestricted) =>
-            `codex mcp add solana-explorer --url ${origin}/mcp${isRestricted ? authHeaderFlag : ''}`,
+            isRestricted ? codexTomlConfig(origin) : `codex mcp add solana-explorer --url ${origin}/mcp`,
         verify: 'codex mcp list shows solana-explorer.',
         where: 'Run in a terminal:',
     },

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -1,24 +1,55 @@
 /**
  * Per-client setup instructions for the overview page. Snippets are functions
  * of the deployment origin so the visitor copies a config that already points
- * at the Explorer instance they are on. The deployed endpoint is open (no auth
- * header anywhere); a deployment that gates it with a key documents that in its
- * own README.
+ * at the Explorer instance they are on.
+ *
+ * `isRestricted` reflects a deployment that gates `/mcp` with `MCP_ACCESS_KEYS`
+ * (the live probe saw a 401/403). In that state the open, key-less config is
+ * rejected, so each snippet switches to its authorized form — a `--header`
+ * flag for the CLIs, a `headers` block for the config-file clients — with an
+ * `<access-key>` placeholder the visitor replaces with the key the deployment
+ * was configured with.
  */
 export type SetupClient = {
     id: string;
     label: string;
     /** Where the snippet goes (command line, config file path, UI path). */
     where: string;
-    snippet: (origin: string) => string;
+    /** Overrides `where` when the endpoint is gated (some flows can't carry a header via their UI). */
+    restrictedWhere?: string;
+    snippet: (origin: string, isRestricted: boolean) => string;
     verify: string;
 };
 
-function mcpJsonConfig(origin: string): string {
+// Placeholder the visitor swaps for the real bearer key on a gated deployment.
+const ACCESS_KEY_PLACEHOLDER = '<access-key>';
+
+const authHeaderFlag = ` \\\n  --header "Authorization: Bearer ${ACCESS_KEY_PLACEHOLDER}"`;
+
+// Cursor and Windsurf both read a `.mcp.json`-shaped config keyed by `mcpServers`.
+function mcpJsonConfig(origin: string, isRestricted: boolean): string {
     return JSON.stringify(
         {
             mcpServers: {
                 'solana-explorer': {
+                    type: 'http',
+                    url: `${origin}/mcp`,
+                    ...(isRestricted && { headers: { Authorization: `Bearer ${ACCESS_KEY_PLACEHOLDER}` } }),
+                },
+            },
+        },
+        undefined,
+        4,
+    );
+}
+
+// VS Code's `mcp.json` keys servers under `servers` (not `mcpServers`).
+function vsCodeJsonConfig(origin: string): string {
+    return JSON.stringify(
+        {
+            servers: {
+                'solana-explorer': {
+                    headers: { Authorization: `Bearer ${ACCESS_KEY_PLACEHOLDER}` },
                     type: 'http',
                     url: `${origin}/mcp`,
                 },
@@ -33,7 +64,8 @@ export const SETUP_CLIENTS: SetupClient[] = [
     {
         id: 'claude-code',
         label: 'Claude Code',
-        snippet: origin => `claude mcp add --transport http solana-explorer ${origin}/mcp`,
+        snippet: (origin, isRestricted) =>
+            `claude mcp add --transport http solana-explorer ${origin}/mcp${isRestricted ? authHeaderFlag : ''}`,
         verify: 'Run /mcp inside Claude Code and check that solana-explorer is connected.',
         where: 'Run in a terminal:',
     },
@@ -54,14 +86,17 @@ export const SETUP_CLIENTS: SetupClient[] = [
     {
         id: 'codex',
         label: 'Codex',
-        snippet: origin => `codex mcp add solana-explorer --url ${origin}/mcp`,
+        snippet: (origin, isRestricted) =>
+            `codex mcp add solana-explorer --url ${origin}/mcp${isRestricted ? authHeaderFlag : ''}`,
         verify: 'codex mcp list shows solana-explorer.',
         where: 'Run in a terminal:',
     },
     {
         id: 'vs-code',
         label: 'VS Code',
-        snippet: origin => `${origin}/mcp`,
+        // The Add-Server UI can't set headers, so a gated deployment needs the config-file form instead.
+        restrictedWhere: 'Add to .vscode/mcp.json (the Add Server UI cannot set an auth header):',
+        snippet: (origin, isRestricted) => (isRestricted ? vsCodeJsonConfig(origin) : `${origin}/mcp`),
         verify: 'The server appears under MCP: List Servers with two tools.',
         where: 'Command Palette → MCP: Add Server → HTTP, then enter the URL:',
     },

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-client setup instructions for the overview page. Snippets are functions
+ * of the deployment origin so the visitor copies a config that already points
+ * at the Explorer instance they are on. The deployed endpoint is open (no auth
+ * header anywhere); a deployment that gates it with a key documents that in its
+ * own README.
+ */
+export type SetupClient = {
+    id: string;
+    label: string;
+    /** Where the snippet goes (command line, config file path, UI path). */
+    where: string;
+    snippet: (origin: string) => string;
+    verify: string;
+};
+
+function mcpJsonConfig(origin: string): string {
+    return JSON.stringify(
+        {
+            mcpServers: {
+                'solana-explorer': {
+                    type: 'http',
+                    url: `${origin}/mcp`,
+                },
+            },
+        },
+        undefined,
+        4,
+    );
+}
+
+export const SETUP_CLIENTS: SetupClient[] = [
+    {
+        id: 'claude-code',
+        label: 'Claude Code',
+        snippet: origin => `claude mcp add --transport http solana-explorer ${origin}/mcp`,
+        verify: 'Run /mcp inside Claude Code and check that solana-explorer is connected.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'cursor',
+        label: 'Cursor',
+        snippet: mcpJsonConfig,
+        verify: 'Settings → MCP lists solana-explorer with the inspect_entity and ping tools.',
+        where: 'Add to .cursor/mcp.json (project) or ~/.cursor/mcp.json (global):',
+    },
+    {
+        id: 'windsurf',
+        label: 'Windsurf',
+        snippet: mcpJsonConfig,
+        verify: 'The server appears in the Cascade MCP panel with two tools.',
+        where: 'Add to ~/.codeium/windsurf/mcp_config.json:',
+    },
+    {
+        id: 'codex',
+        label: 'Codex',
+        snippet: origin => `codex mcp add solana-explorer --url ${origin}/mcp`,
+        verify: 'codex mcp list shows solana-explorer.',
+        where: 'Run in a terminal:',
+    },
+    {
+        id: 'vs-code',
+        label: 'VS Code',
+        snippet: origin => `${origin}/mcp`,
+        verify: 'The server appears under MCP: List Servers with two tools.',
+        where: 'Command Palette → MCP: Add Server → HTTP, then enter the URL:',
+    },
+];
+
+export const AGENT_INSTRUCTIONS_TARGETS = [
+    { file: 'AGENTS.md', tool: 'Codex, Windsurf, and other AGENTS.md-aware agents' },
+    { file: 'CLAUDE.md', tool: 'Claude Code' },
+    { file: '.cursor/rules/solana-explorer-mcp.mdc', tool: 'Cursor' },
+];
+
+export const AGENT_INSTRUCTIONS_SNIPPET = `## Solana Explorer MCP
+
+Prefer the \`solana-explorer\` MCP tools over model memory for any on-chain fact.
+
+1. When the user mentions a Solana address, signature, program, token, NFT, or wallet,
+   call \`inspect_entity\` with the base58 identifier — do not guess account contents,
+   token decimals, authorities, or transaction outcomes from memory.
+2. Pass \`cluster\` explicitly when the user is not on mainnet-beta
+   (\`devnet\`, \`testnet\`, \`simd296\`).
+3. Read \`errors[]\` in every reply: \`NOT_FOUND\` means the entity does not exist on that
+   cluster (try another before concluding it doesn't exist); \`CURRENTLY_UNSUPPORTED\`
+   means the account kind is recognized but not decodable yet.
+4. Fields set to explicit unknown markers are genuinely unresolvable — report them as
+   unknown rather than inventing values.`;

--- a/app/features/mcp-docs/lib/useDeploymentOrigin.ts
+++ b/app/features/mcp-docs/lib/useDeploymentOrigin.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** Shown during SSR and when JS is unavailable; replaced with the real origin after mount. */
+export const DEPLOYMENT_PLACEHOLDER = 'https://<deployment>';
+
+/**
+ * Origin of the deployment the visitor is on, so config snippets are copy-ready
+ * for exactly this Explorer instance.
+ */
+export function useDeploymentOrigin(): string {
+    const [origin, setOrigin] = useState<string>();
+    useEffect(() => {
+        setOrigin(window.location.origin);
+    }, []);
+    return origin ?? DEPLOYMENT_PLACEHOLDER;
+}

--- a/app/features/mcp-docs/lib/useStickyTabs.ts
+++ b/app/features/mcp-docs/lib/useStickyTabs.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// Mobile-only sticky tab strip. While scrolling a section its tab strip pins to the top of the window; once
+// less than `tailPx` is left below the strip to the section's end, it detaches and scrolls away — kept
+// `position: sticky` but with `top` driven negative, so it re-pins on the way back up and its
+// box/width/horizontal-scroll are preserved. Desktop (>= sm) leaves the strip static.
+export function useStickyRelease(tailPx = 320) {
+    const sectionRef = useRef<HTMLDivElement | null>(null);
+    const stripRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 575.98px)');
+        let raf = 0;
+        const update = () => {
+            raf = 0;
+            const section = sectionRef.current;
+            const strip = stripRef.current;
+            if (!section || !strip) return;
+            if (!mq.matches) {
+                strip.style.top = '';
+                return;
+            }
+            const rect = section.getBoundingClientRect();
+            const threshold = tailPx + strip.offsetHeight;
+            strip.style.top = rect.bottom < threshold ? `${Math.round(rect.bottom - threshold)}px` : '0px';
+        };
+        const onScroll = () => {
+            if (!raf) raf = requestAnimationFrame(update);
+        };
+        update();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        mq.addEventListener('change', onScroll);
+        return () => {
+            window.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', onScroll);
+            mq.removeEventListener('change', onScroll);
+            if (raf) cancelAnimationFrame(raf);
+        };
+    }, [tailPx]);
+
+    return { sectionRef, stripRef };
+}
+
+// On tab switch, pull the section's top up to the top of the window — but only if it has scrolled above the
+// viewport (you're inside/past the section). If the section top is still at or below the viewport top (you're
+// above it), leave the scroll alone. Uses `window.scrollTo` (not `scrollIntoView`, which wouldn't move the
+// page here) and defers a frame so it lands after the tab click's own focus-into-view scroll.
+export function scrollSectionToTop(el: HTMLElement | null) {
+    if (!el) return;
+    requestAnimationFrame(() => {
+        const rectTop = el.getBoundingClientRect().top;
+        if (rectTop >= 0) return;
+        window.scrollTo({ behavior: 'instant', top: window.scrollY + rectTop });
+    });
+}

--- a/app/features/mcp-docs/lib/useStickyTabs.ts
+++ b/app/features/mcp-docs/lib/useStickyTabs.ts
@@ -12,15 +12,18 @@ export function useStickyRelease(tailPx = 320) {
 
     useEffect(() => {
         // Must match the CSS `sm:static` release exactly. Tailwind's `sm` is min-width 577px (the config
-        // shifts the 576px token up by 1px — see getScreenDim), so the strip stays sticky below 577px.
-        const mq = window.matchMedia('(max-width: 576.98px)');
+        // shifts the 576px token up by 1px — see getScreenDim), so `sm:static` compiles to this very query
+        // and the strip stays sticky below 577px. Key off the identical `min-width: 577px` boundary (not a
+        // `max-width` sibling) so there's no sub-pixel gap where release logic stops but sticky positioning
+        // hasn't yet — e.g. at 576.99px, still sticky in CSS.
+        const mq = window.matchMedia('(min-width: 577px)');
         let raf = 0;
         const update = () => {
             raf = 0;
             const section = sectionRef.current;
             const strip = stripRef.current;
             if (!section || !strip) return;
-            if (!mq.matches) {
+            if (mq.matches) {
                 strip.style.top = '';
                 return;
             }

--- a/app/features/mcp-docs/lib/useStickyTabs.ts
+++ b/app/features/mcp-docs/lib/useStickyTabs.ts
@@ -11,7 +11,9 @@ export function useStickyRelease(tailPx = 320) {
     const stripRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        const mq = window.matchMedia('(max-width: 575.98px)');
+        // Must match the CSS `sm:static` release exactly. Tailwind's `sm` is min-width 577px (the config
+        // shifts the 576px token up by 1px — see getScreenDim), so the strip stays sticky below 577px.
+        const mq = window.matchMedia('(max-width: 576.98px)');
         let raf = 0;
         const update = () => {
             raf = 0;

--- a/app/features/mcp-docs/ui/CodeBlock.tsx
+++ b/app/features/mcp-docs/ui/CodeBlock.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Check, Copy, XCircle } from 'react-feather';
+
+import { cn } from '@/app/components/shared/utils';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
+
+/**
+ * Multiline code snippet with a copy affordance (`Copyable` is inline-only, hence a dedicated block).
+ * `flush` drops the own border/rounding for use as a full-bleed segment inside a card.
+ */
+export function CodeBlock({
+    code,
+    className,
+    variant = 'panel',
+}: {
+    code: string;
+    className?: string;
+    variant?: 'panel' | 'flush';
+}) {
+    const [state, copy] = useCopyToClipboard(1000);
+
+    const icon = {
+        copied: <Check size={14} aria-hidden />,
+        copy: <Copy size={14} aria-hidden />,
+        errored: <XCircle size={14} aria-hidden />,
+    }[state];
+
+    return (
+        <div
+            className={cn(
+                'relative bg-heavy-metal-900',
+                variant === 'panel' && 'rounded-lg border border-solid border-white/10',
+                className,
+            )}
+        >
+            <button
+                type="button"
+                aria-label="Copy to clipboard"
+                onClick={() => copy(code)}
+                className={cn(
+                    // `flex` collapses the svg's inline line box, keeping the button square.
+                    'absolute right-3 top-3 flex cursor-pointer rounded border-0 bg-transparent p-1.5',
+                    'text-neutral-500 hover:bg-heavy-metal-800 hover:text-neutral-200',
+                    state === 'copied' && 'text-dark-accent hover:text-dark-accent',
+                    state === 'errored' && 'text-red-500 hover:text-red-500',
+                )}
+            >
+                {icon}
+            </button>
+            <pre
+                className={cn(
+                    'm-0 whitespace-pre-wrap font-mono text-xs leading-relaxed text-neutral-200 [overflow-wrap:anywhere]',
+                    // Flush segments sit inside a p-6 card section — match its padding.
+                    variant === 'flush' ? 'p-4 pr-10 sm:p-6 sm:pr-10' : 'p-4 pr-10',
+                )}
+            >
+                {code}
+            </pre>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/CodeBlock.tsx
+++ b/app/features/mcp-docs/ui/CodeBlock.tsx
@@ -8,15 +8,20 @@ import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 /**
  * Multiline code snippet with a copy affordance (`Copyable` is inline-only, hence a dedicated block).
  * `flush` drops the own border/rounding for use as a full-bleed segment inside a card.
+ *
+ * `wrap` soft-wraps long lines — right for prose-like snippets. The default keeps lines intact and
+ * scrolls horizontally instead, so structured code (JSON, commands) doesn't break mid-token on mobile.
  */
 export function CodeBlock({
     code,
     className,
     variant = 'panel',
+    wrap = false,
 }: {
     code: string;
     className?: string;
     variant?: 'panel' | 'flush';
+    wrap?: boolean;
 }) {
     const [state, copy] = useCopyToClipboard(1000);
 
@@ -50,7 +55,10 @@ export function CodeBlock({
             </button>
             <pre
                 className={cn(
-                    'm-0 whitespace-pre-wrap font-mono text-xs leading-relaxed text-neutral-200 [overflow-wrap:anywhere]',
+                    'm-0 font-mono text-xs leading-relaxed text-neutral-200',
+                    wrap
+                        ? 'whitespace-pre-wrap [overflow-wrap:anywhere]'
+                        : 'overflow-x-auto whitespace-pre [scrollbar-width:thin]',
                     // Flush segments sit inside a p-6 card section — match its padding.
                     variant === 'flush' ? 'p-4 pr-10 sm:p-6 sm:pr-10' : 'p-4 pr-10',
                 )}

--- a/app/features/mcp-docs/ui/EndpointStatus.tsx
+++ b/app/features/mcp-docs/ui/EndpointStatus.tsx
@@ -1,0 +1,33 @@
+import { ExternalLink } from 'react-feather';
+
+export type EndpointStatus = { state: 'checking' | 'ready' | 'disabled'; ms?: number };
+
+/** Renders the live health-probe result: checking spinner text, a ready dot with latency, or a disabled state. */
+export function EndpointStatusValue({ status }: { status: EndpointStatus }) {
+    if (status.state === 'checking') {
+        return <span className="text-neutral-500">Checking…</span>;
+    }
+    if (status.state === 'disabled') {
+        return (
+            <span className="flex items-center gap-1.5">
+                <span className="size-1.5 rounded-full bg-neutral-500" aria-hidden />
+                Disabled
+                <a
+                    href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-dark-accent no-underline"
+                >
+                    How to run
+                    <ExternalLink size={12} aria-hidden />
+                </a>
+            </span>
+        );
+    }
+    return (
+        <span className="flex items-center gap-1.5">
+            <span className="size-1.5 rounded-full bg-dark-accent" aria-hidden />
+            Ready{status.ms !== undefined && <span className="text-neutral-500">· {status.ms} ms</span>}
+        </span>
+    );
+}

--- a/app/features/mcp-docs/ui/EndpointStatus.tsx
+++ b/app/features/mcp-docs/ui/EndpointStatus.tsx
@@ -1,11 +1,28 @@
 import { ExternalLink } from 'react-feather';
 
-export type EndpointStatus = { state: 'checking' | 'ready' | 'disabled'; ms?: number };
+export type EndpointStatus = { state: 'checking' | 'ready' | 'restricted' | 'disabled'; ms?: number };
 
-/** Renders the live health-probe result: checking spinner text, a ready dot with latency, or a disabled state. */
+/** Renders the live health-probe result: checking spinner text, a ready dot with latency, a restricted state, or a disabled state. */
 export function EndpointStatusValue({ status }: { status: EndpointStatus }) {
     if (status.state === 'checking') {
         return <span className="text-neutral-500">Checking…</span>;
+    }
+    if (status.state === 'restricted') {
+        return (
+            <span className="flex items-center gap-1.5">
+                <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
+                Restricted — access key required
+                <a
+                    href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-dark-accent no-underline"
+                >
+                    How to run
+                    <ExternalLink size={12} aria-hidden />
+                </a>
+            </span>
+        );
     }
     if (status.state === 'disabled') {
         return (

--- a/app/features/mcp-docs/ui/EndpointStatus.tsx
+++ b/app/features/mcp-docs/ui/EndpointStatus.tsx
@@ -1,8 +1,8 @@
 import { ExternalLink } from 'react-feather';
 
-export type EndpointStatus = { state: 'checking' | 'ready' | 'restricted' | 'disabled'; ms?: number };
+export type EndpointStatus = { state: 'checking' | 'ready' | 'restricted' | 'blocked' | 'disabled'; ms?: number };
 
-/** Renders the live health-probe result: checking spinner text, a ready dot with latency, a restricted state, or a disabled state. */
+/** Renders the live health-probe result: checking spinner text, a ready dot with latency, a restricted state, a blocked state, or a disabled state. */
 export function EndpointStatusValue({ status }: { status: EndpointStatus }) {
     if (status.state === 'checking') {
         return <span className="text-neutral-500">Checking…</span>;
@@ -12,6 +12,23 @@ export function EndpointStatusValue({ status }: { status: EndpointStatus }) {
             <span className="flex items-center gap-1.5">
                 <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
                 Restricted — access key required
+                <a
+                    href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-dark-accent no-underline"
+                >
+                    How to run
+                    <ExternalLink size={12} aria-hidden />
+                </a>
+            </span>
+        );
+    }
+    if (status.state === 'blocked') {
+        return (
+            <span className="flex items-center gap-1.5">
+                <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
+                Blocked — your IP isn’t allowed
                 <a
                     href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
                     target="_blank"

--- a/app/features/mcp-docs/ui/ExamplesCarousel.tsx
+++ b/app/features/mcp-docs/ui/ExamplesCarousel.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Tool } from 'react-feather';
+
+import { cn } from '@/app/components/shared/utils';
+import { Card } from '@/app/shared/ui/Card';
+
+import { scrollSectionToTop, useStickyRelease } from '../lib/useStickyTabs';
+
+/** Table inside an example answer, mirroring the tables the agent printed. */
+function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
+    return (
+        // The rounded outer border lives on the wrapper (kept intact by the scroll container's clipping); cells
+        // draw only the inner grid lines, so no border is lost at the corners.
+        <div className="overflow-x-auto rounded-lg border border-solid border-white/10">
+            <table className="w-full border-collapse text-xs">
+                <thead>
+                    <tr>
+                        {head.map(title => (
+                            <th
+                                key={title}
+                                className="border-0 border-b border-r border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400 last:border-r-0"
+                            >
+                                {title}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map(row => (
+                        <tr key={row[0]}>
+                            {row.map(cell => (
+                                <td
+                                    key={cell}
+                                    className="border-0 border-r border-t border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 [overflow-wrap:anywhere] last:border-r-0"
+                                >
+                                    {cell}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+/** Bold intra-answer heading, standing in for the terminal's highlighted lines. */
+function AnswerHeading({ children }: { children: React.ReactNode }) {
+    return <p className="m-0 font-medium text-white">{children}</p>;
+}
+
+// Real conversations with a coding agent connected to this MCP server, shortened
+// without losing the facts; the long tails sit in `more` behind "Expand message".
+const EXAMPLES: { answer: React.ReactNode; label: string; more?: React.ReactNode; question: string; tool: string }[] = [
+    {
+        answer: (
+            <>
+                <p className="m-0">{'USDC (EPjFWdd5...) — SPL Token mint on mainnet-beta:'}</p>
+                <AnswerTable
+                    head={['Field', 'Value']}
+                    rows={[
+                        ['Mint authority', 'BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG'],
+                        ['Supply', '7748676460441051 raw → 7,748,676,460.441051 USDC'],
+                        ['Decimals', '6'],
+                    ]}
+                />
+                <p className="m-0">
+                    {
+                        'Supply is variable (mint authority present); freeze authority is 7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar.'
+                    }
+                </p>
+            </>
+        ),
+        label: 'Token mint',
+        question: 'What are the mint authority, supply and decimals of EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: (
+            <>
+                <p className="m-0">
+                    {'Squads Multisig Program (SQDS4ep65T...) — BPF upgradeable-loader program on mainnet-beta.'}
+                </p>
+                <p className="m-0">
+                    {
+                        'Upgradeable: no — upgrade_authority: null, the authority was revoked, so the program is frozen. Last deployed at slot 302582236; executable data lives at Fy3YMJCvwbAXUgUM5b91ucUVA3jYzwWLHL3MwBqKsh8n.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'IDL: yes — published on-chain via Anchor, served as Codama, program name "Squads Multisig Program".'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Extras: a verified build against Squads-Protocol/v4 @ 2a47b4c (signer sqdcVVoTcKZjXU8yPUwKFbGx1Hig1rhbWJQtMRXp2E1) and an embedded security.txt — audited by OtterSec and Neodyme, contact security@sqds.io.'
+                    }
+                </p>
+            </>
+        ),
+        label: 'Program inspection',
+        question: 'Inspect SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf — is it upgradeable and does it publish an IDL?',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: (
+            <>
+                <p className="m-0">
+                    {
+                        'A v0 message, success, finalized at slot 439023338. One signer: EVybKZ6kp8CccQSkcAdfsstG5aX8mbQQC6jrKTcuFhVp. Fee 5000 lamports, CU consumed 67888; 53 accounts total, 34 pulled in from 5 address lookup tables.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'There are no inner instructions — anywhere: three invoke [1] lines in the logs and no [2] depth at all. That is the most interesting fact in this transaction.'
+                    }
+                </p>
+            </>
+        ),
+        label: 'Transaction walkthrough',
+        more: (
+            <>
+                <AnswerHeading>Instruction 1 — ComputeBudget</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'SetComputeUnitLimit, value 600,000. No SetComputeUnitPrice anywhere, so no priority fee — the 5000 lamport fee is base fee only.'
+                    }
+                </p>
+                <AnswerHeading>Instruction 2 — System transfer</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'system::transfer, 1002 lamports from EVybKZ6k… (the signer) → Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY. Trivially small, and not a Jito tip pattern.'
+                    }
+                </p>
+                <AnswerHeading>
+                    Instruction 3 — unknown program 8GCr9711iFUmGdW4vPGoBYHoLEACKHKY8aycYNuxViXk
+                </AnswerHeading>
+                <p className="m-0">
+                    {
+                        'The whole payload of the transaction: 53 account references, 154 bytes of data, 67,588 CU consumed. Not decodable — the program is unverified and publishes no IDL (authority 2zYaeycd8jK1RjH9ZXLTHJp13xjmdC5FhPpSWtZrsXwp, deployed at slot 436916586), so the instruction stays raw.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'The account list still talks: LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo (Meteora DLMM), pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA (PumpSwap AMM) plus pfeeUxB6… (PumpSwap fee config), full token infra, and pool/vault-looking accounts from the lookup tables — a multi-venue swap router shape.'
+                    }
+                </p>
+                <AnswerHeading>The thing worth flagging</AnswerHeading>
+                <p className="m-0">
+                    {
+                        'A 53-account instruction touching two AMM programs issued zero CPIs — it burned 67.5k CU reading accounts and returned success without invoking Token, Meteora, or PumpSwap even once. The consistent read (inference, not proof) is an arbitrage/MEV bot: load candidate pools, compute profitability on-chain, exit cleanly when the opportunity is not there. For certainty you would need the program source or a dump of its executable data (FkFnystz3DzSqDr3o64nLsUkecA9dvd9nNTrHZZBCtwQ).'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'The 154-byte payload has no recognizable Anchor discriminator; two constants stand out — e8764817 = 390,000,000 (0.39 SOL if lamports) and a trailing f64 1.0, which reads like a threshold/slippage parameter.'
+                    }
+                </p>
+            </>
+        ),
+        question:
+            'Walk me through this transaction signature 3MVAxtaFp76y23DBd3MdXTEjpzH8zFtVB1HtVdYSKqZPpx1R9gEkDXCF9bX26vkAvyerz2K54eMCFF7cPpkzArM1 instruction by instruction, including inner instructions.',
+        tool: 'inspect_entity',
+    },
+    {
+        answer: (
+            <>
+                <p className="m-0">
+                    {
+                        '"Sent from my Pumpfun App" (App) — Token-2022 mint, 6 decimals, supply 912,905,455.031061 App, fixed.'
+                    }
+                </p>
+                <p className="m-0">{'Only two extensions, and nobody can change any of them:'}</p>
+                <AnswerTable
+                    head={['Extension', 'Current state', 'Who can change it']}
+                    rows={[
+                        ['metadataPointer', 'points at the mint itself', 'authority: null — nobody'],
+                        [
+                            'tokenMetadata',
+                            'name "Sent from my Pumpfun App", symbol "App", uri, no additional fields',
+                            'updateAuthority: null — nobody',
+                        ],
+                    ]}
+                />
+            </>
+        ),
+        label: 'Token-2022 extensions',
+        more: (
+            <>
+                <p className="m-0">
+                    {
+                        'Mint and freeze authorities are also null (supply_type: fixed), and the extensions that carry real issuer power are simply absent: no permanentDelegate, no transferHook, no transferFeeConfig, no confidential-transfer config. There is no key anywhere with authority over this mint.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Two caveats before reading that as "safe": the on-chain metadata pointer is frozen, but it points at https://md.sdfgsdfsdf.uk/metadata/XGrhDXnd — whoever controls that domain can change the name, image and description at any time; and mint-level renunciation says nothing about liquidity or holder concentration — no authority to rug the mint ≠ no way to rug.'
+                    }
+                </p>
+                <p className="m-0">
+                    {
+                        'Incidentally, this mint appeared in the transaction above — one of the read-only accounts pulled in from lookup table BMAAGcWbUNNVE15DpETYXBW7L1Ba4jqq1JywECkzNLSW in instruction 3, consistent with scanning pools for this token and finding nothing worth executing.'
+                    }
+                </p>
+            </>
+        ),
+        question:
+            'Which Token-2022 extensions are enabled on this mint 49nkLrXi8nCZBVKsShDNasEtPe4Vn1mx9Xbr3kTa8pTL, and who can still change them?',
+        tool: 'inspect_entity',
+    },
+];
+
+const EXAMPLE_ROTATION_MS = 6000;
+
+/**
+ * Chat-app layout: example titles as a "chat list" beside a vertical divider,
+ * the selected conversation on the right. Auto-advances; hovering the card
+ * pauses the rotation, and any tap/click (a chat or "Expand message") parks it
+ * until the section scrolls out of view — important on touch devices with no
+ * hover. Long conversations start collapsed behind "Expand message" and
+ * collapse again on every conversation change.
+ */
+export function ExamplesCarousel() {
+    const [index, setIndex] = useState(0);
+    const [hovered, setHovered] = useState(false);
+    const [engaged, setEngaged] = useState(false);
+    const [expanded, setExpanded] = useState(false);
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const sticky = useStickyRelease();
+
+    useEffect(() => {
+        if (hovered || engaged) {
+            return;
+        }
+        const timer = setInterval(() => setIndex(current => (current + 1) % EXAMPLES.length), EXAMPLE_ROTATION_MS);
+        return () => clearInterval(timer);
+        // `index` restarts the timer after an auto-advance so every conversation gets a full period.
+    }, [hovered, engaged, index]);
+
+    // Every newly shown conversation starts collapsed — including returning to one expanded before.
+    useEffect(() => setExpanded(false), [index]);
+
+    // A tap/click parks the rotation; leaving the viewport re-arms it.
+    useEffect(() => {
+        if (!engaged || rootRef.current === null) {
+            return;
+        }
+        const observer = new IntersectionObserver(([entry]) => {
+            if (!entry.isIntersecting) {
+                setEngaged(false);
+            }
+        });
+        observer.observe(rootRef.current);
+        return () => observer.disconnect();
+    }, [engaged]);
+
+    return (
+        <Card
+            variant="tight"
+            ref={sticky.sectionRef}
+            className="mb-12 !bg-transparent"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+        >
+            <div ref={rootRef} className="flex flex-col sm:flex-row">
+                {/* Chat list — mobile: a sticky, horizontal, scrollable underline tab strip (like Setup/Tools);
+                    desktop: a static vertical sidebar with a left-bar active marker. */}
+                <div
+                    ref={sticky.stripRef}
+                    role="tablist"
+                    aria-label="Examples"
+                    className={cn(
+                        'sticky top-0 z-10 flex shrink-0 flex-row gap-x-5 overflow-x-auto rounded-t-[11px] border-0 border-b border-solid border-white/10 bg-dark-background px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                        'sm:static sm:z-auto sm:w-52 sm:flex-col sm:gap-x-0 sm:overflow-visible sm:rounded-none sm:border-b-0 sm:border-r sm:bg-transparent sm:px-0 sm:py-3',
+                    )}
+                >
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <button
+                                key={example.label}
+                                type="button"
+                                role="tab"
+                                aria-selected={active}
+                                onClick={() => {
+                                    setIndex(exampleIndex);
+                                    // Re-selecting the current chat won't change `index` — collapse explicitly.
+                                    setExpanded(false);
+                                    setEngaged(true);
+                                    // Switching chats resets scroll to the top of the new conversation.
+                                    scrollSectionToTop(sticky.sectionRef.current);
+                                }}
+                                className={cn(
+                                    'cursor-pointer whitespace-nowrap border-0 bg-transparent px-0 py-4 text-left text-sm transition-colors sm:px-4 sm:py-3',
+                                    // Active marker: underline on mobile, left bar on the desktop sidebar.
+                                    'border-b-2 border-solid sm:border-b-0 sm:border-l-2',
+                                    active
+                                        ? 'border-dark-accent text-white sm:bg-heavy-metal-900'
+                                        : 'border-transparent text-neutral-400 hover:text-neutral-200 sm:hover:bg-heavy-metal-900',
+                                )}
+                            >
+                                {example.label}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                {/* Conversation view: the active conversation defines the height (no inner scroll);
+                    inactive ones sit absolutely on top of it, kept mounted for the cross-fade. */}
+                <div className="relative min-w-0 grow">
+                    {EXAMPLES.map((example, exampleIndex) => {
+                        const active = exampleIndex === index;
+                        return (
+                            <div
+                                key={example.label}
+                                aria-hidden={!active}
+                                className={cn(
+                                    'flex flex-col gap-2 p-4 transition-opacity duration-500 sm:p-6',
+                                    active
+                                        ? 'opacity-100'
+                                        : 'pointer-events-none absolute inset-0 overflow-hidden opacity-0',
+                                )}
+                            >
+                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white [overflow-wrap:anywhere]">
+                                    {example.question}
+                                </div>
+                                <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
+                                    <Tool size={12} aria-hidden />
+                                    <span>
+                                        Ran <span className="font-mono text-neutral-400">{example.tool}</span> ·
+                                        Explorer MCP
+                                    </span>
+                                </div>
+                                <div className="flex max-w-[85%] flex-col gap-3 self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300 [overflow-wrap:anywhere]">
+                                    {example.answer}
+                                    {expanded && example.more}
+                                    {example.more !== undefined && !expanded && (
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setExpanded(true);
+                                                setEngaged(true);
+                                            }}
+                                            // Match the link hover: `<a>` darkens via the global `a:hover`;
+                                            // a `<button>` isn't covered by it, so set the same token explicitly.
+                                            className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:text-dark-accent-hover"
+                                        >
+                                            Expand message
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </Card>
+    );
+}

--- a/app/features/mcp-docs/ui/ExamplesCarousel.tsx
+++ b/app/features/mcp-docs/ui/ExamplesCarousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Tool } from 'react-feather';
 
 import { cn } from '@/app/components/shared/utils';
@@ -212,59 +212,22 @@ const EXAMPLES: { answer: React.ReactNode; label: string; more?: React.ReactNode
     },
 ];
 
-const EXAMPLE_ROTATION_MS = 6000;
-
 /**
  * Chat-app layout: example titles as a "chat list" beside a vertical divider,
- * the selected conversation on the right. Auto-advances; hovering the card
- * pauses the rotation, and any tap/click (a chat or "Expand message") parks it
- * until the section scrolls out of view — important on touch devices with no
- * hover. Long conversations start collapsed behind "Expand message" and
- * collapse again on every conversation change.
+ * the selected conversation on the right. Click a title to switch conversations.
+ * Long conversations start collapsed behind "Expand message" and collapse again
+ * on every conversation change.
  */
 export function ExamplesCarousel() {
     const [index, setIndex] = useState(0);
-    const [hovered, setHovered] = useState(false);
-    const [engaged, setEngaged] = useState(false);
     const [expanded, setExpanded] = useState(false);
-    const rootRef = useRef<HTMLDivElement | null>(null);
     const sticky = useStickyRelease();
 
-    useEffect(() => {
-        if (hovered || engaged) {
-            return;
-        }
-        const timer = setInterval(() => setIndex(current => (current + 1) % EXAMPLES.length), EXAMPLE_ROTATION_MS);
-        return () => clearInterval(timer);
-        // `index` restarts the timer after an auto-advance so every conversation gets a full period.
-    }, [hovered, engaged, index]);
-
-    // Every newly shown conversation starts collapsed — including returning to one expanded before.
-    useEffect(() => setExpanded(false), [index]);
-
-    // A tap/click parks the rotation; leaving the viewport re-arms it.
-    useEffect(() => {
-        if (!engaged || rootRef.current === null) {
-            return;
-        }
-        const observer = new IntersectionObserver(([entry]) => {
-            if (!entry.isIntersecting) {
-                setEngaged(false);
-            }
-        });
-        observer.observe(rootRef.current);
-        return () => observer.disconnect();
-    }, [engaged]);
+    const active = EXAMPLES[index];
 
     return (
-        <Card
-            variant="tight"
-            ref={sticky.sectionRef}
-            className="mb-12 !bg-transparent"
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-        >
-            <div ref={rootRef} className="flex flex-col sm:flex-row">
+        <Card variant="tight" ref={sticky.sectionRef} className="mb-12 !border-white/10 !bg-transparent">
+            <div className="flex flex-col sm:flex-row">
                 {/* Chat list — mobile: a sticky, horizontal, scrollable underline tab strip (like Setup/Tools);
                     desktop: a static vertical sidebar with a left-bar active marker. */}
                 <div
@@ -277,26 +240,24 @@ export function ExamplesCarousel() {
                     )}
                 >
                     {EXAMPLES.map((example, exampleIndex) => {
-                        const active = exampleIndex === index;
+                        const isActive = exampleIndex === index;
                         return (
                             <button
                                 key={example.label}
                                 type="button"
                                 role="tab"
-                                aria-selected={active}
+                                aria-selected={isActive}
                                 onClick={() => {
                                     setIndex(exampleIndex);
-                                    // Re-selecting the current chat won't change `index` — collapse explicitly.
+                                    // Switching chats collapses the long tail and resets scroll to the top.
                                     setExpanded(false);
-                                    setEngaged(true);
-                                    // Switching chats resets scroll to the top of the new conversation.
                                     scrollSectionToTop(sticky.sectionRef.current);
                                 }}
                                 className={cn(
                                     'cursor-pointer whitespace-nowrap border-0 bg-transparent px-0 py-4 text-left text-sm transition-colors sm:px-4 sm:py-3',
                                     // Active marker: underline on mobile, left bar on the desktop sidebar.
                                     'border-b-2 border-solid sm:border-b-0 sm:border-l-2',
-                                    active
+                                    isActive
                                         ? 'border-dark-accent text-white sm:bg-heavy-metal-900'
                                         : 'border-transparent text-neutral-400 hover:text-neutral-200 sm:hover:bg-heavy-metal-900',
                                 )}
@@ -307,53 +268,34 @@ export function ExamplesCarousel() {
                     })}
                 </div>
 
-                {/* Conversation view: the active conversation defines the height (no inner scroll);
-                    inactive ones sit absolutely on top of it, kept mounted for the cross-fade. */}
-                <div className="relative min-w-0 grow">
-                    {EXAMPLES.map((example, exampleIndex) => {
-                        const active = exampleIndex === index;
-                        return (
-                            <div
-                                key={example.label}
-                                aria-hidden={!active}
-                                className={cn(
-                                    'flex flex-col gap-2 p-4 transition-opacity duration-500 sm:p-6',
-                                    active
-                                        ? 'opacity-100'
-                                        : 'pointer-events-none absolute inset-0 overflow-hidden opacity-0',
-                                )}
-                            >
-                                <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white [overflow-wrap:anywhere]">
-                                    {example.question}
-                                </div>
-                                <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
-                                    <Tool size={12} aria-hidden />
-                                    <span>
-                                        Ran <span className="font-mono text-neutral-400">{example.tool}</span> ·
-                                        Explorer MCP
-                                    </span>
-                                </div>
-                                <div className="flex max-w-[85%] flex-col gap-3 self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300 [overflow-wrap:anywhere]">
-                                    {example.answer}
-                                    {expanded && example.more}
-                                    {example.more !== undefined && !expanded && (
-                                        <button
-                                            type="button"
-                                            onClick={() => {
-                                                setExpanded(true);
-                                                setEngaged(true);
-                                            }}
-                                            // Match the link hover: `<a>` darkens via the global `a:hover`;
-                                            // a `<button>` isn't covered by it, so set the same token explicitly.
-                                            className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:text-dark-accent-hover"
-                                        >
-                                            Expand message
-                                        </button>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    })}
+                {/* Conversation view: only the selected conversation is rendered. */}
+                <div className="min-w-0 grow">
+                    <div className="flex flex-col gap-2 p-4 sm:p-6">
+                        <div className="max-w-[85%] self-end rounded-2xl rounded-br-md border border-solid border-white/10 bg-white/10 px-4 py-2.5 text-sm leading-relaxed text-white [overflow-wrap:anywhere]">
+                            {active.question}
+                        </div>
+                        <div className="flex items-center gap-1.5 self-start px-1 text-xs text-neutral-500">
+                            <Tool size={12} aria-hidden />
+                            <span>
+                                Ran <span className="font-mono text-neutral-400">{active.tool}</span> · Explorer MCP
+                            </span>
+                        </div>
+                        <div className="flex max-w-[85%] flex-col gap-3 self-start rounded-2xl rounded-bl-md border border-solid border-white/10 bg-white/5 px-4 py-2.5 text-sm leading-relaxed text-neutral-300 [overflow-wrap:anywhere]">
+                            {active.answer}
+                            {expanded && active.more}
+                            {active.more !== undefined && !expanded && (
+                                <button
+                                    type="button"
+                                    onClick={() => setExpanded(true)}
+                                    // Match the link hover: `<a>` darkens via the global `a:hover`;
+                                    // a `<button>` isn't covered by it, so set the same token explicitly.
+                                    className="cursor-pointer self-start border-0 bg-transparent p-0 text-xs font-medium text-dark-accent hover:text-dark-accent-hover"
+                                >
+                                    Expand message
+                                </button>
+                            )}
+                        </div>
+                    </div>
                 </div>
             </div>
         </Card>

--- a/app/features/mcp-docs/ui/ExamplesCarousel.tsx
+++ b/app/features/mcp-docs/ui/ExamplesCarousel.tsx
@@ -8,41 +8,89 @@ import { Card } from '@/app/shared/ui/Card';
 
 import { scrollSectionToTop, useStickyRelease } from '../lib/useStickyTabs';
 
-/** Table inside an example answer, mirroring the tables the agent printed. */
-function AnswerTable({ head, rows }: { head: string[]; rows: string[][] }) {
+/**
+ * Table inside an example answer, mirroring the tables the agent printed.
+ *
+ * `breakAnywhere` controls the wrapping mode. Default (`false`) wraps at word
+ * boundaries (`break-words`): each column keeps a min-content width equal to its
+ * longest word, so auto-layout sizes columns to content instead of starving them
+ * to one character per line. Set it for tables whose cells hold long unbreakable
+ * values (base58 addresses) that must break mid-token to keep the table narrow.
+ */
+function AnswerTable({
+    head,
+    rows,
+    breakAnywhere = false,
+}: {
+    head: string[];
+    rows: string[][];
+    breakAnywhere?: boolean;
+}) {
+    const wrap = breakAnywhere ? '[overflow-wrap:anywhere]' : 'break-words';
     return (
-        // The rounded outer border lives on the wrapper (kept intact by the scroll container's clipping); cells
-        // draw only the inner grid lines, so no border is lost at the corners.
-        <div className="overflow-x-auto rounded-lg border border-solid border-white/10">
-            <table className="w-full border-collapse text-xs">
-                <thead>
-                    <tr>
-                        {head.map(title => (
-                            <th
-                                key={title}
-                                className="border-0 border-b border-r border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400 last:border-r-0"
-                            >
-                                {title}
-                            </th>
+        <>
+            {/* Mobile: a real multi-column table can't fit a phone, so stack each row as labelled
+                key/value pairs — readable without horizontal scroll. */}
+            <div className="rounded-lg border border-solid border-white/10 sm:hidden">
+                {rows.map((row, rowIndex) => (
+                    <div
+                        key={row[0]}
+                        className={cn(
+                            'flex flex-col gap-2 p-3',
+                            rowIndex > 0 && 'border-0 border-t border-solid border-white/10',
+                        )}
+                    >
+                        {row.map((cell, columnIndex) => (
+                            <div key={head[columnIndex]} className="flex flex-col gap-0.5">
+                                <span className="text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                                    {head[columnIndex]}
+                                </span>
+                                <span className={cn('text-xs text-neutral-300', wrap)}>{cell}</span>
+                            </div>
                         ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows.map(row => (
-                        <tr key={row[0]}>
-                            {row.map(cell => (
-                                <td
-                                    key={cell}
-                                    className="border-0 border-r border-t border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 [overflow-wrap:anywhere] last:border-r-0"
+                    </div>
+                ))}
+            </div>
+
+            {/* Desktop: the real table. The rounded outer border lives on the wrapper (kept intact by the
+                scroll container's clipping); cells draw only the inner grid lines, so no corner border is lost. */}
+            <div className="hidden overflow-x-auto rounded-lg border border-solid border-white/10 sm:block">
+                <table className="w-full border-collapse text-xs">
+                    <thead>
+                        <tr>
+                            {head.map(title => (
+                                <th
+                                    key={title}
+                                    className={cn(
+                                        'border-0 border-b border-r border-solid border-white/10 px-2.5 py-1.5 text-left font-medium text-neutral-400 last:border-r-0',
+                                        wrap,
+                                    )}
                                 >
-                                    {cell}
-                                </td>
+                                    {title}
+                                </th>
                             ))}
                         </tr>
-                    ))}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                        {rows.map(row => (
+                            <tr key={row[0]}>
+                                {row.map(cell => (
+                                    <td
+                                        key={cell}
+                                        className={cn(
+                                            'border-0 border-r border-t border-solid border-white/10 px-2.5 py-1.5 align-top text-neutral-300 last:border-r-0',
+                                            wrap,
+                                        )}
+                                    >
+                                        {cell}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </>
     );
 }
 
@@ -59,6 +107,7 @@ const EXAMPLES: { answer: React.ReactNode; label: string; more?: React.ReactNode
             <>
                 <p className="m-0">{'USDC (EPjFWdd5...) — SPL Token mint on mainnet-beta:'}</p>
                 <AnswerTable
+                    breakAnywhere
                     head={['Field', 'Value']}
                     rows={[
                         ['Mint authority', 'BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG'],

--- a/app/features/mcp-docs/ui/HeroFact.tsx
+++ b/app/features/mcp-docs/ui/HeroFact.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/** Label/value pair in the hero fact grid (status, endpoint, transport, …). */
+export function HeroFact({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex min-w-0 flex-col gap-1">
+            <span className="text-sm uppercase tracking-wide text-neutral-500">{label}</span>
+            <span className="text-sm text-neutral-200">{children}</span>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/InlineCode.tsx
+++ b/app/features/mcp-docs/ui/InlineCode.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react';
+
+import { cn } from '@/app/components/shared/utils';
+
+/** Inline code token styled for dark cards. */
+export function InlineCode({ children, className }: { children: ReactNode; className?: string }) {
+    return (
+        <code
+            className={cn(
+                'rounded bg-heavy-metal-900 px-1.5 py-0.5 font-mono text-xs text-neutral-200 [overflow-wrap:anywhere]',
+                className,
+            )}
+        >
+            {children}
+        </code>
+    );
+}

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -18,6 +18,12 @@ import { InlineCode } from './InlineCode';
 import { SectionTitle } from './SectionTitle';
 import { ToolsShowcase } from './ToolsShowcase';
 
+function probeState(status: number): EndpointStatus['state'] {
+    if (status >= 500) return 'disabled';
+    if (status === 401 || status === 403) return 'restricted';
+    return 'ready';
+}
+
 export function McpDocsOverviewView() {
     const origin = useDeploymentOrigin();
     const [client, setClient] = useState(SETUP_CLIENTS[0].id);
@@ -25,15 +31,18 @@ export function McpDocsOverviewView() {
     const setupSticky = useStickyRelease();
 
     // Live health probe: a bare GET to /mcp answers 4xx when the endpoint is up (it wants a POST with
-    // MCP headers) — that still means "reachable". Only a 5xx counts as not serving: 503 is the explicit
-    // "MCP disabled" sentinel (route.ts), and other 5xx / a network error mean it can't be reached.
+    // MCP headers) — that still means "reachable". But 401/403 mean the deployment gates access
+    // (MCP_ACCESS_KEYS set or the IP blocked, per route.ts): the endpoint is up yet the open, key-less
+    // config this page shows would be rejected, so surface it as "restricted" rather than "ready". Only
+    // a 5xx counts as not serving: 503 is the explicit "MCP disabled" sentinel (route.ts), and other 5xx
+    // / a network error mean it can't be reached.
     useEffect(() => {
         const started = performance.now();
         fetch('/mcp')
             .then(response =>
                 setStatus({
                     ms: Math.round(performance.now() - started),
-                    state: response.status >= 500 ? 'disabled' : 'ready',
+                    state: probeState(response.status),
                 }),
             )
             .catch(() => setStatus({ state: 'disabled' }));

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -20,7 +20,10 @@ import { ToolsShowcase } from './ToolsShowcase';
 
 function probeState(status: number): EndpointStatus['state'] {
     if (status >= 500) return 'disabled';
-    if (status === 401 || status === 403) return 'restricted';
+    // 403 is only ever a blocked IP (route.ts rejects it before the key check), so no access key
+    // or config change helps — keep it distinct from 401, which genuinely wants an access key.
+    if (status === 403) return 'blocked';
+    if (status === 401) return 'restricted';
     return 'ready';
 }
 
@@ -31,11 +34,12 @@ export function McpDocsOverviewView() {
     const setupSticky = useStickyRelease();
 
     // Live health probe: a bare GET to /mcp answers 4xx when the endpoint is up (it wants a POST with
-    // MCP headers) — that still means "reachable". But 401/403 mean the deployment gates access
-    // (MCP_ACCESS_KEYS set or the IP blocked, per route.ts): the endpoint is up yet the open, key-less
-    // config this page shows would be rejected, so surface it as "restricted" rather than "ready". Only
-    // a 5xx counts as not serving: 503 is the explicit "MCP disabled" sentinel (route.ts), and other 5xx
-    // / a network error mean it can't be reached.
+    // MCP headers) — that still means "reachable". 401 means the deployment gates access with a key
+    // (MCP_ACCESS_KEYS set, per route.ts): the endpoint is up yet the open, key-less config this page
+    // shows would be rejected, so surface it as "restricted". 403 is only a blocked IP (route.ts rejects
+    // it before the key check), which no config fixes — surface it as "blocked". Only a 5xx counts as not
+    // serving: 503 is the explicit "MCP disabled" sentinel (route.ts), and other 5xx / a network error
+    // mean it can't be reached.
     useEffect(() => {
         const started = performance.now();
         fetch('/mcp')

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -193,7 +193,7 @@ export function McpDocsOverviewView() {
                 </p>
                 {/* Snippet as the card's bottom segment behind a full-width divider (no nested card). */}
                 <div className="border-0 border-t border-solid border-white/10">
-                    <CodeBlock variant="flush" code={AGENT_INSTRUCTIONS_SNIPPET} />
+                    <CodeBlock variant="flush" wrap code={AGENT_INSTRUCTIONS_SNIPPET} />
                 </div>
             </Card>
 

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -48,6 +48,10 @@ export function McpDocsOverviewView() {
             .catch(() => setStatus({ state: 'disabled' }));
     }, []);
 
+    // A gated deployment (401/403) rejects the open, key-less config this page documents, so the copy
+    // must stop asserting "no key required" and tell the visitor an access key is needed.
+    const isRestricted = status.state === 'restricted';
+
     return (
         <div className="mx-auto w-full max-w-3xl px-4 py-10">
             {/* Hero */}
@@ -95,7 +99,11 @@ export function McpDocsOverviewView() {
                         <span className="text-sm">Streamable HTTP, stateless</span>
                     </HeroFact>
                     <HeroFact label="Auth">
-                        <span className="text-sm">Open — no key required</span>
+                        {isRestricted ? (
+                            <span className="text-sm text-amber-400">Access key required</span>
+                        ) : (
+                            <span className="text-sm">Open — no key required</span>
+                        )}
                     </HeroFact>
                     <HeroFact label="Clusters">
                         <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
@@ -109,11 +117,29 @@ export function McpDocsOverviewView() {
             {/* Setup */}
             <SectionTitle
                 id="setup"
-                subtitle="Pick your tool, copy the config — snippets already point at this deployment. No API key needed."
+                subtitle={
+                    isRestricted
+                        ? 'Pick your tool, copy the config — snippets already point at this deployment. This deployment requires an access key; add your authorization to the config before connecting.'
+                        : 'Pick your tool, copy the config — snippets already point at this deployment. No API key needed.'
+                }
             >
                 Setup
             </SectionTitle>
             <Card variant="tight" ref={setupSticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+                {isRestricted && (
+                    <div className="-mx-4 mb-4 rounded-t-[11px] border-0 border-b border-solid border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-200 sm:-mx-6 sm:px-6">
+                        This endpoint is gated — the key-less snippets below will be rejected until you add your access
+                        key.{' '}
+                        <a
+                            href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-dark-accent no-underline"
+                        >
+                            How to run
+                        </a>
+                    </div>
+                )}
                 <Tabs
                     value={client}
                     onValueChange={value => {

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -75,7 +75,7 @@ export function McpDocsOverviewView() {
                     </a>
                 </Button>
             </div>
-            <Card variant="tight" className="mb-12 !bg-transparent">
+            <Card variant="tight" className="mb-12 !border-white/10 !bg-transparent">
                 <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
                     <HeroFact label="Status">
                         <EndpointStatusValue status={status} />
@@ -125,7 +125,11 @@ export function McpDocsOverviewView() {
             >
                 Setup
             </SectionTitle>
-            <Card variant="tight" ref={setupSticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+            <Card
+                variant="tight"
+                ref={setupSticky.sectionRef}
+                className="mb-12 !border-white/10 px-4 pb-4 pt-0 sm:px-6 sm:pb-6"
+            >
                 {isRestricted && (
                     <div className="-mx-4 mb-4 rounded-t-[11px] border-0 border-b border-solid border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-200 sm:-mx-6 sm:px-6">
                         This endpoint is gated — the key-less snippets below will be rejected until you add your access
@@ -175,7 +179,7 @@ export function McpDocsOverviewView() {
             <SectionTitle subtitle="Teach the agent to reach for the Explorer instead of guessing — add the block below to the instructions file your tool reads.">
                 Agent instructions
             </SectionTitle>
-            <Card variant="tight" className="mb-12 overflow-hidden">
+            <Card variant="tight" className="mb-12 overflow-hidden !border-white/10">
                 <p className="m-0 p-4 text-sm text-neutral-300 sm:p-6">
                     {AGENT_INSTRUCTIONS_TARGETS.map((target, index) => (
                         <React.Fragment key={target.file}>

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { ExternalLink } from 'react-feather';
+
+import { Button } from '@/app/components/shared/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { Card } from '@/app/shared/ui/Card';
+
+import { AGENT_INSTRUCTIONS_SNIPPET, AGENT_INSTRUCTIONS_TARGETS, SETUP_CLIENTS } from '../lib/setup-clients';
+import { useDeploymentOrigin } from '../lib/useDeploymentOrigin';
+import { scrollSectionToTop, useStickyRelease } from '../lib/useStickyTabs';
+import { CodeBlock } from './CodeBlock';
+import { EndpointStatus, EndpointStatusValue } from './EndpointStatus';
+import { ExamplesCarousel } from './ExamplesCarousel';
+import { HeroFact } from './HeroFact';
+import { InlineCode } from './InlineCode';
+import { SectionTitle } from './SectionTitle';
+import { ToolsShowcase } from './ToolsShowcase';
+
+export function McpDocsOverviewView() {
+    const origin = useDeploymentOrigin();
+    const [client, setClient] = useState(SETUP_CLIENTS[0].id);
+    const [status, setStatus] = useState<EndpointStatus>({ state: 'checking' });
+    const setupSticky = useStickyRelease();
+
+    // Live health probe: a bare GET to /mcp answers 4xx when the endpoint is up (it wants a POST with
+    // MCP headers) — that still means "reachable". Only a 5xx counts as not serving: 503 is the explicit
+    // "MCP disabled" sentinel (route.ts), and other 5xx / a network error mean it can't be reached.
+    useEffect(() => {
+        const started = performance.now();
+        fetch('/mcp')
+            .then(response =>
+                setStatus({
+                    ms: Math.round(performance.now() - started),
+                    state: response.status >= 500 ? 'disabled' : 'ready',
+                }),
+            )
+            .catch(() => setStatus({ state: 'disabled' }));
+    }, []);
+
+    return (
+        <div className="mx-auto w-full max-w-3xl px-4 py-10">
+            {/* Hero */}
+            <h1 className="mb-4 mt-0 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                Live on-chain data for coding agents
+            </h1>
+            <p className="mb-6 mt-0 text-lg leading-relaxed text-neutral-300">
+                Connect your MCP client to the Explorer and let your agent read decoded on-chain state — accounts,
+                programs, tokens and transactions — with the same IDL decoding and enrichments the Explorer renders.
+            </p>
+            <div className="mb-8 flex flex-wrap gap-3">
+                {/* `!px-4` tightens the `lg` size's `px-8` (important beats it — cn has no tailwind-merge). */}
+                <Button asChild variant="accent" size="lg" className="!px-4">
+                    <a href="#setup" className="no-underline">
+                        Set up your agent
+                    </a>
+                </Button>
+                <Button asChild variant="outline" size="lg" className="!px-4">
+                    <a href="#tools" className="no-underline">
+                        Browse the tools
+                    </a>
+                </Button>
+            </div>
+            <Card variant="tight" className="mb-12 !bg-transparent">
+                <div className="grid gap-x-8 gap-y-4 p-4 sm:grid-cols-2 sm:p-6">
+                    <HeroFact label="Status">
+                        <EndpointStatusValue status={status} />
+                    </HeroFact>
+                    <HeroFact label="Endpoint">
+                        <a
+                            href={`${origin}/mcp`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sm text-dark-accent no-underline [overflow-wrap:anywhere]"
+                        >
+                            {`${origin}/mcp`}
+                            <ExternalLink
+                                size={12}
+                                aria-hidden
+                                className="relative -top-0.5 ml-1 inline align-text-bottom"
+                            />
+                        </a>
+                    </HeroFact>
+                    <HeroFact label="Transport">
+                        <span className="text-sm">Streamable HTTP, stateless</span>
+                    </HeroFact>
+                    <HeroFact label="Auth">
+                        <span className="text-sm">Open — no key required</span>
+                    </HeroFact>
+                    <HeroFact label="Clusters">
+                        <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
+                    </HeroFact>
+                    <HeroFact label="Tools">
+                        <span className="text-sm">inspect_entity · ping</span>
+                    </HeroFact>
+                </div>
+            </Card>
+
+            {/* Setup */}
+            <SectionTitle
+                id="setup"
+                subtitle="Pick your tool, copy the config — snippets already point at this deployment. No API key needed."
+            >
+                Setup
+            </SectionTitle>
+            <Card variant="tight" ref={setupSticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+                <Tabs
+                    value={client}
+                    onValueChange={value => {
+                        setClient(value);
+                        // Switching tabs resets scroll to the top of the (possibly shorter/taller) new panel.
+                        scrollSectionToTop(setupSticky.sectionRef.current);
+                    }}
+                >
+                    <TabsList
+                        ref={setupSticky.stripRef}
+                        // `!flex` overrides TabsList's base `inline-flex` (important beats it — cn has no tailwind-merge).
+                        className="sticky top-0 z-10 -mx-4 mb-4 !flex flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 [scrollbar-width:none] sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6 [&::-webkit-scrollbar]:hidden"
+                    >
+                        {SETUP_CLIENTS.map(({ id, label }) => (
+                            <TabsTrigger key={id} value={id} className="shrink-0 whitespace-nowrap">
+                                {label}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                    {SETUP_CLIENTS.map(setupClient => (
+                        <TabsContent key={setupClient.id} value={setupClient.id}>
+                            <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
+                            <CodeBlock code={setupClient.snippet(origin)} />
+                            <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
+                                <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
+                            </p>
+                        </TabsContent>
+                    ))}
+                </Tabs>
+            </Card>
+
+            {/* Agent instructions */}
+            <SectionTitle subtitle="Teach the agent to reach for the Explorer instead of guessing — add the block below to the instructions file your tool reads.">
+                Agent instructions
+            </SectionTitle>
+            <Card variant="tight" className="mb-12 overflow-hidden">
+                <p className="m-0 p-4 text-sm text-neutral-300 sm:p-6">
+                    {AGENT_INSTRUCTIONS_TARGETS.map((target, index) => (
+                        <React.Fragment key={target.file}>
+                            {index > 0 && <span className="text-neutral-500"> / </span>}
+                            <InlineCode>{target.file}</InlineCode>
+                        </React.Fragment>
+                    ))}
+                </p>
+                {/* Snippet as the card's bottom segment behind a full-width divider (no nested card). */}
+                <div className="border-0 border-t border-solid border-white/10">
+                    <CodeBlock variant="flush" code={AGENT_INSTRUCTIONS_SNIPPET} />
+                </div>
+            </Card>
+
+            {/* Tools */}
+            <SectionTitle
+                id="tools"
+                subtitle="The server registers two tools. Both are read-only — nothing signs, sends or mutates."
+            >
+                Tools
+            </SectionTitle>
+            <ToolsShowcase />
+
+            {/* Examples */}
+            <SectionTitle subtitle="Things worth asking once the server is connected.">Examples</SectionTitle>
+            <ExamplesCarousel />
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -119,7 +119,7 @@ export function McpDocsOverviewView() {
                 id="setup"
                 subtitle={
                     isRestricted
-                        ? 'Pick your tool, copy the config — snippets already point at this deployment. This deployment requires an access key; add your authorization to the config before connecting.'
+                        ? 'Pick your tool, copy the config — snippets already point at this deployment and carry an Authorization header. Replace <access-key> with the key this deployment was configured with before connecting.'
                         : 'Pick your tool, copy the config — snippets already point at this deployment. No API key needed.'
                 }
             >
@@ -132,8 +132,9 @@ export function McpDocsOverviewView() {
             >
                 {isRestricted && (
                     <div className="-mx-4 mb-4 rounded-t-[11px] border-0 border-b border-solid border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-200 sm:-mx-6 sm:px-6">
-                        This endpoint is gated — the key-less snippets below will be rejected until you add your access
-                        key.{' '}
+                        This endpoint is gated — the snippets below include an <InlineCode>Authorization</InlineCode>{' '}
+                        header; swap <InlineCode>&lt;access-key&gt;</InlineCode> for the key this deployment was
+                        configured with.{' '}
                         <a
                             href="https://github.com/solana-foundation/explorer/blob/master/app/mcp/README.md"
                             target="_blank"
@@ -165,8 +166,10 @@ export function McpDocsOverviewView() {
                     </TabsList>
                     {SETUP_CLIENTS.map(setupClient => (
                         <TabsContent key={setupClient.id} value={setupClient.id}>
-                            <p className="mb-3 mt-0 text-sm text-neutral-300">{setupClient.where}</p>
-                            <CodeBlock code={setupClient.snippet(origin)} />
+                            <p className="mb-3 mt-0 text-sm text-neutral-300">
+                                {isRestricted ? (setupClient.restrictedWhere ?? setupClient.where) : setupClient.where}
+                            </p>
+                            <CodeBlock code={setupClient.snippet(origin, isRestricted)} />
                             <p className="mb-0 mt-3 text-sm leading-relaxed text-neutral-300">
                                 <span className="font-medium text-neutral-300">Verify:</span> {setupClient.verify}
                             </p>

--- a/app/features/mcp-docs/ui/SectionTitle.tsx
+++ b/app/features/mcp-docs/ui/SectionTitle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/** Section heading with an optional subtitle; `id` provides the in-page anchor target. */
+export function SectionTitle({
+    children,
+    id,
+    subtitle,
+}: {
+    children: React.ReactNode;
+    id?: string;
+    subtitle?: string;
+}) {
+    return (
+        <div className="mb-5 scroll-mt-6" id={id}>
+            <h2 className="m-0 text-2xl font-semibold text-white">{children}</h2>
+            {subtitle && <p className="mb-0 mt-1.5 text-sm text-neutral-300">{subtitle}</p>}
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/ToolsShowcase.tsx
+++ b/app/features/mcp-docs/ui/ToolsShowcase.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Minus, Plus } from 'react-feather';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { Card } from '@/app/shared/ui/Card';
+
+import { scrollSectionToTop, useStickyRelease } from '../lib/useStickyTabs';
+import { CodeBlock } from './CodeBlock';
+import { InlineCode } from './InlineCode';
+
+const INSPECT_ENTITY_COVERS = [
+    'SPL Token and Token-2022 mints, token accounts and multisigs, including parsed Token-2022 extensions.',
+    'Upgradeable programs — upgradeability, upgrade authority, last deploy slot and on-chain IDL discovery.',
+    'Stake, vote, nonce, sysvar, config, address lookup table and feature accounts.',
+    'Compressed NFTs, nftoken accounts and Solana Attestation Service accounts.',
+    'Transactions — signers, fee, status and instructions with inner instructions, decoded through IDL, bundled and raw sources.',
+    'Accounts of unrecognised programs, decoded through the owner program’s on-chain IDL when it publishes one.',
+];
+
+// A real reply: USDC mint on mainnet-beta.
+const INSPECT_ENTITY_RESPONSE = `{
+    "payload": {
+        "entity": {
+            "kind": "spl-token:mint",
+            "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "decimals": 6,
+            "freeze_authority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
+            "is_initialized": true,
+            "mint_authority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
+            "supply": "7902797573976355",
+            "supply_type": "variable",
+            "token_program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+    },
+    "errors": []
+}`;
+
+const TOOL_NAMES = ['inspect_entity', 'ping'] as const;
+
+// Tab labels: plain words, capitalised. The tab `value` stays the raw tool name (it keys the panels).
+const TOOL_LABELS: Record<(typeof TOOL_NAMES)[number], string> = {
+    inspect_entity: 'Inspect entity',
+    ping: 'Ping',
+};
+
+/** Tool reference behind the same underline-tab navigation as the Setup card. */
+export function ToolsShowcase() {
+    const [tool, setTool] = useState<string>(TOOL_NAMES[0]);
+    const sticky = useStickyRelease();
+
+    return (
+        <Card variant="tight" ref={sticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+            <Tabs
+                value={tool}
+                onValueChange={value => {
+                    setTool(value);
+                    // Switching tabs resets scroll to the top of the new panel.
+                    scrollSectionToTop(sticky.sectionRef.current);
+                }}
+            >
+                <TabsList
+                    ref={sticky.stripRef}
+                    // `!flex` overrides TabsList's base `inline-flex` (important beats it — cn has no tailwind-merge).
+                    className="sticky top-0 z-10 -mx-4 mb-4 !flex flex-nowrap gap-x-5 overflow-x-auto rounded-t-[11px] border-b border-white/10 bg-heavy-metal-800 px-4 [scrollbar-width:none] sm:static sm:-mx-6 sm:rounded-none sm:bg-transparent sm:px-6 [&::-webkit-scrollbar]:hidden"
+                >
+                    {TOOL_NAMES.map(name => (
+                        <TabsTrigger key={name} value={name} className="shrink-0 whitespace-nowrap">
+                            {TOOL_LABELS[name]}
+                        </TabsTrigger>
+                    ))}
+                </TabsList>
+                <TabsContent value="inspect_entity">
+                    <InspectEntityDoc />
+                </TabsContent>
+                <TabsContent value="ping">
+                    <PingDoc />
+                </TabsContent>
+            </Tabs>
+        </Card>
+    );
+}
+
+function InspectEntityDoc() {
+    return (
+        <div>
+            <p className="m-0 text-base leading-relaxed text-neutral-300">
+                Retrieves detailed on-chain data for any Solana address or transaction signature. The tool detects which
+                one it was given.
+            </p>
+
+            <ToolDocDivider />
+            <ToolDocSection title="What it covers" defaultOpen={false}>
+                <ul className="m-0 mt-3 flex list-none flex-col gap-1.5 p-0 text-sm leading-relaxed text-neutral-300">
+                    {INSPECT_ENTITY_COVERS.map(item => (
+                        <li key={item} className="flex gap-2">
+                            <span className="mt-[7px] size-1 shrink-0 rounded-full bg-neutral-600" aria-hidden />
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+            </ToolDocSection>
+
+            <ToolDocDivider />
+            <ToolDocSection title="Request parameters">
+                <div className="mt-3 flex flex-col gap-3">
+                    <ToolParam name="identifier" required>
+                        A base58 string, 1–128 characters: a 32-byte account address or a 64-byte transaction signature.
+                    </ToolParam>
+                    <ToolParam name="cluster">
+                        One of <InlineCode>mainnet-beta</InlineCode>, <InlineCode>devnet</InlineCode>,{' '}
+                        <InlineCode>testnet</InlineCode>, <InlineCode>simd296</InlineCode>. Defaults to{' '}
+                        <InlineCode>mainnet-beta</InlineCode>.
+                    </ToolParam>
+                </div>
+            </ToolDocSection>
+
+            <ToolDocDivider />
+            <ToolDocSection title="Response">
+                <div className="mt-3">
+                    <CodeBlock code={INSPECT_ENTITY_RESPONSE} />
+                    <p className="mb-0 mt-4 text-sm leading-relaxed text-neutral-300">
+                        Accounts owned by the legacy loaders are not supported yet and answer with a{' '}
+                        <InlineCode>CURRENTLY_UNSUPPORTED</InlineCode> error. Fields that cannot be resolved come back
+                        as explicit unknown markers rather than being dropped.
+                    </p>
+                </div>
+            </ToolDocSection>
+        </div>
+    );
+}
+
+/** Collapsible tool-doc section: heading with the +/- right after it, framed by the dividers. */
+function ToolDocSection({
+    children,
+    defaultOpen = true,
+    title,
+}: {
+    children: React.ReactNode;
+    defaultOpen?: boolean;
+    title: string;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+
+    return (
+        <div>
+            <button
+                type="button"
+                aria-expanded={open}
+                onClick={() => setOpen(current => !current)}
+                className="group flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left"
+            >
+                <h4 className="m-0 text-sm font-medium text-white">{title}</h4>
+                <span className="text-neutral-500 transition-colors group-hover:text-dark-accent">
+                    {open ? <Minus size={14} aria-hidden /> : <Plus size={14} aria-hidden />}
+                </span>
+            </button>
+            {open && children}
+        </div>
+    );
+}
+
+/** Full-bleed rule between the tool-doc sections (compensates the card padding). */
+function ToolDocDivider() {
+    return <div className="-mx-4 my-4 border-0 border-t border-solid border-white/10 sm:-mx-6" />;
+}
+
+function PingDoc() {
+    return (
+        <p className="m-0 text-base leading-relaxed text-neutral-300">
+            Basic health tool. Takes no arguments and answers <InlineCode>pong</InlineCode>. Ask the agent to call it to
+            verify the connection end-to-end.
+        </p>
+    );
+}
+
+function ToolParam({ name, required, children }: { name: string; required?: boolean; children: React.ReactNode }) {
+    return (
+        <div>
+            <div className="flex items-baseline gap-2">
+                <InlineCode>{name}</InlineCode>
+                <span className="text-xs text-neutral-500">{required ? 'required' : 'optional'}</span>
+            </div>
+            <p className="mb-0 mt-1.5 text-sm leading-relaxed text-neutral-300">{children}</p>
+        </div>
+    );
+}

--- a/app/features/mcp-docs/ui/ToolsShowcase.tsx
+++ b/app/features/mcp-docs/ui/ToolsShowcase.tsx
@@ -51,7 +51,7 @@ export function ToolsShowcase() {
     const sticky = useStickyRelease();
 
     return (
-        <Card variant="tight" ref={sticky.sectionRef} className="mb-12 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
+        <Card variant="tight" ref={sticky.sectionRef} className="mb-12 !border-white/10 px-4 pb-4 pt-0 sm:px-6 sm:pb-6">
             <Tabs
                 value={tool}
                 onValueChange={value => {

--- a/app/features/mcp-docs/ui/__stories__/CodeBlock.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/CodeBlock.stories.tsx
@@ -1,0 +1,48 @@
+import { withClipboardMock } from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { CodeBlock } from '../CodeBlock';
+
+const COMMAND = `claude mcp add --transport http solana-explorer https://explorer.solana.com/mcp`;
+
+const JSON_CONFIG = JSON.stringify(
+    { mcpServers: { 'solana-explorer': { type: 'http', url: 'https://explorer.solana.com/mcp' } } },
+    undefined,
+    4,
+);
+
+const meta: Meta<typeof CodeBlock> = {
+    component: CodeBlock,
+    globals: { backgrounds: { value: 'dark' } },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/CodeBlock',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: { code: COMMAND },
+};
+
+export const MultiLine: Story = {
+    args: { code: JSON_CONFIG },
+};
+
+/** `flush` drops the own border/rounding to sit as a full-bleed segment inside a card. */
+export const Flush: Story = {
+    args: { code: COMMAND, variant: 'flush' },
+};
+
+export const Copy: Story = {
+    args: { code: COMMAND },
+    decorators: [withClipboardMock],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole('button', { name: 'Copy to clipboard' }));
+
+        await expect(navigator.clipboard.writeText).toHaveBeenCalledWith(COMMAND);
+    },
+};

--- a/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { EndpointStatusValue } from '../EndpointStatus';
+
+const meta: Meta<typeof EndpointStatusValue> = {
+    component: EndpointStatusValue,
+    globals: { backgrounds: { value: 'dark' } },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/EndpointStatus',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Before the health probe resolves. */
+export const Checking: Story = {
+    args: { status: { state: 'checking' } },
+};
+
+/** The endpoint answered — dot plus round-trip latency. */
+export const Ready: Story = {
+    args: { status: { ms: 42, state: 'ready' } },
+};
+
+/** A 5xx / network error — falls back to the "How to run" link. */
+export const Disabled: Story = {
+    args: { status: { state: 'disabled' } },
+};

--- a/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
@@ -22,6 +22,11 @@ export const Ready: Story = {
     args: { status: { ms: 42, state: 'ready' } },
 };
 
+/** A 401/403 — the endpoint is up but gated (access key required or IP blocked). */
+export const Restricted: Story = {
+    args: { status: { state: 'restricted' } },
+};
+
 /** A 5xx / network error — falls back to the "How to run" link. */
 export const Disabled: Story = {
     args: { status: { state: 'disabled' } },

--- a/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/EndpointStatus.stories.tsx
@@ -22,9 +22,14 @@ export const Ready: Story = {
     args: { status: { ms: 42, state: 'ready' } },
 };
 
-/** A 401/403 — the endpoint is up but gated (access key required or IP blocked). */
+/** A 401 — the endpoint is up but gated behind an access key. */
 export const Restricted: Story = {
     args: { status: { state: 'restricted' } },
+};
+
+/** A 403 — the endpoint is up but this visitor's IP is blocked; no key or config helps. */
+export const Blocked: Story = {
+    args: { status: { state: 'blocked' } },
 };
 
 /** A 5xx / network error — falls back to the "How to run" link. */

--- a/app/features/mcp-docs/ui/__stories__/ExamplesCarousel.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/ExamplesCarousel.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { ExamplesCarousel } from '../ExamplesCarousel';
+
+const meta: Meta<typeof ExamplesCarousel> = {
+    component: ExamplesCarousel,
+    globals: { backgrounds: { value: 'dark' } },
+    parameters: { layout: 'padded' },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/ExamplesCarousel',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** Selecting a conversation from the chat list swaps in its question and answer. */
+export const SelectConversation: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole('tab', { name: 'Program inspection' }));
+        // Assert on a phrase unique to this answer — "Squads Multisig Program" appears twice in it.
+        const answer = await canvas.findByText('BPF upgradeable-loader program', { exact: false });
+        // The conversation cross-fades in over a 500ms opacity transition; poll until it's fully visible.
+        await waitFor(() => expect(answer).toBeVisible());
+    },
+};
+
+/** Long conversations start collapsed; "Expand message" reveals the tail. */
+export const ExpandMessage: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole('tab', { name: 'Transaction walkthrough' }));
+        await userEvent.click(await canvas.findByRole('button', { name: 'Expand message' }));
+        const tail = await canvas.findByText('Instruction 1 — ComputeBudget', { exact: false });
+        // The conversation cross-fades in over a 500ms opacity transition; poll until it's fully visible.
+        await waitFor(() => expect(tail).toBeVisible());
+    },
+};

--- a/app/features/mcp-docs/ui/__stories__/ExamplesCarousel.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/ExamplesCarousel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook-config/types';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { ExamplesCarousel } from '../ExamplesCarousel';
 
@@ -23,9 +23,7 @@ export const SelectConversation: Story = {
 
         await userEvent.click(canvas.getByRole('tab', { name: 'Program inspection' }));
         // Assert on a phrase unique to this answer — "Squads Multisig Program" appears twice in it.
-        const answer = await canvas.findByText('BPF upgradeable-loader program', { exact: false });
-        // The conversation cross-fades in over a 500ms opacity transition; poll until it's fully visible.
-        await waitFor(() => expect(answer).toBeVisible());
+        await expect(await canvas.findByText('BPF upgradeable-loader program', { exact: false })).toBeVisible();
     },
 };
 
@@ -36,8 +34,6 @@ export const ExpandMessage: Story = {
 
         await userEvent.click(canvas.getByRole('tab', { name: 'Transaction walkthrough' }));
         await userEvent.click(await canvas.findByRole('button', { name: 'Expand message' }));
-        const tail = await canvas.findByText('Instruction 1 — ComputeBudget', { exact: false });
-        // The conversation cross-fades in over a 500ms opacity transition; poll until it's fully visible.
-        await waitFor(() => expect(tail).toBeVisible());
+        await expect(await canvas.findByText('Instruction 1 — ComputeBudget', { exact: false })).toBeVisible();
     },
 };

--- a/app/features/mcp-docs/ui/__stories__/HeroFact.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/HeroFact.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { HeroFact } from '../HeroFact';
+
+const meta: Meta<typeof HeroFact> = {
+    component: HeroFact,
+    globals: { backgrounds: { value: 'dark' } },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/HeroFact',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        children: <span className="text-sm">Streamable HTTP, stateless</span>,
+        label: 'Transport',
+    },
+};
+
+/** How the facts read side by side in the hero grid. */
+export const Grid: Story = {
+    render: () => (
+        <div className="grid max-w-xl gap-x-8 gap-y-4 sm:grid-cols-2">
+            <HeroFact label="Transport">
+                <span className="text-sm">Streamable HTTP, stateless</span>
+            </HeroFact>
+            <HeroFact label="Auth">
+                <span className="text-sm">Open — no key required</span>
+            </HeroFact>
+            <HeroFact label="Clusters">
+                <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
+            </HeroFact>
+            <HeroFact label="Tools">
+                <span className="text-sm">inspect_entity · ping</span>
+            </HeroFact>
+        </div>
+    ),
+};

--- a/app/features/mcp-docs/ui/__stories__/InlineCode.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/InlineCode.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { InlineCode } from '../InlineCode';
+
+const meta: Meta<typeof InlineCode> = {
+    component: InlineCode,
+    globals: { backgrounds: { value: 'dark' } },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/InlineCode',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: { children: 'inspect_entity' },
+};
+
+/** Reads as a token inside running body copy, keeping the line box height. */
+export const InSentence: Story = {
+    render: () => (
+        <p className="m-0 text-sm text-neutral-300">
+            Pass <InlineCode>cluster</InlineCode> explicitly when the user is not on{' '}
+            <InlineCode>mainnet-beta</InlineCode> — one of <InlineCode>devnet</InlineCode>,{' '}
+            <InlineCode>testnet</InlineCode> or <InlineCode>simd296</InlineCode>.
+        </p>
+    ),
+};

--- a/app/features/mcp-docs/ui/__stories__/McpDocsOverviewView.responsive.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/McpDocsOverviewView.responsive.stories.tsx
@@ -1,0 +1,31 @@
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { McpDocsOverviewView } from '../McpDocsOverviewView';
+
+const meta: Meta<typeof McpDocsOverviewView> = {
+    component: McpDocsOverviewView,
+    decorators: [withViewportFromGlobal],
+    globals: { backgrounds: { value: 'dark' } },
+    parameters: {
+        layout: 'fullscreen',
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/Overview@Media',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const render = () => <McpDocsOverviewView />;
+
+export const Mobile: Story = {
+    globals: { viewport: { value: 'iphonex' } },
+    render,
+};
+
+export const TabletPortrait: Story = {
+    globals: { viewport: { value: 'ipad' } },
+    render,
+};

--- a/app/features/mcp-docs/ui/__stories__/McpDocsOverviewView.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/McpDocsOverviewView.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { McpDocsOverviewView } from '../McpDocsOverviewView';
+
+const meta: Meta<typeof McpDocsOverviewView> = {
+    component: McpDocsOverviewView,
+    globals: { backgrounds: { value: 'dark' } },
+    parameters: { layout: 'fullscreen' },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/Overview',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** The Setup and Tools sections are underline-tab switchers — each swaps its panel in place. */
+export const SwitchesSections: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        // Setup: pick a different client, its config target replaces the panel.
+        await userEvent.click(canvas.getByRole('tab', { name: 'Cursor' }));
+        await expect(await canvas.findByText('Add to .cursor/mcp.json', { exact: false })).toBeVisible();
+
+        // Tools: switch to ping, its reference replaces inspect_entity's.
+        await userEvent.click(canvas.getByRole('tab', { name: 'Ping' }));
+        await expect(await canvas.findByText('Basic health tool', { exact: false })).toBeVisible();
+    },
+};

--- a/app/features/mcp-docs/ui/__stories__/SectionTitle.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/SectionTitle.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { SectionTitle } from '../SectionTitle';
+
+const meta: Meta<typeof SectionTitle> = {
+    component: SectionTitle,
+    globals: { backgrounds: { value: 'dark' } },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/SectionTitle',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        children: 'Setup',
+        subtitle: 'Pick your tool, copy the config — snippets already point at this deployment. No API key needed.',
+    },
+};
+
+/** Without a subtitle the heading stands alone. */
+export const HeadingOnly: Story = {
+    args: { children: 'Examples' },
+};

--- a/app/features/mcp-docs/ui/__stories__/ToolsShowcase.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/ToolsShowcase.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { ToolsShowcase } from '../ToolsShowcase';
+
+const meta: Meta<typeof ToolsShowcase> = {
+    component: ToolsShowcase,
+    globals: { backgrounds: { value: 'dark' } },
+    parameters: { layout: 'padded' },
+    tags: ['autodocs', 'test'],
+    title: 'Features/McpDocs/ToolsShowcase',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** Switching to the Ping tab swaps in its short reference. */
+export const SwitchToPing: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole('tab', { name: 'Ping' }));
+        await expect(await canvas.findByText('Basic health tool', { exact: false })).toBeVisible();
+    },
+};
+
+/** The collapsed "What it covers" section expands on click. */
+export const ExpandCovers: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole('button', { name: 'What it covers' }));
+        await expect(await canvas.findByText('Compressed NFTs', { exact: false })).toBeVisible();
+    },
+};

--- a/app/mcp/docs/page-client.tsx
+++ b/app/mcp/docs/page-client.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { McpDocsOverviewView } from '@/app/features/mcp-docs';
+
+export default function McpDocsPageClient() {
+    return <McpDocsOverviewView />;
+}

--- a/app/mcp/docs/page.tsx
+++ b/app/mcp/docs/page.tsx
@@ -1,0 +1,10 @@
+import McpDocsPageClient from './page-client';
+
+export const metadata = {
+    description: `Connect AI coding agents to the Explorer MCP server`,
+    title: `MCP | Solana`,
+};
+
+export default function McpDocsPage() {
+    return <McpDocsPageClient />;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -114,6 +114,8 @@ const config: Config = {
                 // TODO: replace hex with OKLCH.
                 dark: {
                     accent: '#1dd79b',
+                    // Hover shade for accent-colored interactive text, matching the global `a:hover` (styles.css).
+                    'accent-hover': '#2b8a6e',
                     background: '#141816',
                     border: '#282d2b',
                     foreground: '#e5ebe9',


### PR DESCRIPTION
## Description

MCP documentation pages for the Explorer's MCP server. The trimmed v2 (shaped by customer feedback) is now the page everyone sees; the v1 prototype stays reachable only via `/mcp/docs#v1`.

- **Page header**: new `MCP` entry next to Feature Gates (cluster-aware).
- **`/mcp/docs`**: live endpoint status probe, endpoint as an external link with an icon (wraps to show the full URL), per-client setup snippets pointing at the current deployment, agent-instructions card, on-page tool reference (`inspect_entity`, `ping`).
- **Examples**: chat-style carousel of four real agent conversations, tables included; long answers behind "Expand message"; rotation pauses on hover and after any tap.
- **Mobile**: each section's tabs become a horizontal, scrollable strip that pins to the top while scrolling the section (releasing near its end); switching a tab scrolls to the top of the new panel.
- **Disabled state**: "How to run" links out to the MCP README.

## Type of change
-   [x] New feature

## Screenshots
<img width="1423" height="751" alt="Screenshot 2026-08-31 at 11 56 01" src="https://github.com/user-attachments/assets/96eb6dff-4f45-4f27-b1b1-eac80e9fd926" />
<img width="404" height="697" alt="Screenshot 2026-08-31 at 11 56 10" src="https://github.com/user-attachments/assets/3c49ab25-a399-424b-b74d-5c829d10e7cd" />


## Testing
[mcp page](https://explorer-git-fork-hoodieshq-feat-hoo-1-4b23ee-solana-foundation.vercel.app/mcp/docs)

## Related Issues
[HOO-1081](https://linear.app/solana-fndn/issue/HOO-1081/integrate-explorer-mcp-into-the-page-header-next-to-feature-gates)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes
