### PR TITLE
refactor(instruction-simulation): move simulation off web3.js Connection

### DIFF
--- a/app/features/instruction-simulation/lib/__tests__/resolve-address-lookup-tables.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/resolve-address-lookup-tables.spec.ts
@@ -1,4 +1,5 @@
-import type { AccountInfo, Connection, VersionedMessage } from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
+import type { VersionedMessage } from '@solana/web3.js';
 import { Keypair, PublicKey } from '@solana/web3.js';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -8,7 +9,7 @@ import {
     ALT_3_ADDRS,
     ALT_3_EXPECTED_ADDRESSES,
 } from '@/app/fixtures/address-lookup-tables';
-import { fromBase64 } from '@/app/shared/lib/bytes';
+import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 
 import { resolveAddressLookupTables } from '../resolve-address-lookup-tables';
 
@@ -17,18 +18,18 @@ const ALT_KEY_2 = Keypair.generate().publicKey;
 
 describe('resolveAddressLookupTables', () => {
     it('should return empty array when message has no lookups', async () => {
-        const connection = mockConnection([]);
-        const result = await resolveAddressLookupTables(connection, message([]));
+        const rpc = mockRpc([]);
+        const result = await resolveAddressLookupTables(rpc, message([]));
 
         expect(result).toEqual([]);
-        expect(connection.getMultipleAccountsInfo).not.toHaveBeenCalled();
+        expect(rpc.getMultipleAccounts).not.toHaveBeenCalled();
     });
 
     it('should resolve a single lookup table', async () => {
-        const connection = mockConnection([accountInfo(ALT_3_ADDRS)]);
+        const rpc = mockRpc([accountInfo(ALT_3_ADDRS)]);
         const msg = message([{ accountKey: ALT_KEY_1, readonlyIndexes: [0, 1, 2], writableIndexes: [] }]);
 
-        const result = await resolveAddressLookupTables(connection, msg);
+        const result = await resolveAddressLookupTables(rpc, msg);
 
         expect(result).toHaveLength(1);
         expect(result[0].key.toBase58()).toBe(ALT_KEY_1.toBase58());
@@ -36,13 +37,13 @@ describe('resolveAddressLookupTables', () => {
     });
 
     it('should resolve multiple lookup tables', async () => {
-        const connection = mockConnection([accountInfo(ALT_3_ADDRS), accountInfo(ALT_2_ADDRS)]);
+        const rpc = mockRpc([accountInfo(ALT_3_ADDRS), accountInfo(ALT_2_ADDRS)]);
         const msg = message([
             { accountKey: ALT_KEY_1, readonlyIndexes: [], writableIndexes: [0] },
             { accountKey: ALT_KEY_2, readonlyIndexes: [0], writableIndexes: [] },
         ]);
 
-        const result = await resolveAddressLookupTables(connection, msg);
+        const result = await resolveAddressLookupTables(rpc, msg);
 
         expect(result).toHaveLength(2);
         expect(result[0].key.toBase58()).toBe(ALT_KEY_1.toBase58());
@@ -56,59 +57,65 @@ describe('resolveAddressLookupTables', () => {
      * this message to the user, so it has to name the table and say what happened.
      */
     it('should throw naming the table when the RPC returns no account for one', async () => {
-        const connection = mockConnection([null, accountInfo(ALT_2_ADDRS)]);
+        const rpc = mockRpc([null, accountInfo(ALT_2_ADDRS)]);
         const msg = message([
             { accountKey: ALT_KEY_1, readonlyIndexes: [0], writableIndexes: [] },
             { accountKey: ALT_KEY_2, readonlyIndexes: [0], writableIndexes: [] },
         ]);
 
-        await expect(resolveAddressLookupTables(connection, msg)).rejects.toThrow(
+        await expect(resolveAddressLookupTables(rpc, msg)).rejects.toThrow(
             `Address lookup table ${ALT_KEY_1.toBase58()} could not be loaded`,
         );
     });
 
     it('should batch all keys into a single RPC call', async () => {
-        const connection = mockConnection([accountInfo(ALT_3_ADDRS), accountInfo(ALT_2_ADDRS)]);
+        const rpc = mockRpc([accountInfo(ALT_3_ADDRS), accountInfo(ALT_2_ADDRS)]);
         const msg = message([
             { accountKey: ALT_KEY_1, readonlyIndexes: [], writableIndexes: [0] },
             { accountKey: ALT_KEY_2, readonlyIndexes: [], writableIndexes: [0] },
         ]);
 
-        await resolveAddressLookupTables(connection, msg);
+        await resolveAddressLookupTables(rpc, msg);
 
-        expect(connection.getMultipleAccountsInfo).toHaveBeenCalledTimes(1);
-        expect(connection.getMultipleAccountsInfo).toHaveBeenCalledWith([ALT_KEY_1, ALT_KEY_2]);
+        expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+        expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+            [toKitAddress(ALT_KEY_1), toKitAddress(ALT_KEY_2)],
+            expect.objectContaining({ encoding: 'base64' }),
+        );
     });
 
     // Reports the first missing table rather than a count, so the message points at something actionable.
     it('should throw on the first table when none of them load', async () => {
-        const connection = mockConnection([null, null]);
+        const rpc = mockRpc([null, null]);
         const msg = message([
             { accountKey: ALT_KEY_1, readonlyIndexes: [0], writableIndexes: [] },
             { accountKey: ALT_KEY_2, readonlyIndexes: [0], writableIndexes: [] },
         ]);
 
-        await expect(resolveAddressLookupTables(connection, msg)).rejects.toThrow(
+        await expect(resolveAddressLookupTables(rpc, msg)).rejects.toThrow(
             `Address lookup table ${ALT_KEY_1.toBase58()} could not be loaded`,
         );
     });
 });
 
-function accountInfo(base64Data: string): AccountInfo<Uint8Array> {
+function accountInfo(base64Data: string) {
     return {
-        data: fromBase64(base64Data),
+        data: [base64Data, 'base64'] as const,
         executable: false,
-        lamports: 1_000_000,
-        owner: new PublicKey('AddressLookupTab1e1111111111111111111111111'),
-        rentEpoch: 0,
+        lamports: 1_000_000n,
+        owner: new PublicKey('AddressLookupTab1e1111111111111111111111111').toBase58(),
+        rentEpoch: 0n,
+        space: 0n,
     };
 }
 
-function mockConnection(results: (AccountInfo<Uint8Array> | null)[]): Connection {
-    // Partial mock — only getMultipleAccountsInfo is called
+function mockRpc(results: (ReturnType<typeof accountInfo> | null)[]): SolanaRpc {
+    // Partial mock — only getMultipleAccounts is called
     return {
-        getMultipleAccountsInfo: vi.fn().mockResolvedValue(results),
-    } as unknown as Connection;
+        getMultipleAccounts: vi.fn().mockReturnValue({
+            send: vi.fn().mockResolvedValue({ value: results }),
+        }),
+    } as unknown as SolanaRpc;
 }
 
 function message(lookups: { accountKey: PublicKey; writableIndexes: number[]; readonlyIndexes: number[] }[]) {

--- a/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
@@ -1,10 +1,5 @@
-import {
-    type AddressLookupTableAccount,
-    type Connection,
-    Keypair,
-    PublicKey,
-    type VersionedMessage,
-} from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
+import { type AddressLookupTableAccount, Keypair, PublicKey, type VersionedMessage } from '@solana/web3.js';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { Cluster } from '@utils/cluster';
@@ -16,6 +11,7 @@ import { createV1TransactionBytes, RECIPIENT } from '@/app/entities/transaction-
 import { alloc, toBase64, writeU64LE, writeUint32LE } from '@/app/shared/lib/bytes';
 import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
 import { bridgeV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
+import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 
 // Mock VersionedTransaction so we don't need a real message header
 vi.mock('@solana/web3.js', async () => {
@@ -23,7 +19,7 @@ vi.mock('@solana/web3.js', async () => {
     return {
         ...actual,
         VersionedTransaction: vi.fn().mockImplementation(function (msg: unknown) {
-            return { message: msg };
+            return { message: msg, serialize: () => new Uint8Array(0) };
         }),
     };
 });
@@ -59,19 +55,19 @@ describe('simulateTransaction', () => {
         ];
         mockParseProgramLogs.mockReturnValue(mockLogs);
 
-        const result = await simulate(createMockConnection());
+        const result = await simulate(createMockRpc());
 
         expect(result).toMatchObject({ error: undefined, logs: mockLogs });
     });
 
     it('should return units consumed from simulation response', async () => {
-        const result = await simulate(createMockConnection());
+        const result = await simulate(createMockRpc());
 
         expect(result).toMatchObject({ unitsConsumed: 150 });
     });
 
     it('should compute SOL balance changes from simulation data', async () => {
-        const result = await simulate(createMockConnection());
+        const result = await simulate(createMockRpc());
 
         expect(result.solBalanceChanges).toHaveLength(2);
 
@@ -90,7 +86,7 @@ describe('simulateTransaction', () => {
             preBalances: [2_000_000_000, 4_000_000_000],
         };
 
-        const result = await simulate(createMockConnection(), undefined, accountBalances);
+        const result = await simulate(createMockRpc(), undefined, accountBalances);
 
         const change1 = result.solBalanceChanges?.find(c => c.pubkey.equals(ACCOUNT_KEY_1));
         expect(change1?.delta.eq(new BN(3_000_000_000))).toBe(true);
@@ -100,33 +96,33 @@ describe('simulateTransaction', () => {
     });
 
     it('should return undefined solBalanceChanges when all deltas are zero', async () => {
-        const connection = createMockConnection({
-            getMultipleParsedAccounts: vi.fn().mockResolvedValue({
+        const rpc = createMockRpc({
+            getMultipleAccounts: rpcCall({
                 value: [
-                    { data: {}, lamports: 2_000_000_000, owner: new PublicKey(SYSTEM_PROGRAM_ADDRESS) },
-                    { data: {}, lamports: 500_000_000, owner: new PublicKey(SYSTEM_PROGRAM_ADDRESS) },
+                    { data: {}, lamports: 2_000_000_000n, owner: SYSTEM_PROGRAM_ADDRESS },
+                    { data: {}, lamports: 500_000_000n, owner: SYSTEM_PROGRAM_ADDRESS },
                 ],
             }),
         });
 
-        const result = await simulate(connection);
+        const result = await simulate(rpc);
 
         expect(result.solBalanceChanges).toBeUndefined();
     });
 
     it('should throw when simulation response has no accounts', async () => {
-        const connection = createMockConnection({
-            simulateTransaction: vi.fn().mockResolvedValue({
+        const rpc = createMockRpc({
+            simulateTransaction: rpcCall({
                 value: { accounts: null, err: null, logs: [] },
             }),
         });
 
-        await expect(simulate(connection)).rejects.toThrow('RPC did not return account data after simulation');
+        await expect(simulate(rpc)).rejects.toThrow('RPC did not return account data after simulation');
     });
 
     it('should return raw error string when simulation returns error with empty logs', async () => {
-        const connection = createMockConnection({
-            simulateTransaction: vi.fn().mockResolvedValue(
+        const rpc = createMockRpc({
+            simulateTransaction: rpcCall(
                 createSimulationResponse({
                     err: 'AccountNotFound',
                     logs: [],
@@ -134,7 +130,7 @@ describe('simulateTransaction', () => {
             ),
         });
 
-        const result = await simulate(connection);
+        const result = await simulate(rpc);
 
         expect(result).toMatchObject({ error: 'AccountNotFound', logs: undefined });
     });
@@ -151,8 +147,8 @@ describe('simulateTransaction', () => {
         ];
         mockParseProgramLogs.mockReturnValue(mockLogs);
 
-        const connection = createMockConnection({
-            simulateTransaction: vi.fn().mockResolvedValue(
+        const rpc = createMockRpc({
+            simulateTransaction: rpcCall(
                 createSimulationResponse({
                     err: { InstructionError: [0, 'Custom'] },
                     logs: [`Program ${SYSTEM_PROGRAM_ADDRESS} invoke [1]`, 'Program failed'],
@@ -160,27 +156,50 @@ describe('simulateTransaction', () => {
             ),
         });
 
-        const result = await simulate(connection);
+        const result = await simulate(rpc);
 
         expect(result).toMatchObject({ error: 'TransactionError', logs: mockLogs });
     });
 
+    it('should replace bigints inside a transaction error with numbers', async () => {
+        mockParseProgramLogs.mockReturnValue([]);
+
+        const rpc = createMockRpc({
+            simulateTransaction: rpcCall(
+                createSimulationResponse({
+                    err: { InstructionError: [2n, { Custom: 6001n }] },
+                    logs: ['Program failed'],
+                }),
+            ),
+        });
+
+        await simulate(rpc);
+
+        expect(mockParseProgramLogs).toHaveBeenCalledWith(
+            expect.any(Array),
+            { InstructionError: [2, { Custom: 6001 }] },
+            Cluster.Devnet,
+        );
+    });
+
     it('should pass logs, error, and cluster to parseProgramLogs', async () => {
-        const connection = createMockConnection();
-        await simulate(connection);
+        const rpc = createMockRpc();
+        await simulate(rpc);
 
         expect(mockParseProgramLogs).toHaveBeenCalledWith(expect.any(Array), null, Cluster.Devnet);
     });
 
     it('should request simulation with replaceRecentBlockhash and account addresses', async () => {
-        const connection = createMockConnection();
-        await simulate(connection);
+        const rpc = createMockRpc();
+        await simulate(rpc);
 
-        expect(connection.simulateTransaction).toHaveBeenCalledWith(expect.anything(), {
+        expect(rpc.simulateTransaction).toHaveBeenCalledWith(expect.any(String), {
             accounts: {
-                addresses: [ACCOUNT_KEY_1.toBase58(), ACCOUNT_KEY_2.toBase58()],
+                addresses: [toKitAddress(ACCOUNT_KEY_1), toKitAddress(ACCOUNT_KEY_2)],
                 encoding: 'base64',
             },
+            commitment: 'confirmed',
+            encoding: 'base64',
             replaceRecentBlockhash: true,
         });
     });
@@ -211,21 +230,30 @@ describe('simulateTransaction', () => {
         // Addresses start at offset 56
         buf.set(lookupAddress.toBytes(), 56);
 
-        const connection = createMockConnection({
-            getMultipleAccountsInfo: vi.fn().mockResolvedValue([
-                {
-                    data: buf,
-                    executable: false,
-                    lamports: 1,
-                    owner: new PublicKey('AddressLookupTab1e1111111111111111111111111'),
-                    rentEpoch: 0,
-                },
-            ]),
-        });
+        const rpc = createMockRpc();
+        // The first getMultipleAccounts call resolves the lookup table (base64); the second
+        // fetches the parsed pre-simulation accounts and falls through to the factory default.
+        vi.mocked(rpc.getMultipleAccounts).mockReturnValueOnce(
+            sendResult({
+                value: [
+                    {
+                        data: [toBase64(buf), 'base64'],
+                        executable: false,
+                        lamports: 1n,
+                        owner: 'AddressLookupTab1e1111111111111111111111111',
+                        rentEpoch: 0n,
+                        space: 88n,
+                    },
+                ],
+            }),
+        );
 
-        const result = await simulate(connection, message);
+        const result = await simulate(rpc, message);
 
-        expect(connection.getMultipleAccountsInfo).toHaveBeenCalledWith([lookupTableKey]);
+        expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(
+            [toKitAddress(lookupTableKey)],
+            expect.objectContaining({ encoding: 'base64' }),
+        );
         // The resolved keys are what names each instruction's program downstream. A lookup-table address
         // appears only here, never in `staticAccountKeys`, so reading the program id from the message
         // alone would name the wrong program.
@@ -233,11 +261,11 @@ describe('simulateTransaction', () => {
     });
 
     it('should return epoch from epochInfo', async () => {
-        const connection = createMockConnection({
-            getEpochInfo: vi.fn().mockResolvedValue({ epoch: 42 }),
+        const rpc = createMockRpc({
+            getEpochInfo: rpcCall({ epoch: 42n }),
         });
 
-        const result = await simulate(connection);
+        const result = await simulate(rpc);
 
         expect(result.epoch).toBe(42n);
     });
@@ -247,12 +275,12 @@ describe('simulateTransaction', () => {
         const MINT_KEY = MOCK_MINT;
         const OWNER_KEY = MOCK_OWNER;
 
-        function setupTokenAccountConnection(preAmount: bigint, postAmount: bigint, decimals = 6): Connection {
+        function setupTokenAccountRpc(preAmount: bigint, postAmount: bigint, decimals = 6): SolanaRpc {
             const postTokenAccountBase64 = encodeTokenAccountBase64(MINT_KEY, OWNER_KEY, postAmount);
             const mintBase64 = encodeMintAccountBase64(decimals);
 
-            return createMockConnection({
-                getMultipleParsedAccounts: vi.fn().mockResolvedValue({
+            return createMockRpc({
+                getMultipleAccounts: rpcCall({
                     value: [
                         {
                             data: {
@@ -270,9 +298,10 @@ describe('simulateTransaction', () => {
                                     type: 'account',
                                 },
                                 program: 'spl-token',
+                                space: 165n,
                             },
-                            lamports: 2_039_280,
-                            owner: new PublicKey(TOKEN_PROGRAM_ADDRESS),
+                            lamports: 2_039_280n,
+                            owner: TOKEN_PROGRAM_ADDRESS,
                         },
                         {
                             data: {
@@ -281,28 +310,29 @@ describe('simulateTransaction', () => {
                                     type: 'mint',
                                 },
                                 program: 'spl-token',
+                                space: 82n,
                             },
-                            lamports: 1_000_000,
-                            owner: new PublicKey(TOKEN_PROGRAM_ADDRESS),
+                            lamports: 1_000_000n,
+                            owner: TOKEN_PROGRAM_ADDRESS,
                         },
                     ],
                 }),
-                simulateTransaction: vi.fn().mockResolvedValue({
+                simulateTransaction: rpcCall({
                     value: {
                         accounts: [
                             {
                                 data: [postTokenAccountBase64, 'base64'],
                                 executable: false,
-                                lamports: 2_039_280,
+                                lamports: 2_039_280n,
                                 owner: TOKEN_PROGRAM_ADDRESS,
-                                rentEpoch: 0,
+                                rentEpoch: 0n,
                             },
                             {
                                 data: [mintBase64, 'base64'],
                                 executable: false,
-                                lamports: 1_000_000,
+                                lamports: 1_000_000n,
                                 owner: TOKEN_PROGRAM_ADDRESS,
-                                rentEpoch: 0,
+                                rentEpoch: 0n,
                             },
                         ],
                         err: null,
@@ -310,7 +340,7 @@ describe('simulateTransaction', () => {
                             `Program ${TOKEN_PROGRAM_ADDRESS} invoke [1]`,
                             `Program ${TOKEN_PROGRAM_ADDRESS} success`,
                         ],
-                        unitsConsumed: 200,
+                        unitsConsumed: 200n,
                     },
                 }),
             });
@@ -327,9 +357,9 @@ describe('simulateTransaction', () => {
         it('should decode post-simulation token account data and return token balance data', async () => {
             const preAmount = 1_000_000n;
             const postAmount = 2_500_000n;
-            const connection = setupTokenAccountConnection(preAmount, postAmount);
+            const rpc = setupTokenAccountRpc(preAmount, postAmount);
 
-            const result = await simulate(connection, createTokenMessage());
+            const result = await simulate(rpc, createTokenMessage());
 
             expect(result).toMatchObject({ error: undefined });
             if (!result.tokenBalanceData) throw new Error('expected tokenBalanceData');
@@ -348,9 +378,9 @@ describe('simulateTransaction', () => {
         });
 
         it('should handle token accounts with zero amount', async () => {
-            const connection = setupTokenAccountConnection(0n, 0n);
+            const rpc = setupTokenAccountRpc(0n, 0n);
 
-            const result = await simulate(connection, createTokenMessage());
+            const result = await simulate(rpc, createTokenMessage());
 
             expect(result).toMatchObject({ error: undefined });
             expect(result.tokenBalanceData?.postTokenBalances[0]).toMatchObject({ uiTokenAmount: { amount: '0' } });
@@ -358,9 +388,9 @@ describe('simulateTransaction', () => {
 
         it('should handle large token amounts without overflow', async () => {
             const largeAmount = 9_000_000_000_000_000n;
-            const connection = setupTokenAccountConnection(0n, largeAmount);
+            const rpc = setupTokenAccountRpc(0n, largeAmount);
 
-            const result = await simulate(connection, createTokenMessage());
+            const result = await simulate(rpc, createTokenMessage());
 
             expect(result).toMatchObject({ error: undefined });
             expect(result.tokenBalanceData?.postTokenBalances[0]).toMatchObject({
@@ -375,118 +405,113 @@ describe('v1 transactions', () => {
         return bridgeV1MessageBytes(parseTransactionBytes(createV1TransactionBytes(config)).messageBytes).message;
     }
 
-    function connectionWithFeature(activated: boolean, overrides?: Partial<Connection>): Connection {
-        return createMockConnection({
-            getAccountInfo: vi.fn().mockResolvedValue({
-                data: Buffer.from(activated ? [1, 42, 0, 0, 0, 0, 0, 0, 0] : new Uint8Array(9)),
+    function rpcWithFeature(activated: boolean, overrides?: Partial<Record<string, unknown>>): SolanaRpc {
+        return createMockRpc({
+            getAccountInfo: rpcCall({
+                value: {
+                    data: [
+                        toBase64(activated ? new Uint8Array([1, 42, 0, 0, 0, 0, 0, 0, 0]) : new Uint8Array(9)),
+                        'base64',
+                    ],
+                },
             }),
             ...overrides,
-        } as Partial<Connection>);
+        });
     }
 
     it('should name the feature gate when the node rejects the simulation request outright', async () => {
-        const connection = connectionWithFeature(false, {
-            simulateTransaction: vi.fn().mockRejectedValue(new Error('invalid transaction: UnsupportedVersion')),
-        } as Partial<Connection>);
+        const rpc = rpcWithFeature(false, {
+            simulateTransaction: rpcReject(new Error('invalid transaction: UnsupportedVersion')),
+        });
 
-        await expect(simulate(connection, v1Message())).rejects.toThrow('does not support v1 transactions');
+        await expect(simulate(rpc, v1Message())).rejects.toThrow('does not support v1 transactions');
     });
 
     it('should name the feature gate when the node returns UnsupportedVersion as a simulation error', async () => {
-        const connection = connectionWithFeature(false, {
-            simulateTransaction: vi
-                .fn()
-                .mockResolvedValue(createSimulationResponse({ err: 'UnsupportedVersion', logs: [] })),
-        } as Partial<Connection>);
+        const rpc = rpcWithFeature(false, {
+            simulateTransaction: rpcCall(createSimulationResponse({ err: 'UnsupportedVersion', logs: [] })),
+        });
 
-        const result = await simulate(connection, v1Message());
+        const result = await simulate(rpc, v1Message());
 
         expect(result.error).toContain('does not support v1 transactions');
     });
 
     it('should surface the original failure when the cluster does support v1', async () => {
-        const connection = connectionWithFeature(true, {
-            simulateTransaction: vi.fn().mockRejectedValue(new Error('rpc down')),
-        } as Partial<Connection>);
+        const rpc = rpcWithFeature(true, {
+            simulateTransaction: rpcReject(new Error('rpc down')),
+        });
 
-        await expect(simulate(connection, v1Message())).rejects.toThrow('rpc down');
+        await expect(simulate(rpc, v1Message())).rejects.toThrow('rpc down');
     });
 
     it('should surface the original failure when the feature gate cannot be read', async () => {
-        const connection = createMockConnection({
-            getAccountInfo: vi.fn().mockRejectedValue(new Error('gate unreadable')),
-            simulateTransaction: vi.fn().mockRejectedValue(new Error('rpc down')),
-        } as Partial<Connection>);
+        const rpc = createMockRpc({
+            getAccountInfo: rpcReject(new Error('gate unreadable')),
+            simulateTransaction: rpcReject(new Error('rpc down')),
+        });
 
-        await expect(simulate(connection, v1Message())).rejects.toThrow('rpc down');
+        await expect(simulate(rpc, v1Message())).rejects.toThrow('rpc down');
     });
 
     it('should name the feature gate when UnsupportedVersion arrives alongside logs', async () => {
-        const connection = connectionWithFeature(false, {
-            simulateTransaction: vi
-                .fn()
-                .mockResolvedValue(
-                    createSimulationResponse({ err: 'UnsupportedVersion', logs: ['Program log: something'] }),
-                ),
-        } as Partial<Connection>);
+        const rpc = rpcWithFeature(false, {
+            simulateTransaction: rpcCall(
+                createSimulationResponse({ err: 'UnsupportedVersion', logs: ['Program log: something'] }),
+            ),
+        });
 
-        const result = await simulate(connection, v1Message());
+        const result = await simulate(rpc, v1Message());
 
         expect(result.error).toContain('does not support v1 transactions');
     });
 
     it('should keep the original failure as the cause of the feature gate error', async () => {
         const cause = new Error('429 Too Many Requests');
-        const connection = connectionWithFeature(false, {
-            simulateTransaction: vi.fn().mockRejectedValue(cause),
-        } as Partial<Connection>);
+        const rpc = rpcWithFeature(false, {
+            simulateTransaction: rpcReject(cause),
+        });
 
-        await expect(simulate(connection, v1Message())).rejects.toMatchObject({ cause });
+        await expect(simulate(rpc, v1Message())).rejects.toMatchObject({ cause });
     });
 
     it('should not read the feature gate when a v1 simulation succeeds', async () => {
-        const connection = connectionWithFeature(true);
+        const rpc = rpcWithFeature(true);
 
-        await simulate(connection, v1Message());
+        await simulate(rpc, v1Message());
 
-        expect(connection.simulateTransaction).toHaveBeenCalled();
-        expect(connection.getAccountInfo).not.toHaveBeenCalled();
+        expect(rpc.simulateTransaction).toHaveBeenCalled();
+        expect(rpc.getAccountInfo).not.toHaveBeenCalled();
     });
 
     describe('MaxLoadedAccountsDataSizeExceeded', () => {
-        const OWNER = new PublicKey(SYSTEM_PROGRAM_ADDRESS);
         const UPGRADEABLE_LOADER = new PublicKey('BPFLoaderUpgradeab1e11111111111111111111111');
         const PROGRAM_DATA_KEY = Keypair.generate().publicKey;
 
         // The fee payer is empty, the recipient does not exist, and the program holds 74,800 bytes:
         // the runtime loads 74,800 bytes of data and charges 64 bytes for each of the two accounts.
         const PARSED_ACCOUNTS = [
-            { data: Buffer.alloc(0), owner: OWNER },
-            undefined,
-            { data: { parsed: {}, program: 'memo', space: 74_800 }, owner: OWNER },
+            { data: ['', 'base64'], owner: SYSTEM_PROGRAM_ADDRESS },
+            null,
+            { data: { parsed: {}, program: 'memo', space: 74_800n }, owner: SYSTEM_PROGRAM_ADDRESS },
         ];
 
-        function connectionRejectingForSize(
-            accounts: unknown[] = PARSED_ACCOUNTS,
-            programData: unknown[] = [],
-        ): Connection {
-            return connectionWithFeature(true, {
-                getMultipleParsedAccounts: vi
+        function rpcRejectingForSize(accounts: unknown[] = PARSED_ACCOUNTS, programData: unknown[] = []): SolanaRpc {
+            return rpcWithFeature(true, {
+                getMultipleAccounts: vi
                     .fn()
-                    .mockResolvedValueOnce({ value: accounts })
-                    .mockResolvedValue({ value: programData }),
-                simulateTransaction: vi
-                    .fn()
-                    .mockResolvedValue(
-                        createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
-                    ),
-            } as Partial<Connection>);
+                    .mockReturnValueOnce(sendResult({ value: accounts }))
+                    .mockReturnValue(sendResult({ value: programData })),
+                simulateTransaction: rpcCall(
+                    createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
+                ),
+            });
         }
 
         it('should report the size the runtime loaded against the limit the message sets', async () => {
             const message = v1Message({ loadedAccountsDataSizeLimit: 74_900 });
 
-            const result = await simulate(connectionRejectingForSize(), message);
+            const result = await simulate(rpcRejectingForSize(), message);
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
             expect(result.error).toContain('74,800 bytes of account data');
@@ -496,18 +521,18 @@ describe('v1 transactions', () => {
 
         it('should count the program data account of an upgradeable program', async () => {
             const programAccount = {
-                data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36n },
                 executable: true,
-                owner: UPGRADEABLE_LOADER,
+                owner: UPGRADEABLE_LOADER.toBase58(),
             };
             // The first lookup returns the message's accounts, the second the program data account
             // behind the upgradeable program, which the message never lists
-            const connection = connectionRejectingForSize(
-                [{ data: Buffer.alloc(0), owner: OWNER }, programAccount],
-                [{ data: { parsed: {}, program: 'x', space: 500_000 }, owner: UPGRADEABLE_LOADER }],
+            const rpc = rpcRejectingForSize(
+                [{ data: ['', 'base64'], owner: SYSTEM_PROGRAM_ADDRESS }, programAccount],
+                [{ data: { parsed: {}, program: 'x', space: 500_000n }, owner: UPGRADEABLE_LOADER.toBase58() }],
             );
 
-            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+            const result = await simulate(rpc, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
 
             // 500,036 bytes of data across three accounts, each charged 64 bytes of metadata
             expect(result.error).toContain('this transaction loads 500,228 bytes');
@@ -516,18 +541,18 @@ describe('v1 transactions', () => {
 
         it('should count a program data account the message lists only once', async () => {
             const programAccount = {
-                data: { parsed: { info: { programData: RECIPIENT } }, program: 'x', space: 36 },
+                data: { parsed: { info: { programData: RECIPIENT } }, program: 'x', space: 36n },
                 executable: true,
-                owner: UPGRADEABLE_LOADER,
+                owner: UPGRADEABLE_LOADER.toBase58(),
             };
             // RECIPIENT is the message's second account key, so the program's program data account
             // is already among the accounts the first lookup returned
-            const connection = connectionRejectingForSize([
+            const rpc = rpcRejectingForSize([
                 programAccount,
-                { data: { parsed: {}, program: 'x', space: 500_000 }, owner: UPGRADEABLE_LOADER },
+                { data: { parsed: {}, program: 'x', space: 500_000n }, owner: UPGRADEABLE_LOADER.toBase58() },
             ]);
 
-            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+            const result = await simulate(rpc, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
 
             // 500,036 bytes of data across two accounts, each charged 64 bytes of metadata
             expect(result.error).toContain('this transaction loads 500,164 bytes');
@@ -535,22 +560,23 @@ describe('v1 transactions', () => {
         });
 
         it('should not look up program data for a non-executable loader-owned account', async () => {
-            const connection = connectionRejectingForSize([
-                { data: Buffer.alloc(0), owner: OWNER },
-                { data: { parsed: {}, program: 'x', space: 500_000 }, executable: false, owner: UPGRADEABLE_LOADER },
+            const rpc = rpcRejectingForSize([
+                { data: ['', 'base64'], owner: SYSTEM_PROGRAM_ADDRESS },
+                {
+                    data: { parsed: {}, program: 'x', space: 500_000n },
+                    executable: false,
+                    owner: UPGRADEABLE_LOADER.toBase58(),
+                },
             ]);
 
-            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+            const result = await simulate(rpc, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
 
-            expect(connection.getMultipleParsedAccounts).toHaveBeenCalledTimes(1);
+            expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
             expect(result.error).toContain('this transaction loads 500,128 bytes');
         });
 
         it('should report the size as a floor when the accounts it can see fit under the limit', async () => {
-            const result = await simulate(
-                connectionRejectingForSize(),
-                v1Message({ loadedAccountsDataSizeLimit: 200_000 }),
-            );
+            const result = await simulate(rpcRejectingForSize(), v1Message({ loadedAccountsDataSizeLimit: 200_000 }));
 
             expect(result.error).toContain('this transaction loads at least 74,928 bytes');
             expect(result.error).toContain('within the 200,000 byte limit set in the v1 message config');
@@ -559,83 +585,103 @@ describe('v1 transactions', () => {
         });
 
         it('should explain the failure even when the RPC returns it alongside logs', async () => {
-            const connection = connectionWithFeature(true, {
-                getMultipleParsedAccounts: vi
+            const rpc = rpcWithFeature(true, {
+                getMultipleAccounts: vi
                     .fn()
-                    .mockResolvedValueOnce({ value: PARSED_ACCOUNTS })
-                    .mockResolvedValue({ value: [] }),
-                simulateTransaction: vi.fn().mockResolvedValue(
+                    .mockReturnValueOnce(sendResult({ value: PARSED_ACCOUNTS }))
+                    .mockReturnValue(sendResult({ value: [] })),
+                simulateTransaction: rpcCall(
                     createSimulationResponse({
                         err: 'MaxLoadedAccountsDataSizeExceeded',
                         logs: ['Program failed to load accounts'],
                     }),
                 ),
-            } as Partial<Connection>);
+            });
 
-            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 74_900 }));
+            const result = await simulate(rpc, v1Message({ loadedAccountsDataSizeLimit: 74_900 }));
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
         });
 
         it('should name the unset limit as zero when the message sets none', async () => {
-            const result = await simulate(connectionRejectingForSize(), v1Message());
+            const result = await simulate(rpcRejectingForSize(), v1Message());
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
             expect(result.error).toContain('sets no loaded accounts data size limit');
         });
 
         it('should surface the raw error when the program data lookup fails', async () => {
-            const connection = connectionRejectingForSize([
+            const rpc = rpcRejectingForSize([
                 {
-                    data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                    data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36n },
                     executable: true,
-                    owner: UPGRADEABLE_LOADER,
+                    owner: UPGRADEABLE_LOADER.toBase58(),
                 },
             ]);
-            vi.mocked(connection.getMultipleParsedAccounts).mockRejectedValueOnce(new Error('rpc down'));
+            // The queue holds the message accounts first; this makes the second call — the
+            // program data lookup — fail.
+            vi.mocked(rpc.getMultipleAccounts).mockReturnValueOnce(sendError(new Error('rpc down')));
 
-            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+            const result = await simulate(rpc, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
 
             expect(result.error).toBe('MaxLoadedAccountsDataSizeExceeded');
         });
 
         it('should surface the raw error for a non-v1 message', async () => {
-            const connection = createMockConnection({
-                simulateTransaction: vi
-                    .fn()
-                    .mockResolvedValue(
-                        createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
-                    ),
-            } as Partial<Connection>);
+            const rpc = createMockRpc({
+                simulateTransaction: rpcCall(
+                    createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
+                ),
+            });
 
-            const result = await simulate(connection);
+            const result = await simulate(rpc);
 
             expect(result.error).toBe('MaxLoadedAccountsDataSizeExceeded');
         });
     });
 
     it('should not read the feature gate for a non-v1 message', async () => {
-        const connection = connectionWithFeature(false);
+        const rpc = rpcWithFeature(false);
 
-        await simulate(connection);
+        await simulate(rpc);
 
-        expect(connection.getAccountInfo).not.toHaveBeenCalled();
+        expect(rpc.getAccountInfo).not.toHaveBeenCalled();
     });
 });
 
-function createMockConnection(overrides?: Partial<Connection>): Connection {
+/** A pending kit rpc call: `rpc.method(...)` returns an object whose `send()` resolves the result. */
+function sendResult(result: unknown) {
+    return { send: vi.fn().mockResolvedValue(result) } as never;
+}
+
+/** Mock of a kit rpc method whose `send()` resolves `result` on every call. */
+function rpcCall(result: unknown) {
+    return vi.fn().mockReturnValue(sendResult(result));
+}
+
+/** A pending kit rpc call whose `send()` rejects with `error`. */
+function sendError(error: Error) {
+    return { send: vi.fn().mockRejectedValue(error) } as never;
+}
+
+/** Mock of a kit rpc method whose `send()` rejects with `error` on every call. */
+function rpcReject(error: Error) {
+    return vi.fn().mockReturnValue(sendError(error));
+}
+
+function createMockRpc(overrides?: Partial<Record<string, unknown>>): SolanaRpc {
     return {
-        getEpochInfo: vi.fn().mockResolvedValue({ epoch: 100 }),
-        getMultipleAccountsInfo: vi.fn().mockResolvedValue([]),
-        getMultipleParsedAccounts: vi.fn().mockResolvedValue({
+        getAccountInfo: rpcCall({ value: null }),
+        getEpochInfo: rpcCall({ epoch: 100n }),
+        getMultipleAccounts: rpcCall({
             value: [
-                { data: {}, lamports: 1_000_000_000, owner: new PublicKey(SYSTEM_PROGRAM_ADDRESS) },
-                { data: {}, lamports: 1_000_000_000, owner: new PublicKey(SYSTEM_PROGRAM_ADDRESS) },
+                { data: {}, lamports: 1_000_000_000n, owner: SYSTEM_PROGRAM_ADDRESS },
+                { data: {}, lamports: 1_000_000_000n, owner: SYSTEM_PROGRAM_ADDRESS },
             ],
         }),
-        simulateTransaction: vi.fn().mockResolvedValue(createSimulationResponse()),
+        simulateTransaction: rpcCall(createSimulationResponse()),
         ...overrides,
-    } as unknown as Connection;
+    } as unknown as SolanaRpc;
 }
 
 // Partial<VersionedMessage> is too strict for test mocks — getAccountKeys
@@ -665,36 +711,36 @@ function createSimulationResponse(overrides?: Record<string, unknown>) {
                 {
                     data: ['', 'base64'],
                     executable: false,
-                    lamports: 2_000_000_000,
+                    lamports: 2_000_000_000n,
                     owner: SYSTEM_PROGRAM_ADDRESS,
-                    rentEpoch: 0,
+                    rentEpoch: 0n,
                 },
                 {
                     data: ['', 'base64'],
                     executable: false,
-                    lamports: 500_000_000,
+                    lamports: 500_000_000n,
                     owner: SYSTEM_PROGRAM_ADDRESS,
-                    rentEpoch: 0,
+                    rentEpoch: 0n,
                 },
             ],
             err: null,
             logs: [`Program ${SYSTEM_PROGRAM_ADDRESS} invoke [1]`, `Program ${SYSTEM_PROGRAM_ADDRESS} success`],
-            unitsConsumed: 150,
+            unitsConsumed: 150n,
             ...overrides,
         },
     };
 }
 
 function simulate(
-    connection: Connection,
+    rpc: SolanaRpc,
     message?: VersionedMessage,
     accountBalances?: { preBalances: number[]; postBalances: number[] },
 ) {
     return simulateTransaction({
         accountBalances,
         cluster: Cluster.Devnet,
-        connection,
         message: message ?? createMockMessage(),
+        rpc,
     });
 }
 

--- a/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
@@ -1,34 +1,41 @@
-import type { Connection } from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
 import { describe, expect, it, vi } from 'vitest';
+
+import { toBase64 } from '@/app/shared/lib/bytes';
 
 import { ENABLE_TX_V1_FEATURE, isTxV1Active } from '../tx-v1-feature';
 
-function connectionReturning(data: Uint8Array | null): Connection {
+function rpcReturning(data: Uint8Array | null): SolanaRpc {
     return {
-        getAccountInfo: vi.fn().mockResolvedValue(data === null ? null : { data: Buffer.from(data) }),
-    } as unknown as Connection;
+        getAccountInfo: vi.fn().mockReturnValue({
+            send: vi.fn().mockResolvedValue({ value: data === null ? null : { data: [toBase64(data), 'base64'] } }),
+        }),
+    } as unknown as SolanaRpc;
 }
 
 describe('isTxV1Active', () => {
     it('should report active when the gate carries an activation slot', async () => {
         const activatedAtSlot = new Uint8Array([1, 42, 0, 0, 0, 0, 0, 0, 0]);
 
-        await expect(isTxV1Active(connectionReturning(activatedAtSlot))).resolves.toBe(true);
+        await expect(isTxV1Active(rpcReturning(activatedAtSlot))).resolves.toBe(true);
     });
 
     it('should report inactive when the gate is staged but not activated', async () => {
-        await expect(isTxV1Active(connectionReturning(new Uint8Array(9)))).resolves.toBe(false);
+        await expect(isTxV1Active(rpcReturning(new Uint8Array(9)))).resolves.toBe(false);
     });
 
     it('should report inactive when the feature account does not exist', async () => {
-        await expect(isTxV1Active(connectionReturning(null))).resolves.toBe(false);
+        await expect(isTxV1Active(rpcReturning(null))).resolves.toBe(false);
     });
 
     it('should read the transaction v1 feature account', async () => {
-        const connection = connectionReturning(new Uint8Array(9));
+        const rpc = rpcReturning(new Uint8Array(9));
 
-        await isTxV1Active(connection);
+        await isTxV1Active(rpc);
 
-        expect(connection.getAccountInfo).toHaveBeenCalledWith(ENABLE_TX_V1_FEATURE);
+        expect(rpc.getAccountInfo).toHaveBeenCalledWith(
+            ENABLE_TX_V1_FEATURE,
+            expect.objectContaining({ encoding: 'base64' }),
+        );
     });
 });

--- a/app/features/instruction-simulation/lib/resolve-address-lookup-tables.ts
+++ b/app/features/instruction-simulation/lib/resolve-address-lookup-tables.ts
@@ -1,4 +1,9 @@
-import { AddressLookupTableAccount, type Connection, type VersionedMessage } from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
+import { isSome } from '@solana/kit';
+import { AddressLookupTableAccount, type VersionedMessage } from '@solana/web3.js';
+import { fetchAllMaybeAddressLookupTable } from '@solana-program/address-lookup-table';
+
+import { toKitAddress, toLegacyPublicKey } from '@/app/shared/lib/web3js-compat';
 
 /**
  * Fetch and deserialize the address lookup tables referenced by a versioned message.
@@ -13,25 +18,36 @@ import { AddressLookupTableAccount, type Connection, type VersionedMessage } fro
  * `useSimulation` renders this message to the user, so the reason has to be in it.
  */
 export async function resolveAddressLookupTables(
-    connection: Connection,
+    rpc: SolanaRpc,
     message: VersionedMessage,
 ): Promise<AddressLookupTableAccount[]> {
     const lookups = message.addressTableLookups;
     if (lookups.length === 0) return [];
 
     const keys = lookups.map(lookup => lookup.accountKey);
-    const accountInfos = await connection.getMultipleAccountsInfo(keys);
+    const accounts = await fetchAllMaybeAddressLookupTable(
+        rpc,
+        keys.map(key => toKitAddress(key)),
+        { commitment: 'confirmed' },
+    );
 
-    return accountInfos.map((info, i) => {
-        if (!info) {
+    return accounts.map((account, i) => {
+        if (!account.exists) {
             throw new Error(
                 `Address lookup table ${keys[i].toBase58()} could not be loaded: the RPC returned no account ` +
                     `for it. The table may have been closed, or this RPC may not carry it.`,
             );
         }
+        const { addresses, authority, deactivationSlot, lastExtendedSlot, lastExtendedSlotStartIndex } = account.data;
         return new AddressLookupTableAccount({
             key: keys[i],
-            state: AddressLookupTableAccount.deserialize(Uint8Array.from(info.data)),
+            state: {
+                addresses: addresses.map(address => toLegacyPublicKey(address)),
+                authority: isSome(authority) ? toLegacyPublicKey(authority.value) : undefined,
+                deactivationSlot,
+                lastExtendedSlot: Number(lastExtendedSlot),
+                lastExtendedSlotStartIndex,
+            },
         });
     });
 }

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -1,6 +1,7 @@
+import type { SolanaRpc } from '@entities/cluster';
+import type { Address, Base64EncodedWireTransaction } from '@solana/kit';
 import type {
     AccountInfo,
-    Connection,
     ParsedAccountData,
     SimulatedTransactionAccountInfo,
     TransactionError,
@@ -10,8 +11,11 @@ import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import type { Cluster } from '@utils/cluster';
 import { type InstructionLogs, parseProgramLogs } from '@utils/program-logs';
 
+import { withNumbersInsteadOfBigInts } from '@/app/shared/lib/bigint-to-number';
+import { toBase64 } from '@/app/shared/lib/bytes';
 import { Logger } from '@/app/shared/lib/logger';
 import { UnsignedV1WireTransaction, V1MessageView } from '@/app/shared/lib/v1-message-bridge';
+import { toKitAddress, toLegacyPublicKey } from '@/app/shared/lib/web3js-compat';
 
 import { buildTokenBalances, type TokenBalanceData } from './build-token-balances';
 import { computeSolBalanceChanges } from './compute-sol-balance-changes';
@@ -34,27 +38,27 @@ export type SimulationResult = {
 };
 
 type SimulateOptions = {
-    connection: Connection;
+    rpc: SolanaRpc;
     message: VersionedMessage;
     cluster: Cluster;
     accountBalances?: { preBalances: number[]; postBalances: number[] };
 };
 
 /**
- * Run a transaction simulation against the given RPC connection and return
+ * Run a transaction simulation against the given RPC and return
  * parsed results (logs, SOL changes, token balance rows, etc.).
  */
 export async function simulateTransaction({
-    connection,
+    rpc,
     message,
     cluster,
     accountBalances,
 }: SimulateOptions): Promise<SimulationResult> {
     let raw;
     try {
-        raw = await runSimulation(connection, message);
+        raw = await runSimulation(rpc, message);
     } catch (cause) {
-        throw (await inactiveV1GateError(connection, message, cause)) ?? cause;
+        throw (await inactiveV1GateError(rpc, message, cause)) ?? cause;
     }
 
     const result = interpretSimulation(raw, cluster, accountBalances);
@@ -62,19 +66,14 @@ export async function simulateTransaction({
     // Match the error the RPC returned rather than the interpreted one, which reports any failure
     // carrying logs as a bare `TransactionError`.
     if (raw.simResult.err === UNSUPPORTED_VERSION) {
-        const gate = await inactiveV1GateError(connection, message);
+        const gate = await inactiveV1GateError(rpc, message);
         if (gate) {
             return { ...result, error: gate.message };
         }
     }
 
     if (raw.simResult.err === MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED && message instanceof V1MessageView) {
-        const explained = await explainLoadedAccountsDataSize(
-            connection,
-            message,
-            raw.accountKeys,
-            raw.parsedAccountsPre,
-        );
+        const explained = await explainLoadedAccountsDataSize(rpc, message, raw.accountKeys, raw.parsedAccountsPre);
         return explained ? { ...result, error: explained } : result;
     }
 
@@ -98,7 +97,7 @@ const UNSUPPORTED_VERSION = 'UnsupportedVersion';
  * for reasons of its own on a cluster that happens to lack the gate as well.
  */
 async function inactiveV1GateError(
-    connection: Connection,
+    rpc: SolanaRpc,
     message: VersionedMessage,
     cause?: unknown,
 ): Promise<Error | undefined> {
@@ -107,7 +106,7 @@ async function inactiveV1GateError(
     }
 
     try {
-        if (await isTxV1Active(connection)) {
+        if (await isTxV1Active(rpc)) {
             return undefined;
         }
     } catch (cause) {
@@ -116,14 +115,14 @@ async function inactiveV1GateError(
     }
 
     return new Error(
-        `this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE.toBase58()} is not active`,
+        `this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE} is not active`,
         { cause },
     );
 }
 
 type RawSimulation = {
     accountKeys: PublicKey[];
-    epochInfo: { epoch: number };
+    epoch: bigint;
     parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | undefined)[];
     simResult: {
         accounts: (SimulatedTransactionAccountInfo | undefined)[];
@@ -137,26 +136,31 @@ type RawSimulation = {
  * Execute the RPC calls: resolve lookup tables, fetch pre-simulation account
  * state, and run the simulation. Returns raw data for interpretation.
  */
-async function runSimulation(connection: Connection, message: VersionedMessage): Promise<RawSimulation> {
-    const lookupTables = await resolveAddressLookupTables(connection, message);
+async function runSimulation(rpc: SolanaRpc, message: VersionedMessage): Promise<RawSimulation> {
+    const lookupTables = await resolveAddressLookupTables(rpc, message);
     const accountKeys = message.getAccountKeys({ addressLookupTableAccounts: lookupTables }).keySegments().flat();
+    const addresses = accountKeys.map(key => toKitAddress(key));
 
     const [parsedAccountsPre, epochInfo] = await Promise.all([
-        connection.getMultipleParsedAccounts(accountKeys),
-        connection.getEpochInfo(),
+        getMultipleParsedAccounts(rpc, addresses),
+        rpc.getEpochInfo({ commitment: 'confirmed' }).send(),
     ]);
 
     // A v1 message must be sent in the v1 wire envelope (message first); the stock
     // VersionedTransaction envelope is signatures-first and nodes reject it for v1.
     const transaction =
         message instanceof V1MessageView ? new UnsignedV1WireTransaction(message) : new VersionedTransaction(message);
-    const { value: simResult } = await connection.simulateTransaction(transaction, {
-        accounts: {
-            addresses: accountKeys.map(key => key.toBase58()),
+    const { value: simResult } = await rpc
+        .simulateTransaction(toBase64(transaction.serialize()) as Base64EncodedWireTransaction, {
+            accounts: {
+                addresses,
+                encoding: 'base64',
+            },
+            commitment: 'confirmed',
             encoding: 'base64',
-        },
-        replaceRecentBlockhash: true,
-    });
+            replaceRecentBlockhash: true,
+        })
+        .send();
 
     if (!simResult.accounts) {
         throw new Error('RPC did not return account data after simulation');
@@ -170,14 +174,77 @@ async function runSimulation(connection: Connection, message: VersionedMessage):
 
     return {
         accountKeys,
-        epochInfo,
-        parsedAccountsPre: parsedAccountsPre.value.map(a => a ?? undefined),
+        epoch: epochInfo.epoch,
+        parsedAccountsPre,
         simResult: {
-            accounts: simResult.accounts.map(a => a ?? undefined),
-            err: simResult.err,
-            logs: simResult.logs,
-            unitsConsumed: simResult.unitsConsumed,
+            accounts: simResult.accounts.map(account => (account ? toLegacySimulatedAccountInfo(account) : undefined)),
+            // The RPC reports integers inside a transaction error (instruction index, custom program
+            // error code) which kit upcasts to bigint; downstream consumers expect the web3.js shape.
+            err: withNumbersInsteadOfBigInts(simResult.err) as TransactionError | null,
+            logs: [...simResult.logs],
+            unitsConsumed:
+                simResult.unitsConsumed !== null && simResult.unitsConsumed !== undefined
+                    ? Number(simResult.unitsConsumed)
+                    : undefined,
         },
+    };
+}
+
+type KitParsedAccount = {
+    data: { parsed: unknown; program: string; space: bigint } | readonly [string, string];
+    executable: boolean;
+    lamports: bigint;
+    owner: Address;
+};
+
+type KitSimulatedAccount = {
+    data: readonly [string, string];
+    executable: boolean;
+    lamports: bigint;
+    owner: Address;
+};
+
+/**
+ * Fetch accounts in `jsonParsed` encoding and restate them in the web3.js
+ * `getMultipleParsedAccounts` shape the interpretation helpers still consume: parsed JSON with
+ * numbers where kit reports bigints, and raw data as a `Buffer` where the RPC could not parse.
+ */
+async function getMultipleParsedAccounts(
+    rpc: SolanaRpc,
+    addresses: Address[],
+): Promise<(AccountInfo<ParsedAccountData | Buffer> | undefined)[]> {
+    const { value } = await rpc
+        .getMultipleAccounts(addresses, { commitment: 'confirmed', encoding: 'jsonParsed' })
+        .send();
+    return value.map(account => (account ? toLegacyAccountInfo(account) : undefined));
+}
+
+function isBase64Data(data: KitParsedAccount['data']): data is readonly [string, string] {
+    return Array.isArray(data);
+}
+
+function toLegacyAccountInfo(account: KitParsedAccount): AccountInfo<ParsedAccountData | Buffer> {
+    const data = isBase64Data(account.data)
+        ? Buffer.from(account.data[0], 'base64')
+        : {
+              parsed: withNumbersInsteadOfBigInts(account.data.parsed),
+              program: account.data.program,
+              space: Number(account.data.space),
+          };
+    return {
+        data,
+        executable: account.executable,
+        lamports: Number(account.lamports),
+        owner: toLegacyPublicKey(account.owner),
+    };
+}
+
+function toLegacySimulatedAccountInfo(account: KitSimulatedAccount): SimulatedTransactionAccountInfo {
+    return {
+        data: [account.data[0], account.data[1]],
+        executable: account.executable,
+        lamports: Number(account.lamports),
+        owner: account.owner,
     };
 }
 
@@ -186,7 +253,7 @@ async function runSimulation(connection: Connection, message: VersionedMessage):
  * SOL balance changes, and parsed program logs.
  */
 function interpretSimulation(
-    { accountKeys, epochInfo, parsedAccountsPre, simResult }: RawSimulation,
+    { accountKeys, epoch, parsedAccountsPre, simResult }: RawSimulation,
     cluster: Cluster,
     accountBalances?: { preBalances: number[]; postBalances: number[] },
 ): SimulationResult {
@@ -215,7 +282,7 @@ function interpretSimulation(
 
     return {
         accountKeys,
-        epoch: BigInt(epochInfo.epoch),
+        epoch,
         error,
         logs,
         solBalanceChanges: solChanges.length > 0 ? solChanges : undefined,
@@ -256,7 +323,7 @@ const UPGRADEABLE_LOADER_ID = new PublicKey('BPFLoaderUpgradeab1e111111111111111
  * its own; one that does not is reported as the floor it is, and names what the rest must be.
  */
 async function explainLoadedAccountsDataSize(
-    connection: Connection,
+    rpc: SolanaRpc,
     message: V1MessageView,
     accountKeys: PublicKey[],
     parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | undefined)[],
@@ -266,7 +333,7 @@ async function explainLoadedAccountsDataSize(
 
     let programDataAccounts;
     try {
-        programDataAccounts = await fetchProgramDataAccounts(connection, messageAccounts, listedAddresses);
+        programDataAccounts = await fetchProgramDataAccounts(rpc, messageAccounts, listedAddresses);
     } catch (cause) {
         Logger.error(new Error('Failed to load program data accounts', { cause }));
         return undefined;
@@ -302,7 +369,7 @@ async function explainLoadedAccountsDataSize(
  * and only a program account holds a program data address, so the executable flag selects them.
  */
 async function fetchProgramDataAccounts(
-    connection: Connection,
+    rpc: SolanaRpc,
     accounts: AccountInfo<ParsedAccountData | Buffer>[],
     listedAddresses: Set<string>,
 ): Promise<AccountInfo<ParsedAccountData | Buffer>[]> {
@@ -323,8 +390,11 @@ async function fetchProgramDataAccounts(
         return [];
     }
 
-    const { value } = await connection.getMultipleParsedAccounts([...addresses.values()]);
-    return value.filter(account => account !== null);
+    const value = await getMultipleParsedAccounts(
+        rpc,
+        [...addresses.values()].map(key => toKitAddress(key)),
+    );
+    return value.filter(account => account !== undefined);
 }
 
 /**

--- a/app/features/instruction-simulation/lib/tx-v1-feature.ts
+++ b/app/features/instruction-simulation/lib/tx-v1-feature.ts
@@ -1,8 +1,10 @@
-import { getOptionDecoder, getU64Decoder, isSome } from '@solana/kit';
-import { type Connection, PublicKey } from '@solana/web3.js';
+import type { SolanaRpc } from '@entities/cluster';
+import { address, getOptionDecoder, getU64Decoder, isSome } from '@solana/kit';
+
+import { fromBase64 } from '@/app/shared/lib/bytes';
 
 /** The feature gate that activates transaction v1 on a cluster. */
-export const ENABLE_TX_V1_FEATURE = new PublicKey('txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL');
+export const ENABLE_TX_V1_FEATURE = address('txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL');
 
 /**
  * A feature account holds a bincode-serialized `solana_feature_gate_interface::Feature`,
@@ -11,14 +13,16 @@ export const ENABLE_TX_V1_FEATURE = new PublicKey('txv1aq4pp281K9um3tnPgkfX8UqtF
 const featureAccountDecoder = getOptionDecoder(getU64Decoder());
 
 /**
- * Reports whether transaction v1 is live on the cluster behind `connection`.
+ * Reports whether transaction v1 is live on the cluster behind `rpc`.
  *
  * The feature account exists only once the gate has been staged, and its activation slot is
  * filled in only once the gate goes live. Both an absent account and a staged-but-inactive one
  * mean the cluster rejects v1 transactions, so both answer `false`. Local validators activate
  * every feature at genesis, so this is `true` from slot 0 there.
  */
-export async function isTxV1Active(connection: Connection): Promise<boolean> {
-    const account = await connection.getAccountInfo(ENABLE_TX_V1_FEATURE);
-    return account !== null && isSome(featureAccountDecoder.decode(account.data));
+export async function isTxV1Active(rpc: SolanaRpc): Promise<boolean> {
+    const { value: account } = await rpc
+        .getAccountInfo(ENABLE_TX_V1_FEATURE, { commitment: 'confirmed', encoding: 'base64' })
+        .send();
+    return account !== null && isSome(featureAccountDecoder.decode(fromBase64(account.data[0])));
 }

--- a/app/features/instruction-simulation/model/use-simulation.ts
+++ b/app/features/instruction-simulation/model/use-simulation.ts
@@ -1,8 +1,9 @@
 'use client';
 
+import { getRpc } from '@entities/cluster';
 import { sha256 } from '@noble/hashes/sha256';
 import { useCluster } from '@providers/cluster';
-import { Connection, type VersionedMessage } from '@solana/web3.js';
+import { type VersionedMessage } from '@solana/web3.js';
 import { useCallback, useMemo } from 'react';
 import useSWRMutation from 'swr/mutation';
 
@@ -28,8 +29,6 @@ type SimulationArg = {
 export function useSimulation(message: VersionedMessage, accountBalances?: AccountBalances): SimulationState {
     const { cluster, url } = useCluster();
 
-    const connection = useMemo(() => new Connection(url, 'confirmed'), [url]);
-
     // Fingerprint the message so the SWR key changes when the transaction changes,
     // preventing stale cached data from flashing for a different transaction.
     const messageFingerprint = useMemo(() => messageToFingerprint(message), [message]);
@@ -40,8 +39,8 @@ export function useSimulation(message: VersionedMessage, accountBalances?: Accou
             simulateTransaction({
                 accountBalances: arg.accountBalances,
                 cluster: arg.cluster,
-                connection,
                 message: arg.message,
+                rpc: getRpc(url),
             }),
         {
             onError: (cause: unknown) => {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "@sentry/core": "10.39.0",
         "@sentry/nextjs": "10.39.0",
         "@solana-developers/helpers": "=2.8.1",
+        "@solana-program/address-lookup-table": "0.13.0",
         "@solana-program/compute-budget": "0.17.0",
         "@solana-program/memo": "0.12.0",
         "@solana-program/program-metadata": "0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  oxc:
-    oxfmt:
-      specifier: ^0.56.0
-      version: 0.56.0
-    oxlint:
-      specifier: ^1.71.0
-      version: 1.72.0
   storybook:
     '@storybook/addon-a11y':
       specifier: 10.5.7
@@ -214,6 +207,9 @@ importers:
       '@solana-developers/helpers':
         specifier: '=2.8.1'
         version: 2.8.1(patch_hash=3404536e2e71cf96a8aa5675d9b2c17a94f209253305827d7d8dca7686d0c388)(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(utf-8-validate@5.0.10)
+      '@solana-program/address-lookup-table':
+        specifier: 0.13.0
+        version: 0.13.0(@solana/kit@7.0.0(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(utf-8-validate@5.0.10))
       '@solana-program/compute-budget':
         specifier: 0.17.0
         version: 0.17.0(@solana/kit@7.0.0(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(utf-8-validate@5.0.10))


### PR DESCRIPTION
## Description

Migrates `app/features/instruction-simulation/` off the web3.js `Connection` onto `@solana/kit` rpc (kit-migration task 1.7).

- `useSimulation` now obtains the rpc client through the shared `getRpc` accessor instead of constructing a `Connection` per URL.
- `simulateTransaction` runs on kit `getMultipleAccounts` / `getEpochInfo` / `simulateTransaction` (base64 wire encoding, `confirmed` commitment preserved), restating responses in the legacy `AccountInfo` / `SimulatedTransactionAccountInfo` shapes at the RPC boundary so the interpretation helpers are unchanged.
- Address lookup tables resolve via `@solana-program/address-lookup-table` (`fetchAllMaybeAddressLookupTable` + codama decoder), keeping the per-table missing-account error message.
- The v1 feature-gate probe reads the account via kit and decodes with the existing kit option decoder.
- Bigint payloads (transaction `err`, parsed account JSON) are normalized through `bigint-to-number`, matching the fix from tasks 1.2/1.5.

`@solana-program/address-lookup-table` is pinned to 0.13.0, the newest release on the kit ^7 peer line (0.14.0 requires kit ^8).

## Type of change

-   [x] Other (please describe): web3.js → @solana/kit migration refactor

## Testing

- Colocated specs migrated to kit-style rpc mocks; a new case pins bigint→number normalization inside transaction errors (100 specs in the feature pass).
- Full local CI green: format, lint, typecheck, openspec validate, full test suite, `next build`.

## Related Issues

Closes HOO-1274

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information