### PR TITLE
refactor(transaction-history): move feature off web3.js Connection

### DIFF
--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -38,6 +38,7 @@ import { Button } from '@/app/components/shared/ui/button';
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from '@/app/components/shared/ui/dropdown';
 import { INITIAL_TOKENS_TO_FETCH, INITIAL_VISIBLE_COUNT, LOAD_MORE_COUNT } from '@/app/features/token-history/config';
 import { Logger } from '@/app/shared/lib/logger';
+import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
@@ -100,7 +101,7 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     const fetchHistories = React.useCallback(
         (refresh?: boolean) => {
             tokensToFetch.forEach(token => {
-                fetchAccountHistory(token.pubkey, false, refresh);
+                fetchAccountHistory(toKitAddress(token.pubkey), false, refresh);
             });
         },
         [tokensToFetch, fetchAccountHistory],
@@ -115,7 +116,7 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
             newTokens.forEach(token => {
                 const address = token.pubkey.toBase58();
                 if (!accountHistories[address]) {
-                    fetchAccountHistory(token.pubkey, false, true);
+                    fetchAccountHistory(toKitAddress(token.pubkey), false, true);
                 }
             });
             prevTokensToFetchCount.current = tokensToFetchCount;

--- a/app/components/account/history/TokenInstructionsCard.tsx
+++ b/app/components/account/history/TokenInstructionsCard.tsx
@@ -4,11 +4,13 @@ import { Address } from '@components/common/Address';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Signature } from '@components/common/Signature';
+import { type TransactionWithMeta } from '@entities/transaction-data';
 import { useFetchAccountHistory } from '@features/transaction-history/model/use-fetch-account-history';
 import { useAccountHistory } from '@providers/accounts';
 import { FetchStatus } from '@providers/cache';
 import { HistoryCardFooter, HistoryCardHeader } from '@shared/ui/HistoryCard';
-import { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
+import { address as toAddress } from '@solana/kit';
+import { ParsedInstruction, PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
 import { getTokenInstructionName, InstructionContainer } from '@utils/instruction';
 import React, { useMemo } from 'react';
 
@@ -24,8 +26,8 @@ export function TokenInstructionsCard({ address }: { address: string }) {
     const pubkey = useMemo(() => new PublicKey(address), [address]);
     const history = useAccountHistory(address);
     const fetchAccountHistory = useFetchAccountHistory();
-    const refresh = () => fetchAccountHistory(pubkey, true, true);
-    const loadMore = () => fetchAccountHistory(pubkey, true);
+    const refresh = () => fetchAccountHistory(toAddress(address), true, true);
+    const loadMore = () => fetchAccountHistory(toAddress(address), true);
 
     const transactionRows = React.useMemo(() => {
         if (history?.data?.fetched) {
@@ -41,7 +43,7 @@ export function TokenInstructionsCard({ address }: { address: string }) {
     }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const { hasTimestamps, detailsList } = React.useMemo(() => {
-        const detailedHistoryMap = history?.data?.transactionMap || new Map<string, ParsedTransactionWithMeta>();
+        const detailedHistoryMap = history?.data?.transactionMap || new Map<string, TransactionWithMeta>();
         const hasTimestamps = transactionRows.some(element => element.blockTime);
         const detailsList: React.ReactNode[] = [];
         const mintMap = new Map<string, MintDetails>();

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -6,13 +6,15 @@ import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Signature } from '@components/common/Signature';
 import { TokenInstructionType, Transfer, TransferChecked } from '@components/instruction/token/types';
+import { type TransactionWithMeta } from '@entities/transaction-data';
 import { useFetchAccountHistory } from '@features/transaction-history/model/use-fetch-account-history';
 import { isTokenProgramData, useAccountHistory } from '@providers/accounts';
 import { useScaledUiAmountForMint } from '@providers/accounts/tokens';
 import { FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { HistoryCardFooter, HistoryCardHeader } from '@shared/ui/HistoryCard';
-import { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
+import { address as toAddress } from '@solana/kit';
+import { ParsedInstruction, PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { normalizeTokenAmount } from '@utils/index';
 import { InstructionContainer } from '@utils/instruction';
@@ -109,8 +111,8 @@ export function TokenTransfersCard({ address }: { address: string }) {
     const pubkey = useMemo(() => new PublicKey(address), [address]);
     const history = useAccountHistory(address);
     const fetchAccountHistory = useFetchAccountHistory();
-    const refresh = () => fetchAccountHistory(pubkey, true, true);
-    const loadMore = () => fetchAccountHistory(pubkey, true);
+    const refresh = () => fetchAccountHistory(toAddress(address), true, true);
+    const loadMore = () => fetchAccountHistory(toAddress(address), true);
     const swrKey = useMemo(() => getTokenInfoSwrKey(address, cluster, url), [address, cluster, url]);
     const { data: tokenInfo, isLoading: tokenInfoLoading } = useSWR(swrKey, fetchTokenInfo);
 
@@ -128,7 +130,7 @@ export function TokenTransfersCard({ address }: { address: string }) {
     }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const { allTransfers, hasTimestamps } = React.useMemo(() => {
-        const detailedHistoryMap = history?.data?.transactionMap || new Map<string, ParsedTransactionWithMeta>();
+        const detailedHistoryMap = history?.data?.transactionMap || new Map<string, TransactionWithMeta>();
         const hasTimestamps = transactionRows.some(element => element.blockTime);
         const mintMap = new Map<string, MintDetails>();
         const allTransfers: TransferData[] = [];

--- a/app/components/account/history/common.tsx
+++ b/app/components/account/history/common.tsx
@@ -1,11 +1,11 @@
-import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import type { TransactionWithMeta } from '@entities/transaction-data';
 
 export type MintDetails = {
     decimals: number;
     mint: string;
 };
 
-export function extractMintDetails(transactionWithMeta: ParsedTransactionWithMeta, mintMap: Map<string, MintDetails>) {
+export function extractMintDetails(transactionWithMeta: TransactionWithMeta, mintMap: Map<string, MintDetails>) {
     if (transactionWithMeta.meta?.preTokenBalances) {
         transactionWithMeta.meta.preTokenBalances.forEach(balance => {
             const account = transactionWithMeta.transaction.message.accountKeys[balance.accountIndex];

--- a/app/entities/cluster/@x/transaction-data/index.ts
+++ b/app/entities/cluster/@x/transaction-data/index.ts
@@ -1,0 +1,3 @@
+// Cross-entity public API (FSD `@x` notation): the slice of the `cluster` entity that the
+// `transaction-data` entity is allowed to consume.
+export { getRpc } from '../../api/get-rpc';

--- a/app/entities/transaction-data/api/fetch-transaction-details.ts
+++ b/app/entities/transaction-data/api/fetch-transaction-details.ts
@@ -1,4 +1,5 @@
-import { createSolanaRpc, MAX_SUPPORTED_TRANSACTION_VERSION, signature as createSignature } from '@solana/kit';
+import { getRpc } from '@entities/cluster/@x/transaction-data';
+import { MAX_SUPPORTED_TRANSACTION_VERSION, signature as createSignature } from '@solana/kit';
 
 import { adaptParsedTransaction } from '../lib/adapt-parsed-transaction';
 import type { TransactionWithMeta } from '../model/types';
@@ -11,7 +12,7 @@ import type { TransactionWithMeta } from '../model/types';
  * button and the inspector.
  */
 export async function fetchTransactionDetails(url: string, signature: string): Promise<TransactionWithMeta | null> {
-    const response = await createSolanaRpc(url)
+    const response = await getRpc(url)
         .getTransaction(createSignature(signature), {
             commitment: 'confirmed',
             encoding: 'jsonParsed',

--- a/app/entities/transaction-data/lib/instruction-summary.ts
+++ b/app/entities/transaction-data/lib/instruction-summary.ts
@@ -1,15 +1,10 @@
 import { getBase58Encoder, type ReadonlyUint8Array } from '@solana/kit';
-import {
-    ComputeBudgetProgram,
-    ParsedInstruction,
-    ParsedTransactionWithMeta,
-    PartiallyDecodedInstruction,
-    type PublicKey,
-} from '@solana/web3.js';
+import { ComputeBudgetProgram, ParsedInstruction, PartiallyDecodedInstruction, type PublicKey } from '@solana/web3.js';
 import { camelToTitleCase } from '@utils/index';
 import { ParsedInfo } from '@validators/index';
 import { is } from 'superstruct';
 
+import type { TransactionWithMeta } from '../model/types';
 import { findProgramName, UNKNOWN_PROGRAM_NAME } from './get-program-name';
 import { resolveMemoInstructionName } from './memo-name';
 import type { InstructionNames, InstructionSummary } from './types';
@@ -18,7 +13,7 @@ const BASE58_ENCODER = getBase58Encoder();
 
 export const UNKNOWN_INSTRUCTION_NAME = 'Unknown Instruction';
 
-export function getInstructionSummaries(transactionWithMeta: ParsedTransactionWithMeta): InstructionSummary[] {
+export function getInstructionSummaries(transactionWithMeta: TransactionWithMeta): InstructionSummary[] {
     return (
         transactionWithMeta.transaction.message.instructions
             // Drop ComputeBudget: fee/priority boilerplate on nearly every tx that says nothing about what

--- a/app/entities/transaction-data/lib/merge-transaction-map.ts
+++ b/app/entities/transaction-data/lib/merge-transaction-map.ts
@@ -1,10 +1,10 @@
-import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import type { TransactionWithMeta } from '../model/types';
 
-type TransactionMap = Map<string, ParsedTransactionWithMeta>;
+type TransactionMap = Map<string, TransactionWithMeta>;
 
 export function mergeTransactionMap(current: TransactionMap | undefined, update: TransactionMap | undefined) {
     if (!update) {
-        return current ?? new Map<string, ParsedTransactionWithMeta>();
+        return current ?? new Map<string, TransactionWithMeta>();
     }
 
     return new Map([...(current ?? []), ...update]);

--- a/app/features/transaction-history/api/fetch-parsed-transactions.ts
+++ b/app/features/transaction-history/api/fetch-parsed-transactions.ts
@@ -1,4 +1,4 @@
-import { Connection, ParsedTransactionWithMeta } from '@solana/web3.js';
+import { fetchTransactionDetails, type TransactionWithMeta } from '@entities/transaction-data';
 import { Cluster } from '@utils/cluster';
 import { fetchAll } from '@utils/fetch-all';
 import { withBackoff } from '@utils/with-backoff';
@@ -20,16 +20,11 @@ export async function fetchParsedTransactions({
     cluster: Cluster;
     signatures: string[];
 }): Promise<{ transactionMap: TransactionMap; failedTransactionSignatures: FailedTransactionSignatures }> {
-    const connection = new Connection(url);
     const results = await fetchAll(signatures, async signature => {
         try {
-            const transaction = await withBackoff(() =>
-                connection.getParsedTransaction(signature, {
-                    maxSupportedTransactionVersion: 0,
-                }),
-            );
+            const transaction = await withBackoff(() => fetchTransactionDetails(url, signature));
 
-            return { signature, transaction };
+            return { signature, transaction: transaction ?? undefined };
         } catch (error) {
             if (cluster !== Cluster.Custom) {
                 Logger.error(error, { signature, url });
@@ -38,7 +33,7 @@ export async function fetchParsedTransactions({
         }
     });
 
-    const transactionMap = new Map<string, ParsedTransactionWithMeta>();
+    const transactionMap = new Map<string, TransactionWithMeta>();
     const failedTransactionSignatures = new Set<string>();
 
     results.forEach(({ signature, transaction }) => {

--- a/app/features/transaction-history/api/get-signatures-for-address.ts
+++ b/app/features/transaction-history/api/get-signatures-for-address.ts
@@ -1,5 +1,8 @@
-import { Connection, PublicKey, TransactionSignature } from '@solana/web3.js';
+import { getRpc, type SolanaRpc } from '@entities/cluster';
+import type { Address, Signature } from '@solana/kit';
 import { withBackoff } from '@utils/with-backoff';
+
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
 
 import type { AccountHistory, HistoryRow } from '../lib/types';
 
@@ -12,16 +15,46 @@ import type { AccountHistory, HistoryRow } from '../lib/types';
 const EMPTY_FIRST_PAGE_RETRIES = 2;
 const EMPTY_FIRST_PAGE_RETRY_DELAY_MS = 300;
 
+// Element of kit's getSignaturesForAddress response, stated structurally so the mapping below
+// documents what it relies on.
+type RpcSignatureInfo = Readonly<{
+    blockTime: bigint | null;
+    confirmationStatus: 'confirmed' | 'finalized' | 'processed' | null;
+    err: unknown;
+    memo: string | null;
+    signature: string;
+    slot: bigint;
+    transactionIndex?: number;
+}>;
+
+// Kit upcasts integers outside its allow-list to bigints: `slot`/`blockTime` arrive as bigints, and
+// so does every index inside an `err` payload — which downstream consumers JSON.stringify and do
+// arithmetic on. The recursive sweep brings every field back to the numeric HistoryRow shape at the
+// boundary, so a field kit upcasts later cannot leak a bigint past it. `confirmationStatus` is the
+// one shape difference left: the row contract wants undefined where the wire says null.
+function toHistoryRow(item: RpcSignatureInfo): HistoryRow {
+    return {
+        ...(withNumbersInsteadOfBigInts(item) as unknown as HistoryRow),
+        confirmationStatus: item.confirmationStatus ?? undefined,
+    };
+}
+
 export async function fetchSignatures(
-    connection: Connection,
-    pubkey: PublicKey,
-    options: { before?: TransactionSignature; limit: number },
+    rpc: SolanaRpc,
+    address: Address,
+    options: { before?: string; limit: number },
 ): Promise<HistoryRow[]> {
     const isFirstPage = options.before === undefined;
+    const config = {
+        // The cursor is a signature handed back by a previous page, so it is asserted-by-origin
+        // rather than re-validated here.
+        before: options.before as Signature | undefined,
+        limit: options.limit,
+    };
     for (let attempt = 0; ; attempt++) {
-        const fetched = await withBackoff(() => connection.getSignaturesForAddress(pubkey, options));
+        const fetched = await withBackoff(() => rpc.getSignaturesForAddress(address, config).send());
         if (fetched.length > 0 || !isFirstPage || attempt >= EMPTY_FIRST_PAGE_RETRIES) {
-            return fetched;
+            return fetched.map(toHistoryRow);
         }
         await new Promise(resolve => setTimeout(resolve, EMPTY_FIRST_PAGE_RETRY_DELAY_MS));
     }
@@ -35,17 +68,16 @@ export async function fetchSignatures(
  */
 export async function fetchViaSignatures({
     url,
-    pubkey,
+    address,
     limit,
     before,
 }: {
     url: string;
-    pubkey: PublicKey;
+    address: Address;
     limit: number;
     before?: string;
 }): Promise<AccountHistory> {
-    const connection = new Connection(url);
-    const fetched = await fetchSignatures(connection, pubkey, { before, limit });
+    const fetched = await fetchSignatures(getRpc(url), address, { before, limit });
     // No paginationToken on this path: getSignaturesForAddress pages by trailing signature.
     return {
         fetched,

--- a/app/features/transaction-history/api/get-transactions-for-address.ts
+++ b/app/features/transaction-history/api/get-transactions-for-address.ts
@@ -1,4 +1,4 @@
-import { TransactionConfirmationStatus } from '@solana/web3.js';
+import type { TransactionConfirmationStatus } from '@solana/web3.js';
 import { array, create, Infer, nullable, number, optional, string, type, union } from 'superstruct';
 
 import { buildRpcFilters, type HistoryFilters } from '../lib/history-filters';

--- a/app/features/transaction-history/lib/__tests__/reconcile.spec.ts
+++ b/app/features/transaction-history/lib/__tests__/reconcile.spec.ts
@@ -1,10 +1,12 @@
-import { ConfirmedSignatureInfo, Connection, PublicKey } from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
+import { address as toAddress } from '@solana/kit';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { fetchSignatures } from '../../api/get-signatures-for-address';
 import { reconcile } from '../reconcile';
+import type { HistoryRow } from '../types';
 
-const sig = (signature: string) => ({ signature }) as unknown as ConfirmedSignatureInfo;
+const sig = (signature: string) => ({ signature }) as unknown as HistoryRow;
 
 describe('reconcile', () => {
     it('should ignore an empty refresh so a flaky RPC response cannot wipe loaded history or flip foundOldest', () => {
@@ -46,38 +48,73 @@ describe('reconcile', () => {
 describe('fetchSignatures', () => {
     afterEach(() => vi.restoreAllMocks());
 
-    const pubkey = PublicKey.default;
+    const ADDRESS = toAddress('11111111111111111111111111111111');
 
-    function connectionReturning(...pages: ConfirmedSignatureInfo[][]) {
+    // A kit getSignaturesForAddress row: slot and blockTime arrive as bigints.
+    function rpcRow(signature: string, slot = 0n) {
+        return { blockTime: null, confirmationStatus: null, err: null, memo: null, signature, slot };
+    }
+
+    function rpcReturning(...pages: unknown[][]) {
         const getSignaturesForAddress = vi.fn();
-        pages.forEach(page => getSignaturesForAddress.mockResolvedValueOnce(page));
-        return { connection: { getSignaturesForAddress } as unknown as Connection, getSignaturesForAddress };
+        pages.forEach(page => getSignaturesForAddress.mockReturnValueOnce({ send: () => Promise.resolve(page) }));
+        return { getSignaturesForAddress, rpc: { getSignaturesForAddress } as unknown as SolanaRpc };
     }
 
     it('should retry an empty first page and return the signatures once a healthy replica responds', async () => {
-        const { connection, getSignaturesForAddress } = connectionReturning([], [], [sig('a')]);
+        const { rpc, getSignaturesForAddress } = rpcReturning([], [], [rpcRow('a')]);
 
-        const result = await fetchSignatures(connection, pubkey, { limit: 25 });
+        const result = await fetchSignatures(rpc, ADDRESS, { limit: 25 });
 
         expect(result.map(s => s.signature)).toEqual(['a']);
         expect(getSignaturesForAddress).toHaveBeenCalledTimes(3);
     });
 
     it('should accept an empty first page only after the retries are exhausted', async () => {
-        const { connection, getSignaturesForAddress } = connectionReturning([], [], []);
+        const { rpc, getSignaturesForAddress } = rpcReturning([], [], []);
 
-        const result = await fetchSignatures(connection, pubkey, { limit: 25 });
+        const result = await fetchSignatures(rpc, ADDRESS, { limit: 25 });
 
         expect(result).toEqual([]);
         expect(getSignaturesForAddress).toHaveBeenCalledTimes(3);
     });
 
     it('should not retry an empty page when paging (before set) — that is the real end of history', async () => {
-        const { connection, getSignaturesForAddress } = connectionReturning([]);
+        const { rpc, getSignaturesForAddress } = rpcReturning([]);
 
-        const result = await fetchSignatures(connection, pubkey, { before: 'zzz', limit: 25 });
+        const result = await fetchSignatures(rpc, ADDRESS, { before: 'zzz', limit: 25 });
 
         expect(result).toEqual([]);
         expect(getSignaturesForAddress).toHaveBeenCalledTimes(1);
+    });
+
+    // Kit upcasts every integer outside its allow-list to a bigint — slot, blockTime, and the
+    // indices inside an err payload. Consumers JSON.stringify these rows and do arithmetic on
+    // them, so a bigint that leaks through this mapping throws at render time.
+    it('should map bigint slot, blockTime and err payloads back to numbers', async () => {
+        const { rpc } = rpcReturning([
+            {
+                blockTime: 1_700_000_000n,
+                confirmationStatus: 'finalized' as const,
+                err: { InstructionError: [1n, { Custom: 42n }] },
+                memo: 'hi',
+                signature: 'failed-tx',
+                slot: 123n,
+                transactionIndex: 7,
+            },
+        ]);
+
+        const [row] = await fetchSignatures(rpc, ADDRESS, { limit: 25 });
+
+        expect(row).toEqual({
+            blockTime: 1_700_000_000,
+            confirmationStatus: 'finalized',
+            err: { InstructionError: [1, { Custom: 42 }] },
+            memo: 'hi',
+            signature: 'failed-tx',
+            slot: 123,
+            transactionIndex: 7,
+        });
+        expect(() => JSON.stringify(row)).not.toThrow();
     });
 });

--- a/app/features/transaction-history/lib/types.ts
+++ b/app/features/transaction-history/lib/types.ts
@@ -1,6 +1,7 @@
-import { ConfirmedSignatureInfo, ParsedTransactionWithMeta } from '@solana/web3.js';
+import type { TransactionWithMeta } from '@entities/transaction-data';
+import type { ConfirmedSignatureInfo } from '@solana/web3.js';
 
-export type TransactionMap = Map<string, ParsedTransactionWithMeta>;
+export type TransactionMap = Map<string, TransactionWithMeta>;
 export type FailedTransactionSignatures = Set<string>;
 
 // `getTransactionsForAddress` returns a transaction's position within its slot; the standard

--- a/app/features/transaction-history/model/__tests__/use-fetch-account-history.spec.tsx
+++ b/app/features/transaction-history/model/__tests__/use-fetch-account-history.spec.tsx
@@ -1,4 +1,4 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { address as toAddress } from '@solana/kit';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,12 +10,19 @@ vi.mock('@providers/cluster', () => ({
     })),
 }));
 
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
+// The kit rpc pattern is rpc.getSignaturesForAddress(address, config).send(); the mock unwraps
+// the pending-request layer so tests can queue results with plain mockResolvedValue*.
+const rpcMocks = vi.hoisted(() => ({ getSignaturesForAddress: vi.fn() }));
+
+vi.mock('@entities/cluster', async () => {
+    const actual = await vi.importActual<typeof import('@entities/cluster')>('@entities/cluster');
     return {
         ...actual,
-        Connection: vi.fn(),
-        PublicKey: actual.PublicKey,
+        getRpc: () => ({
+            getSignaturesForAddress: (...args: unknown[]) => ({
+                send: () => rpcMocks.getSignaturesForAddress(...args),
+            }),
+        }),
     };
 });
 
@@ -50,7 +57,6 @@ function deferred<T>() {
 }
 
 const fetchMock = vi.fn();
-const mockConnection = { getSignaturesForAddress: vi.fn() };
 
 // Resolve the next fetch call with a getTransactionsForAddress result envelope.
 function mockResult(data: ReturnType<typeof sig>[], paginationToken: string | null) {
@@ -80,9 +86,6 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(Connection).mockImplementation(function () {
-        return mockConnection as unknown as Connection;
-    });
     vi.stubGlobal('fetch', fetchMock);
     // Fallback response; tests queue page-specific results with mockResult (once).
     fetchMock.mockResolvedValue({
@@ -92,7 +95,7 @@ beforeEach(() => {
     });
     // An empty getTransactionsForAddress page is confirmed against getSignaturesForAddress,
     // so every test needs this to resolve. "Also empty" keeps the empty result as-is.
-    mockConnection.getSignaturesForAddress.mockResolvedValue([]);
+    rpcMocks.getSignaturesForAddress.mockResolvedValue([]);
     vi.mocked(useCluster).mockReturnValue({ cluster: 0, url: 'https://mock.rpc' } as any);
 });
 
@@ -103,7 +106,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         });
 
         await act(async () => {
-            result.current(new PublicKey(ADDRESS));
+            result.current(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -130,7 +133,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         );
 
         await act(async () => {
-            result.current(new PublicKey(ADDRESS));
+            result.current(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -145,7 +148,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         const { result } = renderHook(() => useFetchAccountHistory(25, {}), { wrapper });
 
         await act(async () => {
-            result.current(new PublicKey(ADDRESS));
+            result.current(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -169,7 +172,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.length).toBe(25));
@@ -178,7 +181,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         mockResult([], null);
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -203,7 +206,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.length).toBe(1));
@@ -213,7 +216,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         fetchMock.mockClear();
         mockResult([], null);
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -232,7 +235,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.foundOldest).toBe(true));
@@ -240,7 +243,7 @@ describe('useFetchAccountHistory — getTransactionsForAddress', () => {
         fetchMock.mockClear();
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         // foundOldest short-circuits the load-more, so no further request is made.
@@ -265,7 +268,7 @@ describe('useResetAccountHistory', () => {
 
         // Kick off the initial (unfiltered) fetch; it does not resolve yet.
         act(() => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
@@ -273,7 +276,7 @@ describe('useResetAccountHistory', () => {
         mockResult([sig('filtered', 200)], null);
         act(() => {
             result.current.reset(ADDRESS);
-            result.current.fetch(new PublicKey(ADDRESS), false, true);
+            result.current.fetch(toAddress(ADDRESS), false, true);
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('filtered'));
@@ -301,11 +304,11 @@ describe('useResetAccountHistory', () => {
 
         mockResult([sig('a', 10)], null);
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
         mockResult([sig('b', 20)], null);
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS_B));
+            result.current.fetch(toAddress(ADDRESS_B));
         });
 
         await waitFor(() => expect(result.current.historyA?.data?.fetched?.length).toBe(1));
@@ -323,7 +326,7 @@ describe('useResetAccountHistory', () => {
 describe('getSignaturesForAddress fallback', () => {
     it('should fall back when getTransactionsForAddress is not found, applying no filters', async () => {
         mockRpcError(-32601, 'Method not found');
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
 
         const { result } = renderHook(
             () => ({
@@ -334,13 +337,13 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('legacy'));
-        expect(mockConnection.getSignaturesForAddress).toHaveBeenCalledTimes(1);
-        const [pubkey, opts] = mockConnection.getSignaturesForAddress.mock.calls[0];
-        expect(pubkey.toBase58()).toBe(ADDRESS);
+        expect(rpcMocks.getSignaturesForAddress).toHaveBeenCalledTimes(1);
+        const [address, opts] = rpcMocks.getSignaturesForAddress.mock.calls[0];
+        expect(address).toBe(ADDRESS);
         // Standard RPCs support none of the filters, so slot bounds are not forwarded.
         expect(opts).toEqual({ limit: 25 });
     });
@@ -348,7 +351,7 @@ describe('getSignaturesForAddress fallback', () => {
     it('should skip getTransactionsForAddress entirely for a statically disabled address', async () => {
         // wSOL: gTFA times out upstream on this account, so it must never be attempted.
         const WRAPPED_SOL = 'So11111111111111111111111111111111111111112';
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('wsol', 7)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('wsol', 7)]);
 
         const { result } = renderHook(
             () => ({
@@ -360,7 +363,7 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(WRAPPED_SOL));
+            result.current.fetch(toAddress(WRAPPED_SOL));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('wsol'));
@@ -372,7 +375,7 @@ describe('getSignaturesForAddress fallback', () => {
     it('should fall back when an unknown method is reported as a generic internal error', async () => {
         // Helius reports an unknown method as -32603, not -32601.
         mockRpcError(-32603, 'Method not found');
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
 
         const { result } = renderHook(
             () => ({
@@ -384,7 +387,7 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('legacy'));
@@ -404,11 +407,11 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.status).toBe(FetchStatus.FetchFailed));
-        expect(mockConnection.getSignaturesForAddress).not.toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).not.toHaveBeenCalled();
     });
 
     it('should not fall back on a generic RPC error', async () => {
@@ -423,18 +426,18 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.status).toBe(FetchStatus.FetchFailed));
-        expect(mockConnection.getSignaturesForAddress).not.toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).not.toHaveBeenCalled();
     });
 
     it('should confirm an empty getTransactionsForAddress page against the ledger index', async () => {
         // Endpoint answers HTTP 200 with `data: []` because the address falls outside its
         // limited-retention index, while getSignaturesForAddress still has the history.
         mockResult([], null);
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('older-than-retention', 5)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('older-than-retention', 5)]);
 
         const { result } = renderHook(
             () => ({
@@ -445,7 +448,7 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('older-than-retention'));
@@ -464,20 +467,20 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.status).toBe(FetchStatus.Fetched));
         expect(result.current.history?.data?.fetched).toEqual([]);
         expect(result.current.history?.data?.foundOldest).toBe(true);
-        expect(mockConnection.getSignaturesForAddress).toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).toHaveBeenCalled();
     });
 
     it('should keep the empty result when the confirmation call itself fails', async () => {
         // The confirmation only verifies an answer we already hold. A rate-limited endpoint
         // must not turn an empty account into "Failed to fetch transaction history".
         mockResult([], null);
-        mockConnection.getSignaturesForAddress.mockRejectedValue(new Error('429 Too Many Requests'));
+        rpcMocks.getSignaturesForAddress.mockRejectedValue(new Error('429 Too Many Requests'));
 
         const { result } = renderHook(
             () => ({
@@ -488,7 +491,7 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.status).toBe(FetchStatus.Fetched));
@@ -513,27 +516,27 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
         await waitFor(() => expect(result.current.history?.data?.fetched?.length).toBe(25));
 
         // Load More returns an empty page that still advances the cursor.
-        mockConnection.getSignaturesForAddress.mockClear();
+        rpcMocks.getSignaturesForAddress.mockClear();
         mockResult([], 'token-page-3');
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.paginationToken).toBe('token-page-3'));
         expect(result.current.history?.data?.foundOldest).toBe(false);
-        expect(mockConnection.getSignaturesForAddress).not.toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).not.toHaveBeenCalled();
     });
 
     it('should confirm an empty first page even when it carries a token', async () => {
         // No rows means no cursor the UI can reach: Load More is driven by existing rows, so
         // accepting this page would strand the account on an empty table.
         mockResult([], 'token-page-2');
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('from-ledger', 5)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('from-ledger', 5)]);
 
         const { result } = renderHook(
             () => ({
@@ -544,7 +547,7 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('from-ledger'));
@@ -564,19 +567,19 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.status).toBe(FetchStatus.Fetched));
         expect(result.current.history?.data?.fetched).toEqual([]);
-        expect(mockConnection.getSignaturesForAddress).not.toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).not.toHaveBeenCalled();
     });
 
     it('should keep a confirmed address on the signatures path when loading more', async () => {
         // A full page from the ledger index, so foundOldest stays false and Load More runs.
         const page = Array.from({ length: 25 }, (_, i) => sig(`sig${i}`, 1000 - i));
         mockResult([], null);
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce(page);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce(page);
 
         const { result } = renderHook(
             () => ({
@@ -587,25 +590,25 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.length).toBe(25));
 
         fetchMock.mockClear();
-        mockConnection.getSignaturesForAddress.mockClear();
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('next-page', 900)]);
+        rpcMocks.getSignaturesForAddress.mockClear();
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('next-page', 900)]);
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.history?.data?.fetched?.length).toBe(26));
         // The latch holds: no second getTransactionsForAddress attempt, and the trailing
         // signature drives the cursor rather than a (now null) paginationToken.
         expect(fetchMock).not.toHaveBeenCalled();
-        expect(mockConnection.getSignaturesForAddress).toHaveBeenCalledTimes(1);
-        expect(mockConnection.getSignaturesForAddress.mock.calls[0][1]).toEqual({ before: 'sig24', limit: 25 });
+        expect(rpcMocks.getSignaturesForAddress).toHaveBeenCalledTimes(1);
+        expect(rpcMocks.getSignaturesForAddress.mock.calls[0][1]).toEqual({ before: 'sig24', limit: 25 });
     });
 
     it('should not let a request in flight across a cluster change latch the new endpoint', async () => {
@@ -614,7 +617,7 @@ describe('getSignaturesForAddress fallback', () => {
         // the endpoint that is now selected.
         const pendingConfirm = deferred<ReturnType<typeof sig>[]>();
         mockResult([], null); // endpoint A: gTFA answers empty
-        mockConnection.getSignaturesForAddress.mockReturnValueOnce(pendingConfirm.promise);
+        rpcMocks.getSignaturesForAddress.mockReturnValueOnce(pendingConfirm.promise);
 
         const { result, rerender } = renderHook(
             () => ({
@@ -625,10 +628,10 @@ describe('getSignaturesForAddress fallback', () => {
         );
 
         act(() => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
         // The confirmation is issued but not yet resolved.
-        await waitFor(() => expect(mockConnection.getSignaturesForAddress).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(rpcMocks.getSignaturesForAddress).toHaveBeenCalledTimes(1));
 
         // Cluster changes while that confirmation is still open.
         vi.mocked(useCluster).mockReturnValue({ cluster: 0, url: 'https://other.rpc' } as any);
@@ -642,21 +645,21 @@ describe('getSignaturesForAddress fallback', () => {
 
         // A fresh unfiltered request on the new endpoint must still try gTFA.
         fetchMock.mockClear();
-        mockConnection.getSignaturesForAddress.mockClear();
+        rpcMocks.getSignaturesForAddress.mockClear();
         mockResult([sig('from-endpoint-b', 9)], null);
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
         expect(JSON.parse(fetchMock.mock.calls[0][1].body).method).toBe('getTransactionsForAddress');
-        expect(mockConnection.getSignaturesForAddress).not.toHaveBeenCalled();
+        expect(rpcMocks.getSignaturesForAddress).not.toHaveBeenCalled();
     });
 
     it('should mark filtering unsupported after a method-not-found, and stay supported otherwise', async () => {
         mockRpcError(-32601, 'Method not found');
-        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+        rpcMocks.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
 
         const { result } = renderHook(
             () => ({
@@ -670,7 +673,7 @@ describe('getSignaturesForAddress fallback', () => {
         expect(result.current.supported).toBe(true);
 
         await act(async () => {
-            result.current.fetch(new PublicKey(ADDRESS));
+            result.current.fetch(toAddress(ADDRESS));
         });
 
         await waitFor(() => expect(result.current.supported).toBe(false));

--- a/app/features/transaction-history/model/__tests__/use-instruction-summaries.spec.tsx
+++ b/app/features/transaction-history/model/__tests__/use-instruction-summaries.spec.tsx
@@ -4,16 +4,14 @@ import { SWRConfig } from 'swr';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+    fetchTransactionDetails: vi.fn(),
     getInstructionSummaries: vi.fn(),
-    getParsedTransaction: vi.fn(),
 }));
 
-vi.mock('@solana/web3.js', () => ({
-    Connection: class {
-        getParsedTransaction = mocks.getParsedTransaction;
-    },
+vi.mock('@entities/transaction-data', () => ({
+    fetchTransactionDetails: mocks.fetchTransactionDetails,
+    getInstructionSummaries: mocks.getInstructionSummaries,
 }));
-vi.mock('@entities/transaction-data', () => ({ getInstructionSummaries: mocks.getInstructionSummaries }));
 vi.mock('@providers/cluster', () => ({ useCluster: () => ({ url: 'https://api.devnet.solana.com' }) }));
 
 import { useInstructionSummaries } from '../use-instruction-summaries';
@@ -32,7 +30,7 @@ afterEach(() => vi.clearAllMocks());
 describe('useInstructionSummaries', () => {
     it('should return the summaries for a fetched transaction', async () => {
         const summaries = [{ name: 'Transfer', programName: 'System Program' }];
-        mocks.getParsedTransaction.mockResolvedValue({ tx: true });
+        mocks.fetchTransactionDetails.mockResolvedValue({ tx: true });
         mocks.getInstructionSummaries.mockReturnValue(summaries);
 
         const { result } = renderHook(() => useInstructionSummaries('sig'), { wrapper });
@@ -44,18 +42,18 @@ describe('useInstructionSummaries', () => {
     // not "no instructions". It must NOT settle as a cached [] — that would blank the row permanently
     // under useSWRImmutable. The fetcher throws instead, leaving data undefined so SWR can retry.
     it('should not cache an empty result when the transaction is missing', async () => {
-        // getParsedTransaction returns null for a not-yet-indexed tx
-        mocks.getParsedTransaction.mockResolvedValue(null);
+        // fetchTransactionDetails returns null for a not-yet-indexed tx
+        mocks.fetchTransactionDetails.mockResolvedValue(null);
 
         const { result } = renderHook(() => useInstructionSummaries('sig'), { wrapper });
 
-        await waitFor(() => expect(mocks.getParsedTransaction).toHaveBeenCalled());
+        await waitFor(() => expect(mocks.fetchTransactionDetails).toHaveBeenCalled());
         expect(mocks.getInstructionSummaries).not.toHaveBeenCalled();
         expect(result.current).toBeUndefined();
     });
 
     it('should return an empty array for a transaction with no summarizable instructions', async () => {
-        mocks.getParsedTransaction.mockResolvedValue({ tx: true });
+        mocks.fetchTransactionDetails.mockResolvedValue({ tx: true });
         mocks.getInstructionSummaries.mockReturnValue([]);
 
         const { result } = renderHook(() => useInstructionSummaries('sig'), { wrapper });
@@ -66,6 +64,6 @@ describe('useInstructionSummaries', () => {
     it('should not fetch while disabled', () => {
         renderHook(() => useInstructionSummaries('sig', false), { wrapper });
 
-        expect(mocks.getParsedTransaction).not.toHaveBeenCalled();
+        expect(mocks.fetchTransactionDetails).not.toHaveBeenCalled();
     });
 });

--- a/app/features/transaction-history/model/fetch-history-page.ts
+++ b/app/features/transaction-history/model/fetch-history-page.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from '@solana/web3.js';
+import type { Address } from '@solana/kit';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -27,7 +27,7 @@ export type HistoryPage = {
  */
 export async function fetchHistoryPage({
     url,
-    pubkey,
+    address,
     limit,
     // Trailing-signature cursor used only by the getSignaturesForAddress path.
     before,
@@ -42,7 +42,7 @@ export async function fetchHistoryPage({
     onMethodNotFound,
 }: {
     url: string;
-    pubkey: PublicKey;
+    address: Address;
     limit: number;
     before?: string;
     paginationToken?: string;
@@ -53,14 +53,14 @@ export async function fetchHistoryPage({
     // gTFA is disabled up front for a few hot addresses because it times out upstream. Unlike a
     // real method-not-found this is scoped to the address: onMethodNotFound is deliberately NOT
     // called, so filtering stays available for every other account in the session.
-    if (forceSignatures || isGtfaDisabled(pubkey.toBase58())) {
-        return { history: await fetchViaSignatures({ before, limit, pubkey, url }), signaturesOnly: false };
+    if (forceSignatures || isGtfaDisabled(address)) {
+        return { history: await fetchViaSignatures({ address, before, limit, url }), signaturesOnly: false };
     }
 
     let result;
     try {
         result = await getTransactionsForAddress({
-            address: pubkey.toBase58(),
+            address,
             filters,
             limit,
             paginationToken,
@@ -71,7 +71,7 @@ export async function fetchHistoryPage({
         // Endpoint doesn't implement getTransactionsForAddress: disable filtering
         // and fall back to the standard getSignaturesForAddress path.
         onMethodNotFound?.();
-        return { history: await fetchViaSignatures({ before, limit, pubkey, url }), signaturesOnly: false };
+        return { history: await fetchViaSignatures({ address, before, limit, url }), signaturesOnly: false };
     }
 
     const history: AccountHistory = {
@@ -108,10 +108,10 @@ export async function fetchHistoryPage({
     // pre-existing behaviour and a refresh re-runs the check.
     let confirmed;
     try {
-        confirmed = await fetchViaSignatures({ before, limit, pubkey, url });
+        confirmed = await fetchViaSignatures({ address, before, limit, url });
     } catch (error) {
         Logger.warn('[transaction-history] getSignaturesForAddress confirmation failed', {
-            address: pubkey.toBase58(),
+            address,
             error,
             url,
         });

--- a/app/features/transaction-history/model/use-fetch-account-history.ts
+++ b/app/features/transaction-history/model/use-fetch-account-history.ts
@@ -1,8 +1,9 @@
 'use client';
 
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { ParsedTransactionWithMeta, PublicKey } from '@solana/web3.js';
+import type { Address } from '@solana/kit';
 import { Cluster } from '@utils/cluster';
 import { fetchOnce } from '@utils/fetch-once';
 import React from 'react';
@@ -44,17 +45,16 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
     const blockTimeLte = blockTime?.lte;
 
     return React.useCallback(
-        (pubkey: PublicKey, fetchTransactions?: boolean, refresh?: boolean) => {
+        (address: Address, fetchTransactions?: boolean, refresh?: boolean) => {
             const activeFilters: HistoryFilters = {
                 blockTime: { gte: blockTimeGte, lte: blockTimeLte },
                 slot: { gte: slotGte, lte: slotLte },
                 status,
             };
-            const key = pubkey.toBase58();
             // Snapshot the generation at dispatch time; if it advances before the
             // response lands (a filter change), the result is treated as stale.
-            const generation = generations.get(key) ?? 0;
-            const isCurrent = () => (generations.get(key) ?? 0) === generation;
+            const generation = generations.get(address) ?? 0;
+            const isCurrent = () => (generations.get(address) ?? 0) === generation;
 
             // Latch entries are keyed by endpoint as well as address. Index coverage is a
             // property of the endpoint, and a request still in flight when the cluster changes
@@ -62,7 +62,7 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
             // generation guard can't help because it resets to 0 at the same moment. Scoping
             // the key makes such a late write inert instead of skipping a working gTFA path on
             // the new endpoint.
-            const latchKey = `${url}:${key}`;
+            const latchKey = `${url}:${address}`;
 
             // The latch only governs the unfiltered path. getSignaturesForAddress can't honour
             // filters, so once a filter is active getTransactionsForAddress is the only method
@@ -72,6 +72,7 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
             const forceSignatures = signaturesOnly.has(latchKey) && !hasActiveFilters(activeFilters);
 
             const common = {
+                address,
                 cluster,
                 dispatch,
                 fetchTransactions,
@@ -85,11 +86,10 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
                 // return an empty gTFA page for this address, so the next unfiltered request
                 // should still skip it. Cross-endpoint leakage is handled by latchKey above.
                 onSignaturesOnly: () => signaturesOnly.add(latchKey),
-                pubkey,
                 url,
             };
 
-            const cached = state.entries[key];
+            const cached = state.entries[address];
             const isLoadMore = !refresh && Boolean(cached?.data?.fetched?.length);
             if (isLoadMore && cached?.data) {
                 if (cached.data.foundOldest) return;
@@ -97,7 +97,7 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
                 // Cursor for the next page: paginationToken drives getTransactionsForAddress,
                 // the trailing signature drives the getSignaturesForAddress fallback.
                 const oldest = cached.data.fetched[cached.data.fetched.length - 1].signature;
-                fetchOnce(key, inFlight, () =>
+                fetchOnce(address, inFlight, () =>
                     fetchAccountHistory({
                         ...common,
                         additionalSignatures: fetchTransactions ? getUnfetchedSignatures(cached.data) : [],
@@ -107,7 +107,7 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
                     }),
                 ).catch(e => Logger.error(e));
             } else {
-                fetchOnce(key, inFlight, () => fetchAccountHistory({ ...common, append: false })).catch(e =>
+                fetchOnce(address, inFlight, () => fetchAccountHistory({ ...common, append: false })).catch(e =>
                     Logger.error(e),
                 );
             }
@@ -133,7 +133,7 @@ export function useFetchAccountHistory(limit = 25, filters: HistoryFilters = {})
 
 type FetchAccountHistoryOptions = {
     dispatch: Dispatch;
-    pubkey: PublicKey;
+    address: Address;
     cluster: Cluster;
     url: string;
     limit: number;
@@ -157,7 +157,7 @@ type FetchAccountHistoryOptions = {
 // reporting; `fetchHistoryPage` owns which RPC method answers the page.
 async function fetchAccountHistory({
     dispatch,
-    pubkey,
+    address,
     cluster,
     url,
     limit,
@@ -173,7 +173,7 @@ async function fetchAccountHistory({
     onSignaturesOnly,
 }: FetchAccountHistoryOptions) {
     dispatch({
-        key: pubkey.toBase58(),
+        key: address,
         status: FetchStatus.Fetching,
         type: ActionType.Update,
         url,
@@ -184,13 +184,13 @@ async function fetchAccountHistory({
 
     try {
         const page = await fetchHistoryPage({
+            address,
             before,
             filters,
             forceSignatures,
             limit,
             onMethodNotFound,
             paginationToken,
-            pubkey,
             url,
         });
         history = page.history;
@@ -232,7 +232,7 @@ async function fetchAccountHistory({
             history,
             transactionMap,
         },
-        key: pubkey.toBase58(),
+        key: address,
         status,
         type: ActionType.Update,
         url,
@@ -243,7 +243,7 @@ async function fetchAccountHistory({
 // previously fail), so a Load More can top up the transaction map in the same request.
 function getUnfetchedSignatures(history: AccountHistory | undefined): string[] {
     if (!history) return [];
-    const existingMap = history.transactionMap ?? new Map<string, ParsedTransactionWithMeta>();
+    const existingMap = history.transactionMap ?? new Map<string, TransactionWithMeta>();
     const failedSigs = history.failedTransactionSignatures ?? new Set<string>();
     return history.fetched.map(row => row.signature).filter(sig => !existingMap.has(sig) && !failedSigs.has(sig));
 }

--- a/app/features/transaction-history/model/use-instruction-summaries.ts
+++ b/app/features/transaction-history/model/use-instruction-summaries.ts
@@ -1,9 +1,7 @@
-import { getInstructionSummaries, type InstructionSummary } from '@entities/transaction-data';
+import { fetchTransactionDetails, getInstructionSummaries, type InstructionSummary } from '@entities/transaction-data';
 import { useCluster } from '@providers/cluster';
-import { Connection } from '@solana/web3.js';
 import { withBackoff } from '@utils/with-backoff';
 import pLimit from 'p-limit';
-import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 // One global slot: requests run one at a time to avoid rate-limit (429) errors.
@@ -17,7 +15,6 @@ const limit = pLimit(1);
  */
 export function useInstructionSummaries(signature: string, enabled = true): InstructionSummary[] | undefined {
     const { url } = useCluster();
-    const connection = useMemo(() => new Connection(url), [url]);
     // A finalized parsed transaction never changes, so treat it as immutable: fetch once,
     // then serve from cache on remount (e.g. tab switches) without re-fetching.
     const { data } = useSWRImmutable(
@@ -27,15 +24,7 @@ export function useInstructionSummaries(signature: string, enabled = true): Inst
             // Shallow inner backoff: it holds the single slot during its sleeps, so a rate-limited
             // signature here head-of-line blocks every other row. Keep that window short and let SWR's
             // errorRetryCount do the longer recovery — those retries run with the slot already freed.
-            const tx = await limit(() =>
-                withBackoff(
-                    () =>
-                        connection.getParsedTransaction(signature, {
-                            maxSupportedTransactionVersion: 0,
-                        }),
-                    { maxRetries: 2 },
-                ),
-            );
+            const tx = await limit(() => withBackoff(() => fetchTransactionDetails(url, signature), { maxRetries: 2 }));
             // A null tx is a transient miss (a load-balanced node that hasn't indexed the signature
             // yet), not "no instructions" — throw so SWR retries instead of caching [] permanently.
             // Under useSWRImmutable a returned value is a permanent success, so caching that empty

--- a/app/features/transaction-history/ui/TransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/TransactionHistoryCard.tsx
@@ -10,7 +10,7 @@ import { getTransactionRows } from '@components/account/HistoryCardComponents';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { FetchStatus } from '@providers/cache';
-import { PublicKey } from '@solana/web3.js';
+import { address as toAddress } from '@solana/kit';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { isGtfaDisabled } from '../lib/gtfa-disabled-addresses';
@@ -21,7 +21,7 @@ import { InstructionsCell } from './InstructionsCell';
 import { TransactionRawDataCell } from './TransactionRawDataCell';
 
 export function TransactionHistoryCard({ address }: { address: string }) {
-    const pubkey = useMemo(() => new PublicKey(address), [address]);
+    const historyAddress = useMemo(() => toAddress(address), [address]);
     const filters = useHistoryFilters();
     const hasActiveFilters = Object.values(filters).some(value => value !== undefined);
     const filtersKey = JSON.stringify(filters);
@@ -37,8 +37,14 @@ export function TransactionHistoryCard({ address }: { address: string }) {
 
     // Signatures only — the parsed transactions for instruction names are fetched lazily per row, one at a
     // time (see InstructionsCell), so the page never batch-hammers the RPC into 429s.
-    const refresh = useCallback(() => fetchAccountHistory(pubkey, false, true), [fetchAccountHistory, pubkey]);
-    const loadMore = useCallback(() => fetchAccountHistory(pubkey, false), [fetchAccountHistory, pubkey]);
+    const refresh = useCallback(
+        () => fetchAccountHistory(historyAddress, false, true),
+        [fetchAccountHistory, historyAddress],
+    );
+    const loadMore = useCallback(
+        () => fetchAccountHistory(historyAddress, false),
+        [fetchAccountHistory, historyAddress],
+    );
 
     const rows: TransactionHistoryRowView[] = history?.data?.fetched
         ? getTransactionRows(history.data.fetched).map(row => ({

--- a/app/utils/instruction.ts
+++ b/app/utils/instruction.ts
@@ -4,15 +4,11 @@ import {
     parseTokenLendingInstructionTitle,
 } from '@components/instruction/token-lending/types';
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
+import { type TransactionWithMeta } from '@entities/transaction-data';
 import { isSerumInstruction, parseSerumInstructionTitle } from '@explorer/decoder-serum/detection';
 import { isTokenProgram } from '@explorer/parsers';
 import { isTokenProgramId } from '@providers/accounts/tokens';
-import {
-    ConfirmedSignatureInfo,
-    ParsedInstruction,
-    ParsedTransactionWithMeta,
-    PartiallyDecodedInstruction,
-} from '@solana/web3.js';
+import { ConfirmedSignatureInfo, ParsedInstruction, PartiallyDecodedInstruction } from '@solana/web3.js';
 import { intoTransactionInstruction } from '@utils/tx';
 import { ParsedInfo } from '@validators/index';
 import { create } from 'superstruct';
@@ -32,11 +28,11 @@ export interface InstructionItem {
 export class InstructionContainer {
     readonly instructions: InstructionItem[];
 
-    static create(transactionWithMeta: ParsedTransactionWithMeta) {
+    static create(transactionWithMeta: TransactionWithMeta) {
         return new InstructionContainer(transactionWithMeta);
     }
 
-    constructor(transactionWithMeta: ParsedTransactionWithMeta) {
+    constructor(transactionWithMeta: TransactionWithMeta) {
         this.instructions = transactionWithMeta.transaction.message.instructions.map(instruction => {
             if ('parsed' in instruction) {
                 if (typeof instruction.parsed === 'object') {
@@ -73,7 +69,7 @@ export function getTokenProgramInstructionName(ix: ParsedInstruction, signatureI
 }
 
 export function getTokenInstructionName(
-    transactionWithMeta: ParsedTransactionWithMeta,
+    transactionWithMeta: TransactionWithMeta,
     ix: ParsedInstruction | PartiallyDecodedInstruction,
     signatureInfo: ConfirmedSignatureInfo,
 ) {
@@ -118,7 +114,7 @@ export function getTokenInstructionName(
 }
 
 export function getTokenInstructionType(
-    transactionWithMeta: ParsedTransactionWithMeta,
+    transactionWithMeta: TransactionWithMeta,
     ix: ParsedInstruction | PartiallyDecodedInstruction,
     signatureInfo: ConfirmedSignatureInfo,
     index: number,


### PR DESCRIPTION
## Summary
- Fetch history signature pages and full transactions through kit rpc, removing the feature's three `new Connection` sites; the per-signature fetch reuses the entity's `fetchTransactionDetails`, now on the cached `getRpc` client
- Lift the `maxSupportedTransactionVersion: 0` cap: v1 transactions now render in account history, token transfers, token instructions, and per-row instruction summaries
- Normalize kit's bigint upcasts (`slot`, `blockTime`, `err` payloads) back to numbers at the row boundary, with a regression test against an `InstructionError` payload
- Key `useFetchAccountHistory` by kit `Address`; `TransactionMap` carries `TransactionWithMeta`

Deliberate behavior change: reads move from web3.js' `finalized` default commitment to kit's `confirmed`, matching the transaction detail page and prior provider migrations. Bonus: the signatures path now carries `transactionIndex` (Agave 4.0+), which the web3.js transport dropped.

## Test Plan
- `pnpm typecheck && pnpm lint && pnpm openspec:validate && pnpm build` green locally; targeted vitest on transaction-history, transaction-data, cluster, and history-card specs (450+ tests) green
- Verify an account with v1 transactions shows them in history/transfers/instructions tabs

Closes HOO-1402
