### PR TITLE
handle worst case for v1 txs in inspector URL

### DIFF
--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -28,7 +28,7 @@ import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
 import { useCluster } from '@/app/providers/cluster';
 import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
-import { toBase64 } from '@/app/shared/lib/bytes';
+import { fromBase64Url, toBase64Url } from '@/app/shared/lib/bytes';
 import {
     bridgeV1MessageBytes,
     isV1MessageBytes,
@@ -200,7 +200,7 @@ function decodeUrlParams(
     }
 
     try {
-        const buffer = Uint8Array.from(atob(messageParam), c => c.charCodeAt(0));
+        const buffer = fromBase64Url(messageParam);
 
         if (buffer.length < MIN_MESSAGE_LENGTH) {
             throw new Error('message buffer is too short');
@@ -401,8 +401,7 @@ export function TransactionInspectorPage({
                 }
             }
 
-            const base64 = toBase64(inspectorData.rawMessage);
-            const newParam = encodeURIComponent(base64);
+            const newParam = toBase64Url(inspectorData.rawMessage);
             if (currentSearchParams.get('message') !== newParam) {
                 nextQueryParams ||= new URLSearchParams(currentSearchParams?.toString());
                 nextQueryParams.set('message', newParam);

--- a/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
+++ b/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
@@ -8,7 +8,7 @@ import { createV1TransactionBytes } from '@/app/entities/transaction-data/__fixt
 import { AccountsProvider } from '@/app/providers/accounts';
 import { ClusterProvider } from '@/app/providers/cluster';
 import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
-import { toBase64 } from '@/app/shared/lib/bytes';
+import { toBase64Url } from '@/app/shared/lib/bytes';
 import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
 import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
 
@@ -27,7 +27,7 @@ describe('TransactionInspectorPage with a v1 ?message= param', () => {
             createV1TransactionBytes({ computeUnitLimit: 300_000, priorityFeeLamports: 50n }),
         );
         const params = new URLSearchParams();
-        params.set('message', encodeURIComponent(toBase64(messageBytes)));
+        params.set('message', toBase64Url(messageBytes));
 
         vi.spyOn(await import('next/navigation'), 'useSearchParams').mockReturnValue(
             params as unknown as ReturnType<typeof useSearchParams>,

--- a/app/features/idl/interactive-idl/ui/InstructionActivity.tsx
+++ b/app/features/idl/interactive-idl/ui/InstructionActivity.tsx
@@ -3,6 +3,7 @@ import { useExplorerLink } from '@entities/cluster';
 import { ProgramLogs, TxErrorStatus, TxExecutionStatus, TxSimulationStatus } from '@entities/program-logs';
 import { ReactNode } from 'react';
 
+import { fromBase64Url, toBase64Url } from '@/app/shared/lib/bytes';
 import { Card } from '@/app/shared/ui/Card';
 
 import type { InstructionExecutionResult, InstructionSimulationResult } from '../model/transaction/types';
@@ -76,7 +77,7 @@ function CardWithTabs({ tabs }: { tabs: { id: string; title: string; component: 
 function InstructionExecutionStatusHeader({ lastResult }: { lastResult: InstructionExecutionResult }) {
     const { link: txLink } = useExplorerLink(`/tx/${getTxSignature(lastResult) ?? ''}`);
     const { link: inspectorLink } = useExplorerLink(
-        `/tx/inspector?message=${encodeURIComponent(getInspectorMessage(lastResult) ?? '')}`,
+        `/tx/inspector?message=${toInspectorMessageParam(getInspectorMessage(lastResult))}`,
     );
 
     if (lastResult.status === 'success') {
@@ -116,7 +117,7 @@ function InstructionExecutionStatusHeader({ lastResult }: { lastResult: Instruct
 
 function SimulationStatusHeader({ lastSimulation }: { lastSimulation: InstructionSimulationResult }) {
     const { link: inspectorLink } = useExplorerLink(
-        `/tx/inspector?message=${encodeURIComponent(lastSimulation.serializedTxMessage ?? '')}`,
+        `/tx/inspector?message=${toInspectorMessageParam(lastSimulation.serializedTxMessage)}`,
     );
     const link = lastSimulation.serializedTxMessage ? inspectorLink : undefined;
 
@@ -140,6 +141,10 @@ function SimulationStatusHeader({ lastSimulation }: { lastSimulation: Instructio
             />
         </StatusWithError>
     );
+}
+
+function toInspectorMessageParam(message: string | undefined): string {
+    return message ? toBase64Url(fromBase64Url(message)) : '';
 }
 
 // Signature exists on a successful tx and on a broadcast that later failed; never on a local error.

--- a/app/features/idl/interactive-idl/ui/__tests__/InstructionActivity.spec.tsx
+++ b/app/features/idl/interactive-idl/ui/__tests__/InstructionActivity.spec.tsx
@@ -26,8 +26,8 @@ vi.mock('@entities/cluster', () => ({
 }));
 
 const SIGNATURE = 'sig_abc123';
-const SERIALIZED = 'base64encodedmessage==';
-const ENCODED = encodeURIComponent(SERIALIZED);
+const SERIALIZED = '//79/A==';
+const ENCODED = '__79_A';
 const FINISHED_AT = new Date('2026-01-01T00:00:00Z');
 const NO_LOGS = { parsed: [], raw: [] };
 

--- a/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
+++ b/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
@@ -1,6 +1,7 @@
 import { Keypair, PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
+import { fromBase64Url } from '@/app/shared/lib/bytes';
 import { invariant } from '@/app/shared/lib/invariant';
 
 import { base64TxSearchProvider } from '../base64-tx-search-provider';
@@ -32,7 +33,7 @@ describe('base64TxSearchProvider', () => {
         const params = extractParams(results[0].options[0].pathname);
         const messageParam = params.get('message');
         invariant(messageParam, 'expected message param in inspector URL');
-        const decodedMessage = new Uint8Array(Buffer.from(messageParam, 'base64'));
+        const decodedMessage = fromBase64Url(messageParam);
 
         expect(decodedMessage).toEqual(messageBytes);
     });
@@ -81,7 +82,8 @@ describe('base64TxSearchProvider', () => {
     });
 
     it('should not double-encode the message param', async () => {
-        const b64 = createBase64Transaction();
+        const messageBytes = createMessageBytes();
+        const b64 = Buffer.from(messageBytes).toString('base64');
         const results = await base64TxSearchProvider.search(b64, ctx);
         const params = extractParams(results[0].options[0].pathname);
         const message = params.get('message');
@@ -89,8 +91,10 @@ describe('base64TxSearchProvider', () => {
 
         // A double-encoded value would contain '%25' (the encoding of '%')
         expect(message).not.toContain('%25');
-        // Should round-trip as valid base64
-        expect(Buffer.from(message, 'base64').toString('base64')).toBe(message);
+        expect(message).not.toContain('+');
+        expect(message).not.toContain('/');
+        expect(message).not.toContain('=');
+        expect(fromBase64Url(message)).toEqual(messageBytes);
     });
 
     describe('rejection cases', () => {

--- a/app/features/search/model/base64-tx-search-provider.ts
+++ b/app/features/search/model/base64-tx-search-provider.ts
@@ -1,6 +1,6 @@
 import { getBase58Encoder } from '@solana/kit';
 
-import { fromBase64, toBase64 } from '@/app/shared/lib/bytes';
+import { fromBase64, toBase64, toBase64Url } from '@/app/shared/lib/bytes';
 import { MIN_MESSAGE_LENGTH, parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
 
 import type { SearchOptions, SearchProvider } from '../lib/types';
@@ -70,8 +70,7 @@ export const base64TxSearchProvider: SearchProvider = {
         const pathname = '/tx/inspector';
         const searchParams = new URLSearchParams();
 
-        const messageBase64 = toBase64(parsed.messageBytes);
-        searchParams.set('message', messageBase64);
+        searchParams.set('message', toBase64Url(parsed.messageBytes));
 
         if (parsed.signatures) {
             searchParams.set('signatures', JSON.stringify(parsed.signatures));

--- a/app/shared/lib/__tests__/bytes.test.ts
+++ b/app/shared/lib/__tests__/bytes.test.ts
@@ -10,6 +10,7 @@ import {
     concatBytes,
     equals,
     fromBase64,
+    fromBase64Url,
     fromHex,
     fromUtf8,
     isByteArray,
@@ -21,6 +22,7 @@ import {
     readUint32LE,
     startsWith,
     toBase64,
+    toBase64Url,
     toBuffer,
     toHex,
     toLeBytes,
@@ -252,6 +254,31 @@ describe('bytes helpers', () => {
                     const base64 = toBase64(input);
                     expect(base64).toBe(allByteValuesBase64);
                 });
+            });
+        });
+
+        describe('base64url', () => {
+            it('should encode without URL-escaped characters or padding', () => {
+                const input = new Uint8Array([0xff, 0xfe, 0xfd, 0xfc]);
+
+                expect(toBase64Url(input)).toBe('__79_A');
+                expect(fromBase64Url('__79_A')).toEqual(input);
+            });
+
+            it('should decode existing standard base64 links', () => {
+                expect(fromBase64Url('//79/A==')).toEqual(new Uint8Array([0xff, 0xfe, 0xfd, 0xfc]));
+            });
+
+            it("should keep a maximum one-signature v1 message query below Vercel's URL limit", () => {
+                const message = new Uint8Array(4096 - 64).fill(0xff);
+                const query = new URLSearchParams({ message: toBase64Url(message) }).toString();
+
+                expect(query.length).toBeLessThan(14 * 1024);
+                expect(query).not.toContain('%');
+            });
+
+            it('should reject an impossible encoded length', () => {
+                expect(() => fromBase64Url('a')).toThrow('Invalid base64url string');
             });
         });
 

--- a/app/shared/lib/bytes.ts
+++ b/app/shared/lib/bytes.ts
@@ -92,6 +92,22 @@ export function toBase64(bytes: Uint8Array): string {
     return btoa(fromCharCode(bytes));
 }
 
+/** Decode unpadded base64url or standard base64 to bytes. */
+export function fromBase64Url(base64Url: string): Uint8Array {
+    const base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/');
+    const remainder = base64.length % 4;
+    if (remainder === 1) throw new Error('Invalid base64url string');
+    return fromBase64(base64.padEnd(base64.length + ((4 - remainder) % 4), '='));
+}
+
+/** Encode bytes as unpadded base64url for compact query parameters. */
+export function toBase64Url(bytes: Uint8Array): string {
+    const base64 = toBase64(bytes);
+    const paddingIndex = base64.indexOf('=');
+    const unpadded = paddingIndex === -1 ? base64 : base64.slice(0, paddingIndex);
+    return unpadded.replaceAll('+', '-').replaceAll('/', '_');
+}
+
 /**
  * Fallback for fromHex when native API is not available.
  */


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Had a hunch V1 transactions _might_ go over the URL limit on the /tx/inspector route, giving us a `HTTP 414 URI Too Long` Status. 

Fortunately, Vercel's limit is 14KB, but worst case escape characters would mean possibly breaching that limit. 

This PR changes the encoding so that the URL does not hit that limit. 

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #<issue-number>, Addresses #<issue-number> -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
