### PR TITLE
feat(analytics): report Web Vitals to Speed Insights and GA4

### DIFF
--- a/app/@analytics/WebVitalsReporter.tsx
+++ b/app/@analytics/WebVitalsReporter.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+
+import { webVitalsAnalytics } from '@/app/shared/lib/analytics';
+
+export function WebVitalsReporter() {
+    // A stable callback identity matters: useReportWebVitals re-subscribes on every
+    // change, and a second subscription re-reports metrics that fire more than once.
+    useReportWebVitals(webVitalsAnalytics.trackMetric);
+
+    return undefined;
+}

--- a/app/@analytics/default.js
+++ b/app/@analytics/default.js
@@ -1,11 +1,37 @@
 'use client';
 
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import Script from 'next/script';
+import { useState } from 'react';
 
 import { useAnalyticsConsent } from '@/app/features/cookie';
 
+import { WebVitalsReporter } from './WebVitalsReporter';
+
+// At full rate Explorer traffic would run far past the included Speed Insights
+// allowance; 10% still leaves ample volume for per-route percentiles.
+const SPEED_INSIGHTS_SAMPLE_RATE = 0.1;
+
 export default function Analytics() {
     const { isConsentGiven } = useAnalyticsConsent();
+
+    return (
+        <>
+            {/* Ungated: Speed Insights writes nothing to the device, so the cookie
+                banner's scope does not reach it. Everything below feeds gtag. */}
+            <SpeedInsights sampleRate={SPEED_INSIGHTS_SAMPLE_RATE} />
+            {isConsentGiven && <GoogleTags />}
+        </>
+    );
+}
+
+function GoogleTags() {
+    // The reporter waits for gtag rather than mounting alongside it: buffered vitals
+    // arrive the instant it subscribes, which beats an afterInteractive script, and
+    // trackEvent drops silently when no provider is up. Subscribing late costs
+    // nothing, since PerformanceObserver replays what it already saw.
+    const [isGtagReady, setIsGtagReady] = useState(false);
+    const markGtagReady = () => setIsGtagReady(true);
     const safeAnalyticsId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID?.replace("'", "\\'");
     const safeTagId = process.env.NEXT_PUBLIC_GOOGLE_TAG_ID?.replace("'", "\\'");
 
@@ -13,14 +39,11 @@ export default function Analytics() {
         return null;
     }
 
-    if (!isConsentGiven) {
-        return null;
-    }
-
     if (safeTagId) {
         return (
             <>
-                <Script id="google-tag-initialization">
+                {isGtagReady && <WebVitalsReporter />}
+                <Script id="google-tag-initialization" onReady={markGtagReady}>
                     {`
                     (function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({
                             'gtm.start': new Date().getTime(),
@@ -50,13 +73,14 @@ export default function Analytics() {
     // Fallback to Google Analytics if no Tag ID is provided
     return (
         <>
+            {isGtagReady && <WebVitalsReporter />}
             {/* Global site tag (gtag.js) - Google Analytics  */}
             <Script
                 async
                 src={`https://www.googletagmanager.com/gtag/js?id=${safeAnalyticsId}`}
                 strategy="afterInteractive"
             />
-            <Script id="google-analytics-initialization" strategy="afterInteractive">
+            <Script id="google-analytics-initialization" strategy="afterInteractive" onReady={markGtagReady}>
                 {`
                     window.dataLayer = window.dataLayer || [];
                     function gtag(){dataLayer.push(arguments);}

--- a/app/shared/lib/analytics/__tests__/web-vitals.spec.ts
+++ b/app/shared/lib/analytics/__tests__/web-vitals.spec.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '../track-event';
+import { webVitalsAnalytics, type WebVitalsMetric } from '../web-vitals';
+
+vi.mock('../track-event', () => ({
+    trackEvent: vi.fn(),
+}));
+
+const mockedTrackEvent = vi.mocked(trackEvent);
+
+function metric(overrides: Partial<WebVitalsMetric> & Pick<WebVitalsMetric, 'name'>): WebVitalsMetric {
+    return { rating: 'good', value: 0, ...overrides };
+}
+
+describe('webVitalsAnalytics.trackMetric', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it.each([
+        ['LCP', 'wv_lcp'],
+        ['INP', 'wv_inp'],
+        ['CLS', 'wv_cls'],
+        ['FCP', 'wv_fcp'],
+        ['TTFB', 'wv_ttfb'],
+    ])('should emit %s as %s', (name, event) => {
+        webVitalsAnalytics.trackMetric(metric({ name }));
+
+        expect(mockedTrackEvent).toHaveBeenCalledWith(event, expect.anything());
+    });
+
+    it('should pass the rating through', () => {
+        webVitalsAnalytics.trackMetric(metric({ name: 'INP', rating: 'needs-improvement', value: 320 }));
+
+        expect(mockedTrackEvent).toHaveBeenCalledWith('wv_inp', {
+            metric_rating: 'needs-improvement',
+            metric_value: 320,
+        });
+    });
+
+    it('should round millisecond metrics to whole milliseconds', () => {
+        webVitalsAnalytics.trackMetric(metric({ name: 'LCP', value: 2543.6789 }));
+
+        expect(mockedTrackEvent).toHaveBeenCalledWith('wv_lcp', { metric_rating: 'good', metric_value: 2544 });
+    });
+
+    it('should keep CLS precision, which whole-number rounding would erase', () => {
+        webVitalsAnalytics.trackMetric(metric({ name: 'CLS', value: 0.10456789 }));
+
+        expect(mockedTrackEvent).toHaveBeenCalledWith('wv_cls', { metric_rating: 'good', metric_value: 0.1046 });
+    });
+
+    it('should ignore FID, which useReportWebVitals still emits', () => {
+        webVitalsAnalytics.trackMetric(metric({ name: 'FID', value: 12 }));
+
+        expect(mockedTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('should ignore an unrecognised metric', () => {
+        webVitalsAnalytics.trackMetric(metric({ name: 'Next.js-hydration', value: 12 }));
+
+        expect(mockedTrackEvent).not.toHaveBeenCalled();
+    });
+});

--- a/app/shared/lib/analytics/index.ts
+++ b/app/shared/lib/analytics/index.ts
@@ -2,3 +2,4 @@ export { EReceiptDownloadFormat, receiptAnalytics } from './receipt';
 export { refreshAnalytics } from './refresh';
 export { searchAnalytics } from './search';
 export { type GA4EventName, trackEvent } from './track-event';
+export { type WebVitalsMetric, webVitalsAnalytics, WebVitalsEvent } from './web-vitals';

--- a/app/shared/lib/analytics/web-vitals.ts
+++ b/app/shared/lib/analytics/web-vitals.ts
@@ -1,0 +1,46 @@
+import { type GA4EventName, trackEvent } from './track-event';
+
+export enum WebVitalsEvent {
+    CLS = 'wv_cls',
+    FCP = 'wv_fcp',
+    INP = 'wv_inp',
+    LCP = 'wv_lcp',
+    TTFB = 'wv_ttfb',
+}
+
+type _WebVitalsEventNames = `${WebVitalsEvent}`;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- forces a compile error if any enum value exceeds the limit
+const _assertGA4Length: _WebVitalsEventNames extends GA4EventName<_WebVitalsEventNames> ? true : never = true;
+
+export type WebVitalsMetric = {
+    name: string;
+    rating: 'good' | 'needs-improvement' | 'poor';
+    value: number;
+};
+
+const EVENT_BY_METRIC_NAME: Record<string, WebVitalsEvent | undefined> = {
+    CLS: WebVitalsEvent.CLS,
+    FCP: WebVitalsEvent.FCP,
+    INP: WebVitalsEvent.INP,
+    LCP: WebVitalsEvent.LCP,
+    TTFB: WebVitalsEvent.TTFB,
+};
+
+export const webVitalsAnalytics = {
+    trackMetric({ name, rating, value }: WebVitalsMetric): void {
+        const event = EVENT_BY_METRIC_NAME[name];
+
+        // useReportWebVitals also emits the deprecated FID, which INP replaced.
+        if (!event) {
+            return;
+        }
+
+        trackEvent(event, { metric_rating: rating, metric_value: roundMetricValue(event, value) });
+    },
+};
+
+// CLS is a unitless ratio near zero. Every other vital is milliseconds, where
+// sub-millisecond precision is noise.
+function roundMetricValue(event: WebVitalsEvent, value: number): number {
+    return event === WebVitalsEvent.CLS ? Math.round(value * 10_000) / 10_000 : Math.round(value);
+}

--- a/app/utils/__tests__/get-readable-title-from-address.spec.ts
+++ b/app/utils/__tests__/get-readable-title-from-address.spec.ts
@@ -2,7 +2,7 @@ import { gen } from '@__fixtures__/gen';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getTokenInfo } from '@/app/entities/token-info/server';
-import { Cluster, clusterSlug } from '@/app/utils/cluster';
+import { Cluster, CLUSTERS, clusterSlug } from '@/app/utils/cluster';
 import getReadableTitleFromAddress from '@/app/utils/get-readable-title-from-address';
 
 vi.mock('@/app/entities/token-info/server', () => ({
@@ -10,14 +10,11 @@ vi.mock('@/app/entities/token-info/server', () => ({
 }));
 
 describe('getReadableTitleFromAddress', () => {
-    it.each([Cluster.Devnet, Cluster.Testnet, Cluster.Simd296, Cluster.Custom, Cluster.MainnetBeta])(
-        'should look the token up on the cluster the slug names (%i)',
-        async cluster => {
-            await getReadableTitleFromAddress(props(clusterSlug(cluster)));
+    it.each(CLUSTERS)('should look the token up on the cluster the slug names (%i)', async cluster => {
+        await getReadableTitleFromAddress(props(clusterSlug(cluster)));
 
-            expect(getTokenInfo).toHaveBeenCalledWith(TOKEN_ADDRESS, cluster);
-        },
-    );
+        expect(getTokenInfo).toHaveBeenCalledWith(TOKEN_ADDRESS, cluster);
+    });
 
     it.each([undefined, 'not-a-cluster'])('should fall back to the default cluster for %s', async clusterParam => {
         await getReadableTitleFromAddress(props(clusterParam));

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -5,31 +5,31 @@
 | Static | `/` | 130 kB | 530 kB |
 | Static | `/_not-found` | 0 B | 410 kB |
 | Dynamic | `/address/[address]` | 520 kB | 920 kB |
-| Dynamic | `/address/[address]/account-data` | 520 kB | 920 kB |
-| Dynamic | `/address/[address]/anchor-account` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/attestation` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/attributes` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/blockhashes` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/compression` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/concurrent-merkle-tree` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/domains` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/entries` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/account-data` | 530 kB | 930 kB |
+| Dynamic | `/address/[address]/anchor-account` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/attestation` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/attributes` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/blockhashes` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/compression` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/concurrent-merkle-tree` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/domains` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/entries` | 490 kB | 890 kB |
 | Dynamic | `/address/[address]/feature-gate` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/idl` | 600 kB | 0.97 MB |
+| Dynamic | `/address/[address]/idl` | 610 kB | 0.98 MB |
 | Dynamic | `/address/[address]/instructions` | 490 kB | 890 kB |
-| Dynamic | `/address/[address]/metadata` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/program-multisig` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/rewards` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/security` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/slot-hashes` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/stake-history` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/metadata` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/program-multisig` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/rewards` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/security` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/slot-hashes` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/stake-history` | 490 kB | 890 kB |
 | Dynamic | `/address/[address]/subscriptions` | 480 kB | 880 kB |
 | Dynamic | `/address/[address]/token-extensions` | 490 kB | 890 kB |
-| Dynamic | `/address/[address]/tokens` | 490 kB | 900 kB |
-| Dynamic | `/address/[address]/transfers` | 490 kB | 890 kB |
-| Dynamic | `/address/[address]/verified-build` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/vote-history` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/tokens` | 500 kB | 900 kB |
+| Dynamic | `/address/[address]/transfers` | 500 kB | 900 kB |
+| Dynamic | `/address/[address]/verified-build` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/vote-history` | 490 kB | 890 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
 | Dynamic | `/api/geo-location` | — | — |
@@ -50,19 +50,19 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 240 kB | 640 kB |
+| Dynamic | `/block/[slot]` | 250 kB | 650 kB |
 | Dynamic | `/block/[slot]/accounts` | 240 kB | 640 kB |
 | Dynamic | `/block/[slot]/programs` | 240 kB | 640 kB |
-| Dynamic | `/block/[slot]/rewards` | 230 kB | 640 kB |
-| Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
-| Static | `/feature-gates` | 40 kB | 440 kB |
+| Dynamic | `/block/[slot]/rewards` | 240 kB | 640 kB |
+| Dynamic | `/epoch/[epoch]` | 20 kB | 420 kB |
+| Static | `/feature-gates` | 50 kB | 450 kB |
 | Dynamic | `/mcp` | — | — |
-| Static | `/mcp/docs` | 20 kB | 420 kB |
+| Static | `/mcp/docs` | 30 kB | 430 kB |
 | Static | `/mcp/start` | 20 kB | 420 kB |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 410 kB |
-| Dynamic | `/tx/[signature]` | 530 kB | 930 kB |
-| Dynamic | `/tx/[signature]/inspect` | 440 kB | 840 kB |
-| Static | `/tx/inspector` | 440 kB | 840 kB |
+| Static | `/tos` | 10 kB | 410 kB |
+| Dynamic | `/tx/[signature]` | 540 kB | 940 kB |
+| Dynamic | `/tx/[signature]/inspect` | 450 kB | 850 kB |
+| Static | `/tx/inspector` | 450 kB | 850 kB |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -12,18 +12,18 @@ tab_opened → [wallet_connected ↔ sections_expanded] → transaction_submitte
 
 ### Events
 
-| Event | Parameters |
-|-------|------------|
-| `tab_opened` | `program_id` |
-| `wallet_connected` | `program_id`, `wallet_type` |
-| `sections_expanded` | `program_id`, `expanded_sections`, `expanded_sections_count` |
-| `transaction_submitted` | `program_id`, `instruction_name` |
-| `transaction_confirmed` | `program_id`, `instruction_name`, `transaction_signature` |
-| `transaction_failed` | `program_id`, `instruction_name`, `error_message` |
+| Event                   | Parameters                                                   |
+| ----------------------- | ------------------------------------------------------------ |
+| `tab_opened`            | `program_id`                                                 |
+| `wallet_connected`      | `program_id`, `wallet_type`                                  |
+| `sections_expanded`     | `program_id`, `expanded_sections`, `expanded_sections_count` |
+| `transaction_submitted` | `program_id`, `instruction_name`                             |
+| `transaction_confirmed` | `program_id`, `instruction_name`, `transaction_signature`    |
+| `transaction_failed`    | `program_id`, `instruction_name`, `error_message`            |
 
 All events are prefixed with `iidl_anchor_`.
 
-> GA4 event names must be <= 40 characters. This is enforced at compile time via the `GA4EventName` type in ../app/shared/lib/analytics/types.d.ts
+> GA4 event names must be <= 40 characters. This is enforced at compile time via the `GA4EventName` type in ../app/shared/lib/analytics/types.ts
 
 ## Receipt Feature Funnel
 
@@ -35,12 +35,12 @@ button_clicked → receipt_viewed / no_receipt → view_tx_clicked
 
 ### Events
 
-| Event | Parameters |
-|-------|------------|
-| `button_clicked` | `signature` |
-| `viewed` | `signature`, `receipt_type` (sol/token) |
-| `no_receipt` | `signature` |
-| `view_tx_clicked` | `signature` |
+| Event             | Parameters                              |
+| ----------------- | --------------------------------------- |
+| `button_clicked`  | `signature`                             |
+| `viewed`          | `signature`, `receipt_type` (sol/token) |
+| `no_receipt`      | `signature`                             |
+| `view_tx_clicked` | `signature`                             |
 
 All events are prefixed with `rcpt_`.
 
@@ -68,10 +68,44 @@ Tracks usage of the Refresh button across the Explorer.
 
 ### Events
 
-| Event | Parameters |
-|-------|------------|
-| `button_clicked` | `section` |
+| Event            | Parameters |
+| ---------------- | ---------- |
+| `button_clicked` | `section`  |
 
 All events are prefixed with `rfsh_`.
 
 The `section` parameter identifies the page surface where the button was clicked. Each call site provides a hardcoded literal (e.g. `transaction_card`, `token_mint_card`, `vote_account_section`, `token_history_card`). Shared components (`AccountHeader`, `HistoryCardHeader`) accept an explicit `analyticsSection` prop so the tracked value is decoupled from display text.
+
+## Web Vitals
+
+Real-user performance is reported to two independent sinks from the `app/@analytics/` slot:
+
+- **Vercel Speed Insights** — `@vercel/speed-insights/next`, sampled at 10%. Core Web Vitals with route, country, and element breakdowns in the Vercel dashboard. Requires Speed Insights Plus for the individual metrics, which is included on the Enterprise plan.
+- **GA4** — `useReportWebVitals` from `next/web-vitals`, unsampled, so the vitals sit alongside the funnels above.
+
+The two sit on opposite sides of the cookie consent gate. Speed Insights writes nothing to the device — no cookie, no storage, no client-generated identifier — so the banner, which exists to cover cookies, does not reach it and it runs ungated. The GA4 path feeds gtag, so it stays behind consent along with the GA and GTM scripts.
+
+The GA4 reporter also waits for the tag script's `onReady` before it subscribes. `trackEvent` drops an event when neither `gtag` nor `dataLayer` exists yet, and buffered vitals arrive the instant the reporter subscribes — earlier than an `afterInteractive` script can load. Waiting costs nothing, because `PerformanceObserver` replays entries it already saw.
+
+### Events
+
+| Event     | Parameters                      | Metric                    |
+| --------- | ------------------------------- | ------------------------- |
+| `wv_lcp`  | `metric_rating`, `metric_value` | Largest Contentful Paint  |
+| `wv_inp`  | `metric_rating`, `metric_value` | Interaction to Next Paint |
+| `wv_cls`  | `metric_rating`, `metric_value` | Cumulative Layout Shift   |
+| `wv_fcp`  | `metric_rating`, `metric_value` | First Contentful Paint    |
+| `wv_ttfb` | `metric_rating`, `metric_value` | Time to First Byte        |
+
+All events are prefixed with `wv_`.
+
+- `metric_rating`: `good`, `needs-improvement`, or `poor`, as classified by the `web-vitals` library
+- `metric_value`: milliseconds rounded to a whole number, except `wv_cls`, which is a unitless ratio kept to four decimal places
+
+`useReportWebVitals` also emits the deprecated First Input Delay (FID); INP replaced it, so it is dropped rather than given an event name.
+
+### Reading the numbers
+
+Speed Insights sees every visitor, so its numbers are the ones to trust for country and route comparisons.
+
+The GA4 events are a consent-gated subset. Non-EU visitors are auto-granted, but an EU visitor who ignores the banner never grants consent and contributes nothing, so the EU slice is thin and skewed toward people who click. Consent granted part-way through a page load loses less than it looks: `web-vitals` registers buffered `PerformanceObserver`s, so paint and layout entries from before the mount still arrive.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@solana/web3.js": "1.98.4",
         "@sqds/multisig": "2.1.3",
         "@types/bn.js": "5.1.0",
+        "@vercel/speed-insights": "2.0.0",
         "bignumber.js": "9.0.2",
         "bn.js": "5.2.1",
         "botid": "1.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  oxc:
+    oxfmt:
+      specifier: ^0.56.0
+      version: 0.56.0
+    oxlint:
+      specifier: ^1.71.0
+      version: 1.72.0
   storybook:
     '@storybook/addon-a11y':
       specifier: 10.5.7
@@ -261,6 +268,9 @@ importers:
       '@types/bn.js':
         specifier: 5.1.0
         version: 5.1.0
+      '@vercel/speed-insights':
+        specifier: 2.0.0
+        version: 2.0.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@22.15.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.53.0))(react@19.2.6)
       bignumber.js:
         specifier: 9.0.2
         version: 9.0.2
@@ -5839,6 +5849,32 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
@@ -15939,6 +15975,11 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/speed-insights@2.0.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@22.15.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.53.0))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(@types/node@22.15.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.53.0)
+      react: 19.2.6
 
   '@vitejs/plugin-react@4.3.4(vite@6.4.3(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.53.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Description

Adds production Web Vitals monitoring for LCP, INP, CLS, FCP and TTFB, reported to two independent sinks from the `app/@analytics/` slot:

- **Vercel Speed Insights** — `@vercel/speed-insights` 2.0.0, sampled at 10%. Gives route, country and element breakdowns in the Vercel dashboard.
- **GA4** — `useReportWebVitals` from `next/web-vitals`, feeding the existing `trackEvent` pipeline as `wv_lcp` / `wv_inp` / `wv_cls` / `wv_fcp` / `wv_ttfb`.

No standalone `web-vitals` dependency is added. `useReportWebVitals` also emits the deprecated FID, which INP replaced, so it is dropped rather than given an event name.

### On the consent gate

The two sinks sit on opposite sides of it, deliberately.

Speed Insights writes nothing to the visitor's device — no cookie, no storage, no client-generated identifier ([Vercel's data table](https://vercel.com/docs/speed-insights/privacy-policy)). The cookie banner in `CookieConsent.tsx` exists to cover cookies, and auto-grants for non-EU visitors, so its scope does not reach Speed Insights. Gating it would also thin the country breakdown it exists to provide: an EU visitor who ignores the banner never grants consent and would contribute nothing.

The GA4 path feeds gtag, so it stays behind consent along with the GA and GTM scripts.

Whether legitimate interest covers the processing is a call for whoever owns the privacy policy — flagging it here rather than deciding it in code.

## Type of change

-   [x] New feature

## Screenshots

No UI changes — both sinks render nothing.

## Testing

Manual testing on the preview deployment:

- [Home — Speed Insights intake fires in the network tab before the cookie banner is answered](https://explorer-git-fork-hoodieshq-feat-web-v-03841d-solana-foundation.vercel.app)
- [Address page — `wv_*` events reach GA4 DebugView after accepting the banner](https://explorer-git-fork-hoodieshq-feat-web-v-03841d-solana-foundation.vercel.app/address/So11111111111111111111111111111111111111112)
- [Transaction page — the same, on a heavier route where LCP and INP are worth watching](https://explorer-git-fork-hoodieshq-feat-web-v-03841d-solana-foundation.vercel.app/tx/inspector)

Speed Insights v2 randomizes the intake path per build, so match on the request rather than a fixed URL.

## Related Issues

Closes [HOO-1147](https://linear.app/solana-fndn/issue/HOO-1147/add-production-web-vitals-monitoring)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information

## Additional Notes

- **Speed Insights has to be enabled on the Vercel project** or the package reports into a void. The individual Core Web Vitals (as opposed to the aggregate Real Experience Score) need Speed Insights Plus, which is included on the Enterprise plan.
- **The 10% sample rate is not calibrated.** It was chosen against the $0.65 per 10,000 on-demand event rate, not against Explorer's actual traffic — worth revisiting once there is a real number to size it with.
- **Bundle impact:** roughly 10 kB across most routes per `bench/BUILD.md`. That is the granularity floor of that table, so the true delta is somewhere at or below it; the dependency lands in the root layout, so it touches every route.


