### PR TITLE
refactor(kit): move remaining small-fry Connection sites off web3.js

### DIFF
--- a/app/__tests__/mock-rpc.ts
+++ b/app/__tests__/mock-rpc.ts
@@ -55,4 +55,10 @@ export const mockSolanaRpc = (overrides?: Partial<ClusterInfo> & { genesisHash?:
     getGenesisHash: () => ({
         send: vi.fn().mockResolvedValue(mockGenesisHash(overrides?.genesisHash)),
     }),
+    getMultipleAccounts: (addresses: readonly unknown[]) => ({
+        send: vi.fn().mockResolvedValue({
+            context: { slot: 0n },
+            value: addresses.map(() => null),
+        }),
+    }),
 });

--- a/app/api/verification/bluprynt/[mintAddress]/route.ts
+++ b/app/api/verification/bluprynt/[mintAddress]/route.ts
@@ -1,5 +1,4 @@
-import { type Address, address } from '@solana/kit';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { type Address, address, createSolanaRpc } from '@solana/kit';
 import { Cluster, serverClusterUrl } from '@utils/cluster';
 import { NextResponse } from 'next/server';
 import { findAttestationPda, findSchemaPda } from 'sas-lib';
@@ -13,12 +12,7 @@ const RPC_TIMEOUT_MS = 15_000;
 // SAS protocol supports up to 256 schema versions. We decided to use 32 for now.
 const MAX_SCHEMA_VERSIONS = 32;
 
-const connection = new Connection(serverClusterUrl(Cluster.MainnetBeta), {
-    commitment: 'confirmed',
-    fetchMiddleware: (info, init, fetch) => {
-        fetch(info, { ...init, signal: AbortSignal.timeout(RPC_TIMEOUT_MS) });
-    },
-});
+const rpc = createSolanaRpc(serverClusterUrl(Cluster.MainnetBeta));
 
 async function getSchemaVersionPdas(credentialAddress: Address, schemaName: string): Promise<Address[]> {
     const versions = await Promise.all(
@@ -42,15 +36,15 @@ type Params = {
 export async function GET(_request: Request, props: Params) {
     const { mintAddress } = await props.params;
 
+    let mintAddr: Address;
     try {
-        new PublicKey(mintAddress);
+        mintAddr = address(mintAddress);
     } catch {
         return NextResponse.json({ error: 'Invalid mint address' }, { status: 400 });
     }
 
     try {
         const credentialAddr = address(BLUPRYNT_CONFIG.credentialAuthority);
-        const mintAddr = address(mintAddress);
 
         const schemaPdas = await getSchemaVersionPdas(credentialAddr, BLUPRYNT_CONFIG.schemaName);
 
@@ -64,9 +58,12 @@ export async function GET(_request: Request, props: Params) {
             ),
         );
 
-        const accountInfos = await connection.getMultipleAccountsInfo(
-            attestationPdas.map(([addr]) => new PublicKey(addr)),
-        );
+        const { value: accountInfos } = await rpc
+            .getMultipleAccounts(
+                attestationPdas.map(([addr]) => addr),
+                { commitment: 'confirmed', encoding: 'base64' },
+            )
+            .send({ abortSignal: AbortSignal.timeout(RPC_TIMEOUT_MS) });
         const verified = accountInfos.some(info => info !== null);
 
         return NextResponse.json({ verified }, { headers: CACHE_HEADERS });

--- a/app/api/verification/bluprynt/__tests__/route.test.ts
+++ b/app/api/verification/bluprynt/__tests__/route.test.ts
@@ -8,9 +8,21 @@ const VALID_MINT = 'B61SyRxF2b8JwSLZHgEUF6rtn6NUikkrK1EMEgP6nhXW';
 const MOCK_SCHEMA_PDA = 'Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS';
 const MOCK_ATTESTATION_PDA = '7UX2i7SucgLMQcfZ75s3VXmZZY4YRUyJN9X1RgfMoDUi';
 
-const mockGetMultipleAccountsInfo = vi.fn();
+const mockGetMultipleAccounts = vi.fn();
 const mockFindSchemaPda = vi.fn().mockResolvedValue([MOCK_SCHEMA_PDA, 255]);
 const mockFindAttestationPda = vi.fn().mockResolvedValue([MOCK_ATTESTATION_PDA, 255]);
+
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
+    return {
+        ...actual,
+        createSolanaRpc: vi.fn(() => ({
+            getMultipleAccounts: (...args: unknown[]) => ({
+                send: async () => ({ value: await mockGetMultipleAccounts(...args) }),
+            }),
+        })),
+    };
+});
 
 vi.mock('sas-lib', () => ({
     findAttestationPda: mockFindAttestationPda,
@@ -21,18 +33,6 @@ vi.mock('@utils/cluster', () => ({
     Cluster: { MainnetBeta: 'mainnet-beta' },
     serverClusterUrl: () => 'https://unused.test',
 }));
-
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
-    return {
-        ...actual,
-        Connection: vi.fn().mockImplementation(function () {
-            return {
-                getMultipleAccountsInfo: mockGetMultipleAccountsInfo,
-            };
-        }),
-    };
-});
 
 vi.mock('../config', () => ({
     BLUPRYNT_CONFIG: {
@@ -56,30 +56,30 @@ describe('Bluprynt API Route', () => {
 
     it('should return verified true when any attestation account exists', async () => {
         const nulls = new Array(31).fill(null);
-        mockGetMultipleAccountsInfo.mockResolvedValueOnce([...nulls, { data: Buffer.alloc(0), lamports: 1 }]);
+        mockGetMultipleAccounts.mockResolvedValueOnce([...nulls, { data: Buffer.alloc(0), lamports: 1 }]);
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual({ verified: true });
     });
 
     it('should return verified false when no attestation accounts exist', async () => {
-        mockGetMultipleAccountsInfo.mockResolvedValueOnce(new Array(32).fill(null));
+        mockGetMultipleAccounts.mockResolvedValueOnce(new Array(32).fill(null));
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual({ verified: false });
     });
 
     it('should batch-check all schema versions in a single RPC call', async () => {
-        mockGetMultipleAccountsInfo.mockResolvedValueOnce(new Array(32).fill(null));
+        mockGetMultipleAccounts.mockResolvedValueOnce(new Array(32).fill(null));
         await callRoute(VALID_MINT);
-        expect(mockGetMultipleAccountsInfo).toHaveBeenCalledTimes(1);
-        const [[accounts]] = mockGetMultipleAccountsInfo.mock.calls;
+        expect(mockGetMultipleAccounts).toHaveBeenCalledTimes(1);
+        const [[accounts]] = mockGetMultipleAccounts.mock.calls;
         expect(accounts).toHaveLength(32);
     });
 
     it('should return 504 with short negative cache when RPC request times out', async () => {
         const timeoutError = new DOMException('Signal timed out.', 'TimeoutError');
-        mockGetMultipleAccountsInfo.mockRejectedValueOnce(timeoutError);
+        mockGetMultipleAccounts.mockRejectedValueOnce(timeoutError);
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(504);
         expect(await response.json()).toEqual({ error: 'Verification request timed out' });
@@ -91,7 +91,7 @@ describe('Bluprynt API Route', () => {
     });
 
     it('should return 500 with short negative cache when RPC throws a non-timeout error', async () => {
-        mockGetMultipleAccountsInfo.mockRejectedValueOnce(new Error('Connection refused'));
+        mockGetMultipleAccounts.mockRejectedValueOnce(new Error('Connection refused'));
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(500);
         expect(await response.json()).toEqual({ error: 'Failed to verify bluprynt data' });

--- a/app/components/account/nftoken/nftoken.ts
+++ b/app/components/account/nftoken/nftoken.ts
@@ -1,5 +1,5 @@
-import { getBase58Decoder } from '@solana/kit';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { getRpc } from '@entities/cluster';
+import { address, type Base58EncodedBytes, getBase58Decoder, getBase64Encoder } from '@solana/kit';
 import pLimit from 'p-limit';
 
 import { fromHex } from '@/app/shared/lib/bytes';
@@ -8,6 +8,7 @@ import { Logger } from '@/app/shared/lib/logger';
 import { NftokenTypes } from './nftoken-types';
 
 const BASE58_DECODER = getBase58Decoder();
+const BASE64_ENCODER = getBase64Encoder();
 
 export const NFTOKEN_ADDRESS = 'nftokf9qcHSYkVSP3P2gUMmV6d4AwjMueXgUu43HyLL';
 
@@ -22,36 +23,43 @@ export namespace NftokenFetcher {
         collection: string;
         rpcUrl: string;
     }): Promise<NftokenTypes.NftInfo[]> => {
-        const connection = new Connection(rpcUrl);
-        const accounts = await connection.getProgramAccounts(new PublicKey(NFTOKEN_ADDRESS), {
-            filters: [
-                {
-                    memcmp: {
-                        bytes: BASE58_DECODER.decode(fromHex(nftokenAccountDiscInHex)),
-                        offset: 0,
+        const accounts = await getRpc(rpcUrl)
+            .getProgramAccounts(address(NFTOKEN_ADDRESS), {
+                encoding: 'base64',
+                // Offsets are typed as bigint, but the BigInt toJSON polyfill in app/types/bigint.ts
+                // (loaded by the address layout) turns bigints into JSON strings before kit's
+                // serializer can handle them, and the RPC rejects string offsets. Plain numbers
+                // serialize correctly either way.
+                filters: [
+                    {
+                        memcmp: {
+                            bytes: BASE58_DECODER.decode(fromHex(nftokenAccountDiscInHex)) as Base58EncodedBytes,
+                            encoding: 'base58',
+                            offset: 0 as unknown as bigint,
+                        },
                     },
-                },
-                {
-                    memcmp: {
-                        // authority_can_update
-                        bytes: collection,
-                        offset:
-                            8 + // discriminator
-                            1 + // version
-                            32 + // holder
-                            32 + // authority
-                            1,
+                    {
+                        memcmp: {
+                            // authority_can_update
+                            bytes: collection as Base58EncodedBytes,
+                            encoding: 'base58',
+                            offset: (8 + // discriminator
+                                1 + // version
+                                32 + // holder
+                                32 + // authority
+                                1) as unknown as bigint,
+                        },
                     },
-                },
-            ],
-        });
+                ],
+            })
+            .send();
 
         const parsed_accounts: NftokenTypes.NftAccount[] = accounts.flatMap(account => {
             try {
-                const parsed = NftokenTypes.nftAccountDecoder.decode(account.account.data);
+                const parsed = NftokenTypes.nftAccountDecoder.decode(BASE64_ENCODER.encode(account.account.data[0]));
 
                 return {
-                    address: account.pubkey.toBase58(),
+                    address: account.pubkey.toString(),
                     authority: parsed.authority,
                     authority_can_update: Boolean(parsed.authority_can_update),
                     collection: parsed.collection,

--- a/app/entities/account/model/__tests__/use-accounts-info.test.tsx
+++ b/app/entities/account/model/__tests__/use-accounts-info.test.tsx
@@ -13,16 +13,6 @@ vi.mock('swr', () => ({
     default: vi.fn(() => ({ data: undefined, error: undefined, isLoading: false })),
 }));
 
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
-    return {
-        ...actual,
-        Connection: vi.fn().mockImplementation(() => ({
-            getMultipleAccountsInfo: vi.fn(),
-        })),
-    };
-});
-
 describe('useAccountsInfo', () => {
     beforeEach(() => {
         vi.mocked(useSWR).mockImplementation(

--- a/app/entities/account/model/__tests__/use-raw-account-data.test.tsx
+++ b/app/entities/account/model/__tests__/use-raw-account-data.test.tsx
@@ -1,29 +1,37 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { SWRConfig } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toBase64 } from '@/app/shared/lib/bytes';
 
 import { useRawAccountData } from '../use-raw-account-data';
 
 const MOCK_URL = 'https://api.mainnet-beta.solana.com';
 const MOCK_ADDRESS = PublicKey.default.toBase58();
 
+const mockGetAccountInfo = vi.fn();
+
 vi.mock('@providers/cluster', () => ({
     useCluster: () => ({ url: MOCK_URL }),
 }));
 
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
+vi.mock('@entities/cluster/@x/account', async () => {
+    const actual = await vi.importActual<typeof import('@entities/cluster/@x/account')>('@entities/cluster/@x/account');
     return {
         ...actual,
-        Connection: vi.fn().mockImplementation(function () {
-            return {
-                getAccountInfo: vi.fn(),
-            };
-        }),
+        getRpc: vi.fn(() => ({
+            getAccountInfo: (...args: unknown[]) => ({
+                send: async () => ({ value: await mockGetAccountInfo(...args) }),
+            }),
+        })),
     };
 });
+
+function accountInfoValue(data: Uint8Array) {
+    return { data: [toBase64(data), 'base64'] };
+}
 
 function wrapper({ children }: { children: React.ReactNode }) {
     return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
@@ -48,10 +56,7 @@ describe('useRawAccountData', () => {
 
     it('should fetch raw data and return it when mutate is called', async () => {
         const mockData = new Uint8Array([4, 5, 6]);
-
-        vi.mocked(Connection).mockImplementation(function () {
-            return { getAccountInfo: vi.fn().mockResolvedValue({ data: mockData }) } as unknown as Connection;
-        });
+        mockGetAccountInfo.mockResolvedValue(accountInfoValue(mockData));
 
         const { result } = renderHook(() => useRawAccountData(MOCK_ADDRESS), { wrapper });
 
@@ -60,7 +65,7 @@ describe('useRawAccountData', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.data).toEqual(new Uint8Array(mockData));
+            expect(result.current.data).toEqual(mockData);
         });
 
         expect(result.current.isLoading).toBe(false);
@@ -69,14 +74,9 @@ describe('useRawAccountData', () => {
     it('should refetch data when mutate is called again', async () => {
         const mockData1 = new Uint8Array([4, 5, 6]);
         const mockData2 = new Uint8Array([7, 8, 9]);
-        const mockGetAccountInfo = vi
-            .fn()
-            .mockResolvedValueOnce({ data: mockData1 })
-            .mockResolvedValueOnce({ data: mockData2 });
-
-        vi.mocked(Connection).mockImplementation(function () {
-            return { getAccountInfo: mockGetAccountInfo } as unknown as Connection;
-        });
+        mockGetAccountInfo
+            .mockResolvedValueOnce(accountInfoValue(mockData1))
+            .mockResolvedValueOnce(accountInfoValue(mockData2));
 
         const { result } = renderHook(() => useRawAccountData(MOCK_ADDRESS), { wrapper });
 
@@ -85,7 +85,7 @@ describe('useRawAccountData', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.data).toEqual(new Uint8Array(mockData1));
+            expect(result.current.data).toEqual(mockData1);
         });
 
         // Call mutate again — should revalidate with fresh data
@@ -94,7 +94,7 @@ describe('useRawAccountData', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.data).toEqual(new Uint8Array(mockData2));
+            expect(result.current.data).toEqual(mockData2);
         });
     });
 });

--- a/app/entities/account/model/use-accounts-info.ts
+++ b/app/entities/account/model/use-accounts-info.ts
@@ -1,7 +1,9 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { getRpc } from '@entities/cluster/@x/account';
+import { address } from '@solana/kit';
+import { PublicKey } from '@solana/web3.js';
 import useSWR from 'swr';
 
-import { ByteArray } from '@/app/shared/lib/bytes';
+import { ByteArray, fromBase64 } from '@/app/shared/lib/bytes';
 
 export interface AccountInfo {
     data: ByteArray;
@@ -9,15 +11,20 @@ export interface AccountInfo {
 }
 
 async function fetchAccountsInfo(pubkeys: PublicKey[], clusterUrl: string): Promise<Map<string, AccountInfo>> {
-    const connection = new Connection(clusterUrl);
-    const infos = await connection.getMultipleAccountsInfo(pubkeys);
+    const { value: infos } = await getRpc(clusterUrl)
+        .getMultipleAccounts(
+            pubkeys.map(pubkey => address(pubkey.toBase58())),
+            { encoding: 'base64' },
+        )
+        .send();
 
     const result = new Map<string, AccountInfo>();
     infos.forEach((info, i) => {
         if (info) {
+            const data = fromBase64(info.data[0]);
             result.set(pubkeys[i].toBase58(), {
-                data: info.data,
-                size: info.data.length,
+                data,
+                size: data.length,
             });
         }
     });

--- a/app/entities/account/model/use-raw-account-data.ts
+++ b/app/entities/account/model/use-raw-account-data.ts
@@ -31,6 +31,8 @@ export function useRawAccountDataOnMount(pubkey: PublicKey): { data: Uint8Array 
 }
 
 async function fetchRawAccountData(rpc: SolanaRpc, accountAddress: string): Promise<Uint8Array | undefined> {
-    const { value } = await rpc.getAccountInfo(address(accountAddress), { encoding: 'base64' }).send();
+    const { value } = await rpc
+        .getAccountInfo(address(accountAddress), { commitment: 'confirmed', encoding: 'base64' })
+        .send();
     return value ? fromBase64(value.data[0]) : undefined;
 }

--- a/app/entities/account/model/use-raw-account-data.ts
+++ b/app/entities/account/model/use-raw-account-data.ts
@@ -1,20 +1,18 @@
+import { getRpc, type SolanaRpc } from '@entities/cluster/@x/account';
 import { useCluster } from '@providers/cluster';
-import { Connection, PublicKey } from '@solana/web3.js';
-import { useMemo } from 'react';
+import { address } from '@solana/kit';
+import { PublicKey } from '@solana/web3.js';
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
+import { fromBase64 } from '@/app/shared/lib/bytes';
+
 export const rawAccountDataKey = (url: string, address: string) => ['raw-account-data', url, address] as const;
 
-function useConnection() {
+export function useRawAccountData(accountAddress: string) {
     const { url } = useCluster();
-    return useMemo(() => new Connection(url, 'confirmed'), [url]);
-}
 
-export function useRawAccountData(address: string) {
-    const connection = useConnection();
-
-    return useSWR(rawAccountDataKey(connection.rpcEndpoint, address), () => fetchRawAccountData(connection, address), {
+    return useSWR(rawAccountDataKey(url, accountAddress), () => fetchRawAccountData(getRpc(url), accountAddress), {
         revalidateOnFocus: false,
         revalidateOnMount: false,
         revalidateOnReconnect: false,
@@ -23,16 +21,16 @@ export function useRawAccountData(address: string) {
 
 /** Eager variant — fetches immediately on mount. Used by RawAccountRows in AccountCard. */
 export function useRawAccountDataOnMount(pubkey: PublicKey): { data: Uint8Array | undefined; isLoading: boolean } {
-    const connection = useConnection();
+    const { url } = useCluster();
 
-    const { data, isLoading } = useSWRImmutable(rawAccountDataKey(connection.rpcEndpoint, pubkey.toBase58()), () =>
-        fetchRawAccountData(connection, pubkey.toBase58()),
+    const { data, isLoading } = useSWRImmutable(rawAccountDataKey(url, pubkey.toBase58()), () =>
+        fetchRawAccountData(getRpc(url), pubkey.toBase58()),
     );
 
     return { data, isLoading };
 }
 
-async function fetchRawAccountData(connection: Connection, address: string): Promise<Uint8Array | undefined> {
-    const info = await connection.getAccountInfo(new PublicKey(address));
-    return info?.data ? new Uint8Array(info.data) : undefined;
+async function fetchRawAccountData(rpc: SolanaRpc, accountAddress: string): Promise<Uint8Array | undefined> {
+    const { value } = await rpc.getAccountInfo(address(accountAddress), { encoding: 'base64' }).send();
+    return value ? fromBase64(value.data[0]) : undefined;
 }

--- a/app/entities/cluster/@x/account/index.ts
+++ b/app/entities/cluster/@x/account/index.ts
@@ -1,0 +1,3 @@
+// Cross-entity public API (FSD `@x` notation): the slice of the `cluster` entity that the
+// `account` entity is allowed to consume.
+export { getRpc, type SolanaRpc } from '../../api/get-rpc';

--- a/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
@@ -13,7 +13,7 @@ const VALID_CID = 'QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u';
 
 const mocks = vi.hoisted(() => ({
     fetchResource: vi.fn(),
-    getMultipleParsedAccounts: vi.fn(),
+    getMultipleAccounts: vi.fn(),
     getUmi: vi.fn(() => ({})),
     safeFetchAllMetadata: vi.fn(),
 }));
@@ -30,14 +30,13 @@ vi.mock('@metaplex-foundation/mpl-token-metadata', async () => {
     };
 });
 
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
     return {
         ...actual,
-        // `Connection` is called with `new`, so the stand-in has to be constructible.
-        Connection: class {
-            getMultipleParsedAccounts = mocks.getMultipleParsedAccounts;
-        },
+        createSolanaRpc: vi.fn(() => ({
+            getMultipleAccounts: (...args: unknown[]) => ({ send: () => mocks.getMultipleAccounts(...args) }),
+        })),
     };
 });
 
@@ -81,7 +80,7 @@ describe('getTokenInfosFromMetaplex', () => {
         vi.clearAllMocks();
         mocks.getUmi.mockReturnValue({});
         mocks.safeFetchAllMetadata.mockResolvedValue([]);
-        mocks.getMultipleParsedAccounts.mockResolvedValue({ value: [] });
+        mocks.getMultipleAccounts.mockResolvedValue({ value: [] });
         mocks.fetchResource.mockResolvedValue(jsonResource({}));
     });
 
@@ -125,7 +124,7 @@ describe('getTokenInfosFromMetaplex', () => {
         mocks.safeFetchAllMetadata
             .mockRejectedValueOnce(new Error('rpc exploded'))
             .mockResolvedValueOnce([metadata(MINT_B)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(9)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(9)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const result = await getTokenInfosFromMetaplex(addresses, RPC, { onError });
@@ -136,7 +135,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should map on-chain metadata into unverified token info', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
         mocks.fetchResource.mockResolvedValueOnce(jsonResource({ image: 'https://example.com/logo.png' }));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
@@ -158,7 +157,7 @@ describe('getTokenInfosFromMetaplex', () => {
             metadata(MINT_A),
             metadata(MINT_B, { tokenStandard: some(TokenStandard.NonFungible) }),
         ]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const result = await getTokenInfosFromMetaplex([MINT_A, MINT_B], RPC);
@@ -173,14 +172,14 @@ describe('getTokenInfosFromMetaplex', () => {
 
         await expect(getTokenInfosFromMetaplex([MINT_A], RPC)).resolves.toEqual([]);
         // Nothing survived the filter, so the mint accounts are never read.
-        expect(mocks.getMultipleParsedAccounts).not.toHaveBeenCalled();
+        expect(mocks.getMultipleAccounts).not.toHaveBeenCalled();
     });
 
     it('should strip the null padding the metadata program adds', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([
             metadata(MINT_A, { name: `USD Coin${NULL_CHAR.repeat(24)}`, symbol: `USDC${NULL_CHAR.repeat(6)}` }),
         ]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -191,7 +190,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should read decimals from the mint account, including zero', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(0)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(0)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -201,7 +200,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should fall back to 6 decimals when the mint account is missing', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [null] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [null] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -211,7 +210,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should report a null logo when the off-chain JSON has no image', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
         mocks.fetchResource.mockResolvedValueOnce(jsonResource({}));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
@@ -224,7 +223,7 @@ describe('getTokenInfosFromMetaplex', () => {
     // never fetch the mint's URI outside the proxy's hardened fetcher.
     it('should read the off-chain JSON through the proxy fetcher, bounded by the timeout', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex, METAPLEX_TIMEOUT_MS } = await importSubject();
         await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -238,7 +237,7 @@ describe('getTokenInfosFromMetaplex', () => {
     it('should keep the off-chain reads within the concurrency limit', async () => {
         const addresses = Array.from({ length: 20 }, (_, i) => gen.address(i));
         mocks.safeFetchAllMetadata.mockResolvedValueOnce(addresses.map(address => metadata(address)));
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: addresses.map(() => parsedMint(6)) });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: addresses.map(() => parsedMint(6)) });
 
         let inFlight = 0;
         let peak = 0;
@@ -260,7 +259,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should keep every logo with its own mint when the reads settle out of order', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A), metadata(MINT_B)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
         mocks.fetchResource
             .mockImplementationOnce(
                 () => new Promise(resolve => setTimeout(() => resolve(jsonResource({ image: 'logo-a' })), 10)),
@@ -280,7 +279,7 @@ describe('getTokenInfosFromMetaplex', () => {
         vi.useFakeTimers();
         try {
             mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A), metadata(MINT_B)]);
-            mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
+            mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
 
             const { getTokenInfosFromMetaplex, LOGO_BUDGET_MS } = await importSubject();
             mocks.fetchResource.mockImplementationOnce(async () => {
@@ -303,7 +302,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should report a null logo when the proxy fetcher rejects the address', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
         // What `fetchResource` does for a private host or a redirect loop.
         mocks.fetchResource.mockRejectedValueOnce(new Error('Hostname resolves to a private IP'));
         const onError = vi.fn();
@@ -317,7 +316,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should ignore a non-JSON body rather than treat it as metadata', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
         mocks.fetchResource.mockResolvedValueOnce({
             data: { image: 'https://example.com/logo.png' },
             headers: new Headers({ 'content-type': 'text/html' }),
@@ -331,7 +330,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should skip the off-chain read for a mint with no uri', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: '' })]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -345,7 +344,7 @@ describe('getTokenInfosFromMetaplex', () => {
     // path already maps these through a gateway in `getProxiedUri`; this path must match it.
     it('should read an ipfs uri through the http gateway', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: `ipfs://${VALID_CID}/meta.json` })]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
         mocks.fetchResource.mockResolvedValueOnce(jsonResource({ image: 'https://example.com/logo.png' }));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
@@ -360,7 +359,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should skip the off-chain read for an ipfs uri with a malformed CID', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: 'ipfs://not-a-valid-cid' })]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -372,7 +371,7 @@ describe('getTokenInfosFromMetaplex', () => {
     it('should skip the off-chain read for an unparseable uri', async () => {
         const onError = vi.fn();
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: 'not-a-url' })]);
-        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMultipleAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC, { onError });
@@ -396,7 +395,7 @@ describe('getTokenInfosFromMetaplex', () => {
     it('should keep the token when reading its decimals fails', async () => {
         const onError = vi.fn();
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-        mocks.getMultipleParsedAccounts.mockRejectedValueOnce(new Error('rpc exploded'));
+        mocks.getMultipleAccounts.mockRejectedValueOnce(new Error('rpc exploded'));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC, { onError });

--- a/app/entities/token-info/api/fetch-token-metaplex.ts
+++ b/app/entities/token-info/api/fetch-token-metaplex.ts
@@ -6,7 +6,7 @@ import {
     TokenStandard,
 } from '@metaplex-foundation/mpl-token-metadata';
 import { publicKey, unwrapOption } from '@metaplex-foundation/umi';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { address, createSolanaRpc } from '@solana/kit';
 import { fetchAll } from '@utils/fetch-all';
 
 import { MAX_SIZE, USER_AGENT } from '@/app/api/metadata/proxy/config';
@@ -79,16 +79,21 @@ async function fetchDecimals(
     const decimals = new Map<string, number>();
     if (mints.length === 0) return decimals;
 
-    const connection = new Connection(rpcEndpoint);
+    const rpc = createSolanaRpc(rpcEndpoint);
 
     await Promise.all(
         chunk(mints, ACCOUNTS_CHUNK_SIZE).map(async batch => {
             try {
-                const { value } = await connection.getMultipleParsedAccounts(batch.map(mint => new PublicKey(mint)));
+                const { value } = await rpc
+                    .getMultipleAccounts(
+                        batch.map(mint => address(mint)),
+                        { encoding: 'jsonParsed' },
+                    )
+                    .send();
                 value.forEach((account, index) => {
                     const data = account?.data;
                     if (!data || !('parsed' in data)) return;
-                    const parsedDecimals = data.parsed?.info?.decimals;
+                    const parsedDecimals = (data.parsed as { info?: { decimals?: unknown } }).info?.decimals;
                     if (typeof parsedDecimals === 'number') {
                         decimals.set(batch[index], parsedDecimals);
                     }

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -1,6 +1,6 @@
 import { useAnchorProgram } from '@entities/idl';
 import { hashProgramBytes, orderVerifiedEntries, TRUSTED_SIGNERS } from '@explorer/entity-inspector/verification';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { useEffect, useMemo } from 'react';
 import { array, boolean, create, Infer, nullable, string, type } from 'superstruct';
 import useSWRImmutable from 'swr/immutable';
@@ -288,11 +288,10 @@ function useEnrichedOsecInfo({
     programAuthority: PublicKey | null;
 }) {
     const { url: clusterUrl, cluster: cluster } = useCluster();
-    const connection = new Connection(clusterUrl);
 
     const { program: accountAnchorProgram, isLoading: isIdlLoading } = useAnchorProgram(
         VERIFY_PROGRAM_ID,
-        connection.rpcEndpoint,
+        clusterUrl,
         cluster,
     );
     const signerAuthorities = useMemo(


### PR DESCRIPTION
## Description

Task 1.8 of the kit migration (Phase 1: kill `Connection`). Replaces the last small-fry `new Connection(...)` sites with kit RPC:

- `app/utils/verified-builds.tsx` — the `Connection` existed only to read back `rpcEndpoint`; the cluster URL is now passed straight to `useAnchorProgram`.
- `app/api/verification/bluprynt/[mintAddress]/route.ts` — module-scope server `Connection` → `createSolanaRpc`, with the request timeout moved from `fetchMiddleware` to `.send({ abortSignal })`; mint validation via `address()`.
- `app/entities/account/model/use-raw-account-data.ts` / `use-accounts-info.ts` — hooks now use the shared `getRpc` accessor through a new `@entities/cluster/@x/account` cross-entity API (FSD boundaries forbid direct entity→entity imports).
- `app/entities/token-info/api/fetch-token-metaplex.ts` — `getMultipleParsedAccounts` → kit `getMultipleAccounts` with `jsonParsed`; umi stays until Phase 5.
- `app/components/account/nftoken/nftoken.ts` — `getProgramAccounts` via `getRpc` with kit memcmp filters. Offsets are passed as plain numbers (typed-cast to bigint) because the `BigInt.prototype.toJSON` polyfill loaded by the address layout turns bigint params into JSON strings the RPC rejects.
- Shared test RPC mock gains a `getMultipleAccounts` stub; colocated tests migrated.

Public API shapes are unchanged; `PublicKey` in signatures stays until Phase 7. `app/entities/domain/api/*` was already clean (landed with task 0.5).

## Type of change

-   [x] Other (please describe): web3.js → @solana/kit migration (refactor)

## Screenshots

N/A — no UI changes.

## Testing

Full local CI green: format, lint, typecheck, openspec validate, full test suite (4603 passed), `next build`.

## Related Issues

Closes HOO-1275

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information