### PR TITLE
fix(feature-gate): measure slot time instead of assuming 400ms

### DIFF
--- a/app/api/slot-time/__tests__/route.spec.ts
+++ b/app/api/slot-time/__tests__/route.spec.ts
@@ -1,0 +1,283 @@
+import { MEASURED_SAMPLES } from '@entities/slot-time/server';
+import {
+    createSolanaRpc,
+    SOLANA_ERROR__JSON_RPC__INTERNAL_ERROR,
+    SOLANA_ERROR__JSON_RPC__METHOD_NOT_FOUND,
+    SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
+    SolanaError,
+} from '@solana/kit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+import { ROUTE_TIMEOUT_MS, UPSTREAM_TIMEOUT_MS } from '@/app/shared/lib/timeouts';
+import { Cluster } from '@/app/utils/cluster';
+
+import { GET, maxDuration } from '../route';
+
+const mocks = vi.hoisted(() => ({ getRecentPerformanceSamples: vi.fn(), send: vi.fn() }));
+
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
+    return {
+        ...actual,
+        createSolanaRpc: vi.fn(() => ({ getRecentPerformanceSamples: mocks.getRecentPerformanceSamples })),
+    };
+});
+
+// Stubbed, so a local `.env` cannot decide what the route resolves to — an empty one would fail these
+// tests for a reason that has nothing to do with the route.
+const MAINNET_RPC_URL = 'https://mainnet.test/rpc';
+const TESTNET_RPC_URL = 'https://testnet.test/rpc';
+
+const NO_STORE = 'no-store, max-age=0';
+const ERROR_CACHE = 'public, max-age=30, s-maxage=30';
+
+// Testnet in September 2026: 319 slots a minute, the rate the 200 ms gate produced there.
+const SAMPLES = [{ numSlots: 319n, samplePeriodSecs: 60 }];
+
+describe('GET /api/slot-time', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubEnv('MAINNET_RPC_URL', MAINNET_RPC_URL);
+        vi.stubEnv('TESTNET_RPC_URL', TESTNET_RPC_URL);
+        mocks.getRecentPerformanceSamples.mockReturnValue({ send: mocks.send });
+        mocks.send.mockResolvedValue(SAMPLES);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    // Otherwise a route that resolved every cluster to mainnet would pass the whole suite, and testnet
+    // visitors would count down at mainnet's rate — the very mix-up this route exists to end.
+    it.each([
+        ['mainnet-beta', Cluster.MainnetBeta, MAINNET_RPC_URL],
+        ['testnet', Cluster.Testnet, TESTNET_RPC_URL],
+    ])('should dial the endpoint configured for %s', async (_name, cluster, expectedUrl) => {
+        await GET(createRequest(cluster));
+
+        expect(createSolanaRpc).toHaveBeenCalledWith(expectedUrl);
+    });
+
+    it('should return the measured rate', async () => {
+        const response = await GET(createRequest(Cluster.Testnet));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ msPerSlot: 188 });
+    });
+
+    it('should measure over the window both fetch paths use', async () => {
+        await GET(createRequest(Cluster.MainnetBeta));
+
+        expect(mocks.getRecentPerformanceSamples).toHaveBeenCalledWith(MEASURED_SAMPLES);
+    });
+
+    it('should cache a successful response at the CDN', async () => {
+        const response = await GET(createRequest(Cluster.MainnetBeta));
+
+        expect(response.headers.get('Cache-Control')).toBe(
+            'public, max-age=60, s-maxage=300, stale-while-revalidate=3600',
+        );
+    });
+
+    // The value, not just the presence: a signal is a signal at any duration, and one set above the
+    // function's own budget lets the platform kill the invocation before the classified answer is written.
+    it('should bound the call with a deadline, so a wedged node cannot hold the function open', async () => {
+        const timeout = vi.spyOn(AbortSignal, 'timeout');
+
+        await GET(createRequest(Cluster.MainnetBeta));
+
+        expect(mocks.send).toHaveBeenCalledWith({ abortSignal: expect.any(AbortSignal) });
+        expect(timeout).toHaveBeenCalledWith(UPSTREAM_TIMEOUT_MS);
+    });
+
+    it('should keep the RPC bound under the function duration, and that under the browser’s', () => {
+        expect(UPSTREAM_TIMEOUT_MS).toBeLessThan(maxDuration * 1000);
+        expect(maxDuration * 1000).toBeLessThan(ROUTE_TIMEOUT_MS);
+    });
+
+    describe('requests it will not answer', () => {
+        it('should return an uncached 400 when the cluster param is missing', async () => {
+            const response = await GET(new Request('http://localhost:3000/api/slot-time'));
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid query params' });
+            expect(response.headers.get('Cache-Control')).toBe(NO_STORE);
+            expect(mocks.getRecentPerformanceSamples).not.toHaveBeenCalled();
+        });
+
+        // The CDN keys on the whole URL, so every extra spelling of one request is another miss. One
+        // shape gets answered, and nothing else reaches the node.
+        it.each([
+            ['an unexpected extra param', `?cluster=${Cluster.MainnetBeta}&bust=1`],
+            ['a repeated param', `?cluster=${Cluster.MainnetBeta}&cluster=${Cluster.MainnetBeta}`],
+            ['a percent-encoded digit', '?cluster=%30'],
+            ['the param in another position', `?bust=1&cluster=${Cluster.MainnetBeta}`],
+        ])('should refuse %s without asking the node', async (_reason, query) => {
+            const response = await GET(new Request(`http://localhost:3000/api/slot-time${query}`));
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid query params' });
+            expect(mocks.getRecentPerformanceSamples).not.toHaveBeenCalled();
+        });
+
+        // The server must never resolve a custom endpoint: its URL comes from the caller. An unknown
+        // cluster is the same refusal for the same reason.
+        it.each([
+            ['the custom cluster', Cluster.Custom.toString()],
+            ['an unknown cluster', '999'],
+            ['a param that is not an integer', '0x0'],
+            ['a leading-zero param, which Number() would coerce', '01'],
+        ])('should return an uncached 400 for %s', async (_reason, cluster) => {
+            const response = await GET(new Request(`http://localhost:3000/api/slot-time?cluster=${cluster}`));
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid cluster' });
+            expect(response.headers.get('Cache-Control')).toBe(NO_STORE);
+            expect(mocks.getRecentPerformanceSamples).not.toHaveBeenCalled();
+        });
+
+        // Anyone can ask for these, so a report would be a way for anyone to raise an alert. Pinned on the
+        // call shape rather than the level: a warning reaches Sentry too, the moment it is handed a
+        // context, so asserting the level alone would let one be added here unnoticed.
+        it.each([
+            ['a query that is not the canonical shape', `?cluster=${Cluster.MainnetBeta}&bust=1`],
+            ['a cluster the server must not resolve', '?cluster=999'],
+        ])('should keep the refusal for %s out of Sentry', async (_reason, query) => {
+            await GET(new Request(`http://localhost:3000/api/slot-time${query}`));
+
+            expect(Logger.warn).toHaveBeenCalled();
+            expect(vi.mocked(Logger.warn).mock.calls.map(([, context]) => context)).not.toContainEqual(
+                expect.objectContaining({ sentry: true }),
+            );
+            expect(Logger.error).not.toHaveBeenCalled();
+            expect(Logger.panic).not.toHaveBeenCalled();
+        });
+    });
+
+    // A cluster we own with no endpoint set: every countdown on it is absent until someone fixes that,
+    // and no caller can provoke it, so this is the one refusal that has to reach Sentry.
+    it('should report a known cluster with no endpoint configured', async () => {
+        vi.stubEnv('TESTNET_RPC_URL', '');
+
+        const response = await GET(createRequest(Cluster.Testnet));
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Cluster not configured' });
+        expect(response.headers.get('Cache-Control')).toBe(ERROR_CACHE);
+        expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), reported({ cluster: Cluster.Testnet.toString() }));
+        expect(mocks.getRecentPerformanceSamples).not.toHaveBeenCalled();
+    });
+
+    describe('upstream failures', () => {
+        // The route is the only place that can catch this. Served as a 200 it would be cached for
+        // everyone, and every countdown would then be drawn against a rate nothing measured.
+        it.each([
+            ['samples covering no slot', [{ numSlots: 0n, samplePeriodSecs: 60 }]],
+            ['no samples at all', []],
+        ])('should refuse %s rather than serve a rate', async (_reason, samples) => {
+            mocks.send.mockResolvedValueOnce(samples);
+
+            const response = await GET(createRequest(Cluster.MainnetBeta));
+
+            // Unclassified: one node behind a balancer may have history the next one lacks, so it stays
+            // re-askable.
+            expect(response.status).toBe(503);
+            expect(response.headers.get('Cache-Control')).toBe(ERROR_CACHE);
+            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), reported({ reason: 'unclassified' }));
+        });
+
+        // Warned, never escalated: this route is public, so a slow node must not become a way to page
+        // anyone. Cached briefly, so one visitor's retries cost a cache hit rather than another call.
+        it('should warn and briefly cache a 504 when the node misses the deadline', async () => {
+            mocks.send.mockRejectedValueOnce(new DOMException('The operation timed out.', 'TimeoutError'));
+
+            const response = await GET(createRequest(Cluster.Testnet));
+
+            expect(response.status).toBe(504);
+            expect(response.headers.get('Cache-Control')).toBe(ERROR_CACHE);
+            expect(Logger.warn).toHaveBeenCalledWith(
+                expect.any(String),
+                reported({ cluster: Cluster.Testnet.toString() }),
+            );
+            expect(Logger.error).not.toHaveBeenCalled();
+            expect(Logger.panic).not.toHaveBeenCalled();
+        });
+
+        // 503 rather than 502: the client retries this tier and leaves the refusal tier alone, which it
+        // cannot do if both answer with one status.
+        it('should warn and briefly cache a 503 on a transient RPC error', async () => {
+            mocks.send.mockRejectedValueOnce(
+                new SolanaError(SOLANA_ERROR__JSON_RPC__INTERNAL_ERROR, { __serverMessage: 'Internal error' }),
+            );
+
+            const response = await GET(createRequest(Cluster.MainnetBeta));
+
+            expect(response.status).toBe(503);
+            expect(await response.json()).toEqual({ error: 'Upstream RPC error' });
+            expect(response.headers.get('Cache-Control')).toBe(ERROR_CACHE);
+            expect(Logger.warn).toHaveBeenCalledWith(expect.any(String), reported({ rpcError: expect.any(String) }));
+            expect(Logger.error).not.toHaveBeenCalled();
+        });
+
+        // Needs a configuration change, not a page — a node that serves no performance samples at all is
+        // the likely one here.
+        it.each([
+            [
+                'a method the node will not serve',
+                new SolanaError(SOLANA_ERROR__JSON_RPC__METHOD_NOT_FOUND, { __serverMessage: 'Method not found' }),
+            ],
+            ['credentials the node will not take', httpError(401)],
+        ])('should report, and briefly cache, %s', async (_reason, error) => {
+            mocks.send.mockRejectedValueOnce(error);
+
+            const response = await GET(createRequest(Cluster.MainnetBeta));
+
+            expect(response.status).toBe(502);
+            expect(response.headers.get('Cache-Control')).toBe(ERROR_CACHE);
+            expect(Logger.error).toHaveBeenCalledWith(expect.anything(), reported({ reason: 'rpc-refused' }));
+            expect(Logger.panic).not.toHaveBeenCalled();
+        });
+
+        // Nothing here can say the next attempt fails the same way, so 502 stays reserved for a refusal.
+        it('should report an unrecognised connection failure, and leave it re-askable', async () => {
+            mocks.send.mockRejectedValueOnce(connectionFailure('ENOTFOUND'));
+
+            const response = await GET(createRequest(Cluster.MainnetBeta));
+
+            expect(response.status).toBe(503);
+            expect(await response.json()).toEqual({ error: 'Failed to measure slot time' });
+            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), reported({ reason: 'unclassified' }));
+            expect(Logger.panic).not.toHaveBeenCalled();
+        });
+    });
+});
+
+function createRequest(cluster: Cluster) {
+    return new Request(`http://localhost:3000/api/slot-time?cluster=${cluster}`);
+}
+
+/** A node answering over HTTP rather than in JSON-RPC: a gateway, a key check, a wrong path. */
+function httpError(statusCode: number) {
+    return new SolanaError(SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR, {
+        headers: new Headers(),
+        message: `HTTP ${statusCode}`,
+        statusCode,
+    });
+}
+
+/** Shaped the way undici reports one: the code sits on an `Error` nested as `cause`. */
+function connectionFailure(code: string) {
+    const cause = Object.assign(new Error(`${code} on connect`), { code });
+    return Object.assign(new TypeError('fetch failed'), { cause });
+}
+
+/**
+ * What has to be on a log call for the failure to reach Sentry at all: the flag, and the reason under
+ * `sentryExtras`, which is the only part of a context Sentry receives. A bare `toHaveBeenCalled` passes
+ * with both dropped, and the tier then fails silently for everyone.
+ */
+function reported(extras: Record<string, unknown>) {
+    return expect.objectContaining({ sentry: true, sentryExtras: expect.objectContaining(extras) });
+}

--- a/app/api/slot-time/route.ts
+++ b/app/api/slot-time/route.ts
@@ -1,0 +1,100 @@
+import { resolveServerClusterUrl } from '@entities/cluster/server';
+import { MEASURED_SAMPLES, toSlotTimePayload } from '@entities/slot-time/server';
+import { isRetryableError, isRpcMisconfigError } from '@shared/lib/errors';
+import { ERROR_CACHE_HEADERS, isTimeoutError, NO_STORE_HEADERS } from '@shared/lib/http-utils';
+import { Logger } from '@shared/lib/logger';
+import { UPSTREAM_TIMEOUT_MS } from '@shared/lib/timeouts';
+import { createSolanaRpc } from '@solana/kit';
+import { NextResponse } from 'next/server';
+
+// The rate moves only when a slot-time feature gate activates, at an epoch boundary. A few minutes of
+// staleness costs a countdown nothing, and every visitor asks for the same figure.
+const SLOT_TIME_CACHE_HEADERS = {
+    'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate=3600',
+};
+
+// Above the RPC bound this route passes to the node, so that bound is what fires and the classified
+// branches are what answer, rather than the platform killing the invocation with no headers on the way out.
+export const maxDuration = 35;
+
+/** Known clusters only. A custom URL comes from the caller, so the server must never be aimed at it. */
+export async function GET(request: Request) {
+    const { search, searchParams } = new URL(request.url);
+    const clusterParam = searchParams.get('cluster');
+
+    // The CDN keys on the whole URL, so a second spelling of one request is a fresh miss. Comparing the
+    // raw query against the param it parsed to leaves one URL that reaches the node: the one every
+    // visitor's client already sends.
+    if (clusterParam === null || search !== `?cluster=${clusterParam}`) {
+        // Console only, like every refusal a caller can provoke: reporting one would hand anyone a way
+        // to raise alerts.
+        Logger.warn('[api:slot-time] Rejected a query that is not the canonical shape');
+        return NextResponse.json({ error: 'Invalid query params' }, { headers: NO_STORE_HEADERS, status: 400 });
+    }
+
+    const context = { cluster: clusterParam };
+    const resolved = resolveServerClusterUrl(clusterParam);
+
+    if (resolved.kind === 'refused') {
+        Logger.warn('[api:slot-time] Refused a cluster the server must not resolve', context);
+        return NextResponse.json({ error: 'Invalid cluster' }, { headers: NO_STORE_HEADERS, status: 400 });
+    }
+
+    if (resolved.kind === 'unconfigured') {
+        // Ours, and no caller can provoke it: every countdown on this cluster is absent until someone
+        // sets an endpoint for it, and nothing else would say so.
+        Logger.error(new Error('[api:slot-time] No endpoint configured for cluster'), {
+            sentry: true,
+            sentryExtras: context,
+        });
+        return NextResponse.json({ error: 'Cluster not configured' }, { headers: ERROR_CACHE_HEADERS, status: 500 });
+    }
+
+    try {
+        const rpc = createSolanaRpc(resolved.url);
+        const samples = await rpc
+            .getRecentPerformanceSamples(MEASURED_SAMPLES)
+            // A wedged node would otherwise hold the function open long past any useful answer.
+            .send({ abortSignal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) });
+
+        return NextResponse.json(toSlotTimePayload(samples), { headers: SLOT_TIME_CACHE_HEADERS });
+    } catch (error) {
+        if (isTimeoutError(error)) {
+            Logger.warn('[api:slot-time] RPC request timed out', { sentry: true, sentryExtras: context });
+            return NextResponse.json(
+                { error: 'Upstream request timed out' },
+                { headers: ERROR_CACHE_HEADERS, status: 504 },
+            );
+        }
+
+        if (isRetryableError(error)) {
+            Logger.warn('[api:slot-time] RPC error fetching performance samples', {
+                sentry: true,
+                sentryExtras: { ...context, rpcError: error instanceof Error ? error.message : String(error) },
+            });
+            return NextResponse.json({ error: 'Upstream RPC error' }, { headers: ERROR_CACHE_HEADERS, status: 503 });
+        }
+
+        // 502 is what tells the client not to ask again: someone has to change configuration first.
+        if (isRpcMisconfigError(error)) {
+            Logger.error(error, { sentry: true, sentryExtras: { ...context, reason: 'rpc-refused' } });
+            return NextResponse.json({ error: 'Upstream RPC error' }, { headers: ERROR_CACHE_HEADERS, status: 502 });
+        }
+
+        // A node answering with samples that state no rate lands here too, alongside the connection
+        // failures nothing above recognises. Both are worth looking at, and neither says the next attempt
+        // fails the same way, so 502 stays reserved for a node that refuses.
+        Logger.error(new Error('[api:slot-time] Request failed', { cause: error }), {
+            sentry: true,
+            sentryExtras: {
+                ...context,
+                reason: 'unclassified',
+                rpcError: error instanceof Error ? error.message : String(error),
+            },
+        });
+        return NextResponse.json(
+            { error: 'Failed to measure slot time' },
+            { headers: ERROR_CACHE_HEADERS, status: 503 },
+        );
+    }
+}

--- a/app/components/account/FeatureAccountSection.tsx
+++ b/app/components/account/FeatureAccountSection.tsx
@@ -1,6 +1,7 @@
 import { Address } from '@components/common/Address';
 import { Slot } from '@components/common/Slot';
 import { type FeatureInfoType, getFeatureInfo } from '@entities/feature-gate';
+import { useSlotTime } from '@entities/slot-time';
 import { AccountCard } from '@features/account';
 import { Account } from '@providers/accounts';
 import { PublicKey } from '@solana/web3.js';
@@ -165,8 +166,6 @@ const BaseFeatureCard = ({
     );
 };
 
-const AVERAGE_SLOT_TIME_MS = 400;
-
 function formatCountdown(totalSeconds: number): string {
     if (totalSeconds <= 0) return 'any moment now';
     const hours = Math.floor(totalSeconds / 3600);
@@ -179,8 +178,8 @@ function formatCountdown(totalSeconds: number): string {
     return `~${parts.join(' ')}`;
 }
 
-function EpochCountdown({ remainingSlots }: { remainingSlots: bigint }) {
-    const estimatedSeconds = Math.ceil((Number(remainingSlots) * AVERAGE_SLOT_TIME_MS) / 1000);
+function EpochCountdown({ remainingSlots, msPerSlot }: { remainingSlots: bigint; msPerSlot: number }) {
+    const estimatedSeconds = Math.ceil((Number(remainingSlots) * msPerSlot) / 1000);
     const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
 
     useEffect(() => {
@@ -199,6 +198,22 @@ function EpochCountdown({ remainingSlots }: { remainingSlots: bigint }) {
         <span className="text-dk-warning-on-dark" style={{ fontVariantNumeric: 'tabular-nums' }}>
             {secondsLeft > 0 ? `${label} remaining` : label}
         </span>
+    );
+}
+
+/**
+ * Owns the slot-time request, so it is made where the countdown is about to render. Only a pending
+ * feature has one, and a custom cluster never gets this far — asking higher up would put a request on
+ * every feature account page, and on a custom cluster it would reach the visitor's own node for nothing.
+ */
+function PendingEpochCountdown({ remainingSlots }: { remainingSlots: bigint }) {
+    const msPerSlot = useSlotTime();
+    if (msPerSlot === undefined) return null;
+
+    return (
+        <div className="mt-[3px]">
+            <EpochCountdown remainingSlots={remainingSlots} msPerSlot={msPerSlot} />
+        </div>
     );
 }
 
@@ -232,9 +247,7 @@ function ClusterActivationEpochAtCluster({
                 <Link href={`/epoch/${nextEpoch}?cluster=${cluster}`}>
                     {clusterName(cluster)} Epoch {nextEpoch.toString()}
                 </Link>
-                <div className="mt-[3px]">
-                    <EpochCountdown remainingSlots={remainingSlots} />
-                </div>
+                <PendingEpochCountdown remainingSlots={remainingSlots} />
             </div>
         );
     }

--- a/app/entities/cluster/@x/slot-time/index.ts
+++ b/app/entities/cluster/@x/slot-time/index.ts
@@ -1,0 +1,6 @@
+// Cross-entity public API (FSD `@x` notation): the slice of the `cluster` entity that the
+// `slot-time` entity is allowed to consume.
+export { getRpc } from '../../api/get-rpc';
+export { type ConnectableUrl } from '../../lib/connectable-url';
+export { shouldUseDirectRpc } from '../../lib/should-use-direct-rpc';
+export { useCluster } from '../../model/use-cluster';

--- a/app/entities/slot-time/api/fetch-slot-time.ts
+++ b/app/entities/slot-time/api/fetch-slot-time.ts
@@ -1,0 +1,77 @@
+import { type ConnectableUrl, getRpc } from '@entities/cluster/@x/slot-time';
+import { Logger } from '@shared/lib/logger';
+import { ROUTE_TIMEOUT_MS, UPSTREAM_TIMEOUT_MS } from '@shared/lib/timeouts';
+import { type Cluster } from '@utils/cluster';
+
+import { MEASURED_SAMPLES, parseSlotTimePayload, toMsPerSlot } from '../lib/slot-time';
+
+/** Carries whether asking again could answer differently, judged where the response is in hand. */
+export class SlotTimeFetchError extends Error {
+    readonly name = 'SlotTimeFetchError';
+    readonly retryable: boolean;
+
+    constructor(message: string, options: { retryable: boolean }) {
+        super(message);
+        this.retryable = options.retryable;
+    }
+}
+
+/** An error from anywhere else is most likely the connection, which is worth another go. */
+export function isRetryableSlotTimeError(error: unknown): boolean {
+    return error instanceof SlotTimeFetchError ? error.retryable : true;
+}
+
+/** Throws rather than returning a nominal rate, which every countdown would then present as measured. */
+export async function fetchSlotTimeFromRoute(cluster: Cluster): Promise<number> {
+    const response = await fetch(`/api/slot-time?cluster=${cluster}`, {
+        // Without one, a connection that is accepted and never answered leaves the countdown absent for good.
+        signal: AbortSignal.timeout(ROUTE_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        const retryable = RETRYABLE_STATUSES.has(response.status);
+        // The one answer the route cannot have reported: it refuses a caller's input silently, since
+        // anyone can provoke that. This client sends a single fixed request, so a refusal reaching it
+        // means our own bug or a deploy that left it behind. Warned, not errored — the bot gate ahead of
+        // the route refuses visitors it misjudges.
+        if (response.status < 500 && !retryable) {
+            Logger.warn('[slot-time] /api/slot-time refused the request', {
+                sentry: true,
+                sentryExtras: { cluster, status: response.status },
+            });
+        }
+        throw new SlotTimeFetchError(`[slot-time] /api/slot-time returned ${response.status}`, { retryable });
+    }
+
+    // The route counts a 200 as answered, so nothing on its side reported this: an intermediary replied
+    // in its place, or a deploy left the two sides disagreeing on the payload — and only the parse
+    // failure tells those apart. Not retryable, because asking again cannot change a body's shape.
+    // Warned rather than errored, like the refusal above: someone else's middlebox must not page us.
+    try {
+        return parseSlotTimePayload(await response.json());
+    } catch (error) {
+        Logger.warn(UNREADABLE_BODY, {
+            sentry: true,
+            sentryExtras: { cluster, parseError: error instanceof Error ? error.message : String(error) },
+        });
+        throw new SlotTimeFetchError(UNREADABLE_BODY, { retryable: false });
+    }
+}
+
+/** For endpoints the server cannot or must not reach — a custom URL, or a local validator. */
+export async function fetchSlotTimeFromRpc(url: ConnectableUrl): Promise<number> {
+    const samples = await getRpc(url)
+        .getRecentPerformanceSamples(MEASURED_SAMPLES)
+        .send({ abortSignal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) });
+
+    return toMsPerSlot(samples);
+}
+
+// Asking again can only answer differently for these: the route's transient upstream error and its
+// deadline, plus a rate limit from anything standing in front of it. Its other answers wait on someone
+// changing configuration, and a rate limit is nobody's bug, so it is not reported either.
+const RETRYABLE_STATUSES = new Set([429, 503, 504]);
+
+// One sentence for the report and the throw: Sentry groups on the message, and a second wording would
+// split one failure into two issues.
+const UNREADABLE_BODY = '[slot-time] /api/slot-time answered with a body it could not read';

--- a/app/entities/slot-time/index.ts
+++ b/app/entities/slot-time/index.ts
@@ -1,0 +1,1 @@
+export { useSlotTime } from './model/use-slot-time';

--- a/app/entities/slot-time/lib/__tests__/slot-time.spec.ts
+++ b/app/entities/slot-time/lib/__tests__/slot-time.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { MEASURED_SAMPLES, parseSlotTimePayload, toMsPerSlot, toSlotTimePayload } from '../slot-time';
+
+/** One minute of slots at a given rate, as `getRecentPerformanceSamples` reports it. */
+function sample(msPerSlot: number, samplePeriodSecs = 60) {
+    return { numSlots: BigInt(Math.round((samplePeriodSecs * 1000) / msPerSlot)), samplePeriodSecs };
+}
+
+describe('toMsPerSlot', () => {
+    it('should measure the rate a single sample states', () => {
+        expect(toMsPerSlot([sample(200)])).toBe(200);
+    });
+
+    // The bug this exists for: the countdown read a 400 ms constant while every cluster had already
+    // stepped down through SIMD-0525. Slot counts as the clusters reported them in September 2026.
+    it.each([
+        ['a cluster before SIMD-0525', 150n, 400],
+        ['testnet at the 200 ms gate', 319n, 188],
+        ['devnet at the 200 ms gate', 361n, 166],
+        ['mainnet at the 300 ms gate', 191n, 314],
+    ])('should measure %s', (_name, numSlots, expected) => {
+        expect(toMsPerSlot([{ numSlots, samplePeriodSecs: 60 }])).toBe(expected);
+    });
+
+    // Total time over total slots, not the mean of the per-sample rates: a sample covering a longer
+    // period describes more of the epoch and has to weigh more.
+    it('should weigh each sample by the time it covers', () => {
+        const samples = [sample(200, 30), sample(400, 90)];
+
+        expect(toMsPerSlot(samples)).toBe(Math.round(120_000 / (150 + 225)));
+    });
+
+    it('should ignore samples beyond the measured window', () => {
+        const samples = [...Array.from({ length: MEASURED_SAMPLES }, () => sample(200)), sample(4000)];
+
+        expect(toMsPerSlot(samples)).toBe(200);
+    });
+
+    // A sample that covers no slot states no rate, and dividing by it would yield Infinity.
+    it('should skip a sample covering no slot', () => {
+        expect(toMsPerSlot([{ numSlots: 0n, samplePeriodSecs: 60 }, sample(200)])).toBe(200);
+    });
+
+    it.each([
+        ['a period of zero', { numSlots: 300n, samplePeriodSecs: 0 }],
+        ['a negative period', { numSlots: 300n, samplePeriodSecs: -60 }],
+        ['a period that is not finite', { numSlots: 300n, samplePeriodSecs: Number.NaN }],
+        // Kit types these fields without checking what the node put in them.
+        ['a slot count that is not a bigint', { numSlots: 300 as unknown as bigint, samplePeriodSecs: 60 }],
+        ['a period that is not a number', { numSlots: 300n, samplePeriodSecs: '60' as unknown as number }],
+    ])('should skip a sample with %s', (_reason, broken) => {
+        expect(toMsPerSlot([broken, sample(200)])).toBe(200);
+    });
+
+    // Throws rather than returning a fallback: a countdown built on a rate nothing measured is a
+    // confidently wrong one.
+    it.each([
+        ['no samples at all', []],
+        ['no sample that states a rate', [{ numSlots: 0n, samplePeriodSecs: 60 }]],
+    ])('should throw when a node reports %s', (_reason, samples) => {
+        expect(() => toMsPerSlot(samples)).toThrow('no sample states a rate');
+    });
+});
+
+describe('toSlotTimePayload', () => {
+    it('should carry the measured rate', () => {
+        expect(toSlotTimePayload([sample(200)])).toEqual({ msPerSlot: 200 });
+    });
+});
+
+describe('parseSlotTimePayload', () => {
+    it('should read back a rate the route measured', () => {
+        expect(parseSlotTimePayload({ msPerSlot: 188 })).toBe(188);
+    });
+
+    it.each([
+        ['an absent rate', {}],
+        ['a rate as a string', { msPerSlot: '200' }],
+        ['a rate of zero', { msPerSlot: 0 }],
+        ['a negative rate', { msPerSlot: -200 }],
+        ['a rate that is not finite', { msPerSlot: Number.POSITIVE_INFINITY }],
+        ['no body at all', undefined],
+    ])('should throw on %s', (_reason, body) => {
+        expect(() => parseSlotTimePayload(body)).toThrow();
+    });
+});

--- a/app/entities/slot-time/lib/slot-time.ts
+++ b/app/entities/slot-time/lib/slot-time.ts
@@ -1,0 +1,58 @@
+import { assert, type Infer, number, refine, type } from 'superstruct';
+
+/** The fields of a `getRecentPerformanceSamples` entry this reads. */
+type PerformanceSample = Readonly<{
+    numSlots: bigint;
+    samplePeriodSecs: number;
+}>;
+
+type SlotTimePayload = Infer<typeof SlotTimePayloadStruct>;
+
+/**
+ * How many of the most recent samples (one minute each) the rate is measured over. Wide enough that one
+ * odd minute cannot move it, narrow enough that a slot-time feature gate shows up within minutes of
+ * activating.
+ */
+export const MEASURED_SAMPLES = 5;
+
+export function toSlotTimePayload(samples: readonly PerformanceSample[]): SlotTimePayload {
+    return { msPerSlot: toMsPerSlot(samples) };
+}
+
+/**
+ * The boundary constructor: wall-clock time the cluster spent per slot, over the samples it reports.
+ *
+ * Rounded to whole milliseconds so both fetch paths agree on the figure and the cached body stays stable.
+ * At epoch scale that costs well under a minute, against a rate that moves by a hundred milliseconds a
+ * slot when a SIMD-0525 gate activates.
+ */
+export function toMsPerSlot(samples: readonly PerformanceSample[]): number {
+    let slots = 0n;
+    let seconds = 0;
+
+    for (const sample of samples.slice(0, MEASURED_SAMPLES)) {
+        // Kit types these without checking them, and a sample that covers no slot cannot state a rate.
+        if (typeof sample.numSlots !== 'bigint' || sample.numSlots <= 0n) continue;
+        if (typeof sample.samplePeriodSecs !== 'number' || !Number.isFinite(sample.samplePeriodSecs)) continue;
+        if (sample.samplePeriodSecs <= 0) continue;
+
+        slots += sample.numSlots;
+        seconds += sample.samplePeriodSecs;
+    }
+
+    if (slots === 0n) {
+        throw new Error('[slot-time] no sample states a rate');
+    }
+
+    return Math.round((seconds * 1000) / Number(slots));
+}
+
+/** Throws rather than handing back a rate it cannot vouch for, which every countdown would then use. */
+export function parseSlotTimePayload(body: unknown): number {
+    assert(body, SlotTimePayloadStruct);
+    return body.msPerSlot;
+}
+
+const SlotTimePayloadStruct = type({
+    msPerSlot: refine(number(), 'msPerSlot', value => Number.isFinite(value) && value > 0),
+});

--- a/app/entities/slot-time/model/__tests__/use-slot-time.spec.tsx
+++ b/app/entities/slot-time/model/__tests__/use-slot-time.spec.tsx
@@ -1,0 +1,347 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { Cluster, clusterName, clusterSelection, ClusterStatus } from '@utils/cluster';
+import { type ReactNode } from 'react';
+import { SWRConfig, type SWRConfiguration } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Both from their own modules rather than the cross-entity barrel, which this file mocks.
+import { toConnectableUrl } from '@/app/entities/cluster/lib/connectable-url';
+import type { useCluster } from '@/app/entities/cluster/model/use-cluster';
+import { Logger } from '@/app/shared/lib/logger';
+import { ROUTE_TIMEOUT_MS, UPSTREAM_TIMEOUT_MS } from '@/app/shared/lib/timeouts';
+
+import { ERROR_RETRY_COUNT, useSlotTime } from '../use-slot-time';
+
+const MAINNET_URL = 'https://api.mainnet-beta.solana.com';
+const TESTNET_URL = 'https://api.testnet.solana.com';
+const LOCAL_URL = 'http://localhost:8899';
+const CUSTOM_URL = 'https://my-node.test';
+
+/** Long enough to cover every backoff step the configured retry interval produces. */
+const RETRY_SETTLE_MS = 50;
+
+/** `SWRConfig` takes the cache provider too, which `SWRConfiguration` alone does not name. */
+type SwrOverrides = SWRConfiguration & { provider?: () => Map<unknown, unknown> };
+
+const mocks = vi.hoisted(() => ({
+    cluster: {} as ClusterContext,
+    getRecentPerformanceSamples: vi.fn(),
+    getRpc: vi.fn(),
+}));
+
+type ClusterContext = ReturnType<typeof useCluster>;
+
+// `shouldUseDirectRpc` stays real: which endpoint gets asked is the decision under test.
+vi.mock('@entities/cluster/@x/slot-time', async () => {
+    const { shouldUseDirectRpc } = await vi.importActual<
+        typeof import('@/app/entities/cluster/lib/should-use-direct-rpc')
+    >('@/app/entities/cluster/lib/should-use-direct-rpc');
+    return { getRpc: mocks.getRpc, shouldUseDirectRpc, useCluster: () => mocks.cluster };
+});
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+describe('useSlotTime', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.cluster = clusterContext({ cluster: Cluster.MainnetBeta, connectableUrl: MAINNET_URL, url: MAINNET_URL });
+        fetchMock.mockResolvedValue(routeResponse(314));
+        mocks.getRpc.mockReturnValue({ getRecentPerformanceSamples: mocks.getRecentPerformanceSamples });
+        mocks.getRecentPerformanceSamples.mockReturnValue({
+            send: () => Promise.resolve([{ numSlots: 300n, samplePeriodSecs: 60 }]),
+        });
+    });
+
+    it('should report nothing before the request resolves', () => {
+        fetchMock.mockReturnValue(new Promise(() => {}));
+
+        expect(renderSlotTime().result.current).toBeUndefined();
+    });
+
+    it('should report the rate the route measured', async () => {
+        const { result } = renderSlotTime();
+
+        await waitFor(() => expect(result.current).toBe(314));
+    });
+
+    it('should ask the route for the active cluster', async () => {
+        renderSlotTime();
+
+        await waitFor(() =>
+            expect(fetchMock).toHaveBeenCalledWith(
+                `/api/slot-time?cluster=${Cluster.MainnetBeta}`,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            ),
+        );
+    });
+
+    // The value, not just the presence: this deadline has to outlast the route's own, or a cold start
+    // turns a classified answer into an abort.
+    it('should wait on the route for longer than the route waits on the node', async () => {
+        const timeout = vi.spyOn(AbortSignal, 'timeout');
+
+        renderSlotTime();
+
+        await waitFor(() => expect(timeout).toHaveBeenCalledWith(ROUTE_TIMEOUT_MS));
+    });
+
+    it.each([
+        ['a custom cluster, which the route refuses to resolve', Cluster.Custom, CUSTOM_URL],
+        ['a known cluster pointed at a local validator, which the server cannot reach', Cluster.Devnet, LOCAL_URL],
+    ])('should ask the endpoint directly on %s', async (_reason, cluster, url) => {
+        mocks.cluster = clusterContext({ cluster, connectableUrl: url, url });
+
+        const { result } = renderSlotTime();
+
+        await waitFor(() => expect(result.current).toBe(200));
+        expect(mocks.getRpc).toHaveBeenCalledWith(url);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // A connection that is accepted and never answered would otherwise leave the countdown absent with
+    // nothing waiting on it.
+    it('should bound the wait at the visitor’s own node too', async () => {
+        mocks.cluster = clusterContext({ cluster: Cluster.Custom, connectableUrl: CUSTOM_URL, url: CUSTOM_URL });
+        const send = vi.fn(() => Promise.resolve([{ numSlots: 300n, samplePeriodSecs: 60 }]));
+        mocks.getRecentPerformanceSamples.mockReturnValue({ send });
+        const timeout = vi.spyOn(AbortSignal, 'timeout');
+
+        const { result } = renderSlotTime();
+
+        await waitFor(() => expect(result.current).toBe(200));
+        expect(send).toHaveBeenCalledWith({ abortSignal: expect.any(AbortSignal) });
+        expect(timeout).toHaveBeenCalledWith(UPSTREAM_TIMEOUT_MS);
+    });
+
+    // Covers a URL held for consent and one not yet judged alike: both leave `url` on the fallback, so
+    // only `connectableUrl` can gate the request.
+    it('should ask nothing until the endpoint is one the visitor agreed to', async () => {
+        mocks.cluster = clusterContext({ cluster: Cluster.Custom, connectableUrl: undefined, url: LOCAL_URL });
+
+        const { result } = renderSlotTime();
+
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+        expect(result.current).toBeUndefined();
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(mocks.getRpc).not.toHaveBeenCalled();
+    });
+
+    // A caller that renders no duration would otherwise reach the visitor's own node for nothing.
+    it('should ask nothing when the caller has deferred the request', async () => {
+        mocks.cluster = clusterContext({ cluster: Cluster.Custom, connectableUrl: CUSTOM_URL, url: CUSTOM_URL });
+
+        const { result } = renderHook(() => useSlotTime({ enabled: false }), { wrapper: swrWrapper() });
+
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+        expect(result.current).toBeUndefined();
+        expect(mocks.getRpc).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // One cluster's rate against another's epoch is off by up to a factor of two, which is the whole bug.
+    it('should drop the previous cluster rate when the cluster changes', async () => {
+        const { rerender, result } = renderSlotTime();
+        await waitFor(() => expect(result.current).toBe(314));
+
+        fetchMock.mockReturnValue(new Promise(() => {}));
+        mocks.cluster = clusterContext({ cluster: Cluster.Testnet, connectableUrl: TESTNET_URL, url: TESTNET_URL });
+        rerender();
+
+        expect(result.current).toBeUndefined();
+        await waitFor(() =>
+            expect(fetchMock).toHaveBeenCalledWith(`/api/slot-time?cluster=${Cluster.Testnet}`, expect.anything()),
+        );
+    });
+
+    // A known cluster repointed at a local validator keeps the same cluster, so only the endpoint in the
+    // key can tell the two requests apart.
+    it('should ask again when only the endpoint changes', async () => {
+        const { rerender, result } = renderSlotTime();
+        await waitFor(() => expect(result.current).toBe(314));
+
+        mocks.cluster = clusterContext({ cluster: Cluster.MainnetBeta, connectableUrl: LOCAL_URL, url: LOCAL_URL });
+        rerender();
+
+        await waitFor(() => expect(mocks.getRpc).toHaveBeenCalledWith(LOCAL_URL));
+    });
+
+    it.each([
+        ['the route fails', () => fetchMock.mockResolvedValue({ ok: false, status: 503 } as Response)],
+        [
+            'the route answers with a body it cannot trust',
+            () => fetchMock.mockResolvedValue(untrustedResponse(() => Promise.resolve({ msPerSlot: 'fast' }))),
+        ],
+    ])('should report nothing when %s, rather than a rate nothing measured', async (_reason, arrange) => {
+        arrange();
+
+        const { result } = renderSlotTime();
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    // The route stays quiet about a refusal, because any caller can provoke one. This client sends a
+    // single fixed request, so a refusal reaching it means our own bug or a deploy that left it behind —
+    // and nothing else anywhere would say so.
+    it('should report a refusal the route deliberately did not', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 400 } as Response);
+
+        renderSlotTime();
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                sentry: true,
+                sentryExtras: expect.objectContaining({ cluster: Cluster.MainnetBeta, status: 400 }),
+            }),
+        );
+        // The bot gate ahead of the route refuses visitors it misjudges, and this fires once per visitor
+        // with no CDN in front of it: one gate misfiring must not set the error rate on its own.
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    // It will refuse the next attempt identically, and every repeat would report it again.
+    it('should not retry a refusal, nor report it more than once', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 400 } as Response);
+
+        renderSlotTime({ dedupingInterval: 0 });
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(Logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    // The route counted this one answered, so nothing on its side could have said otherwise. The parse
+    // failure goes with it: it is what separates an intermediary's reply from a payload the two sides
+    // disagree on, and the status is 200 for both.
+    it('should report a body the route could not have known was unreadable', async () => {
+        fetchMock.mockResolvedValue(untrustedResponse(() => Promise.resolve({ msPerSlot: 'fast' })));
+
+        renderSlotTime();
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                sentry: true,
+                sentryExtras: expect.objectContaining({
+                    cluster: Cluster.MainnetBeta,
+                    parseError: expect.any(String),
+                }),
+            }),
+        );
+        // A captive portal or an interstitial proxy answers for the route this way, once per visitor with
+        // no CDN in front of it: someone else's middlebox must not set the error rate.
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    // Asking again cannot change a body's shape. Covers a body that parses but states no rate and one
+    // that is not JSON at all: only the second rejects on the way in, and both must land the same way.
+    it.each([
+        ['a body that states no rate', () => Promise.resolve({ msPerSlot: 'fast' })],
+        ['a body that is not JSON at all', () => Promise.reject(new SyntaxError('Unexpected token <'))],
+    ])('should not retry %s, nor report it more than once', async (_reason, json) => {
+        fetchMock.mockResolvedValue(untrustedResponse(json));
+
+        renderSlotTime({ dedupingInterval: 0 });
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(Logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    // The route recorded these itself; repeating them per visitor turns one outage into a flood.
+    it.each([
+        ['a node the route could not reach', 502],
+        ['a cluster the route has no endpoint for', 500],
+    ])('should not report %s, which the route already logged', async (_reason, status) => {
+        fetchMock.mockResolvedValue({ ok: false, status } as Response);
+
+        renderSlotTime();
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    // Not the route's own answer: a rate limit comes from whatever stands in front of it and clears on
+    // its own. It is nobody's bug, and one throttled region would otherwise report once per visitor.
+    it('should retry a rate limit without reporting it', async () => {
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 429 } as Response);
+
+        const { result } = renderSlotTime();
+
+        await waitFor(() => expect(result.current).toBe(314));
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    // A tab may sit open for hours; uncapped, the route is asked forever, once per interval, per tab.
+    it('should stop retrying a failure that keeps repeating', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 503 } as Response);
+
+        renderSlotTime({ dedupingInterval: 0 });
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(fetchMock).toHaveBeenCalledTimes(ERROR_RETRY_COUNT + 1);
+    });
+
+    it("should not retry at the visitor's own node", async () => {
+        mocks.cluster = clusterContext({ cluster: Cluster.Custom, connectableUrl: CUSTOM_URL, url: CUSTOM_URL });
+        mocks.getRecentPerformanceSamples.mockReturnValue({ send: () => Promise.reject(new Error('rpc down')) });
+
+        const { result } = renderSlotTime({ dedupingInterval: 0 });
+        await new Promise(resolve => setTimeout(resolve, RETRY_SETTLE_MS));
+
+        expect(result.current).toBeUndefined();
+        expect(mocks.getRecentPerformanceSamples).toHaveBeenCalledTimes(1);
+    });
+});
+
+function renderSlotTime(overrides: SwrOverrides = {}) {
+    return renderHook(() => useSlotTime(), { wrapper: swrWrapper(overrides) });
+}
+
+/** A cache per test, so one test's pending promise cannot satisfy the next. Retries stay fast. */
+function swrWrapper(overrides: SwrOverrides = {}) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <SWRConfig value={{ errorRetryInterval: 1, provider: () => new Map(), ...overrides }}>{children}</SWRConfig>
+        );
+    };
+}
+
+// The real return type, not a hand-written stand-in: a weaker one lets the hook read a field the
+// provider no longer publishes, and types the endpoint as the plain string the brand exists to refuse.
+function clusterContext({
+    cluster,
+    connectableUrl,
+    url,
+}: {
+    cluster: Cluster;
+    connectableUrl: string | undefined;
+    url: string;
+}): ClusterContext {
+    const selection = clusterSelection(cluster, url);
+    return {
+        ...selection,
+        connectableUrl: connectableUrl === undefined ? undefined : toConnectableUrl(connectableUrl),
+        name: clusterName(cluster),
+        selection,
+        // Connecting on purpose: the rate must not wait on the cluster health check.
+        status: ClusterStatus.Connecting,
+        url,
+    };
+}
+
+function routeResponse(msPerSlot: number): Response {
+    return { json: () => Promise.resolve({ msPerSlot }), ok: true } as Response;
+}
+
+/** A 200 whose body the client cannot read, either because it parses to the wrong shape or not at all. */
+function untrustedResponse(json: () => Promise<unknown>): Response {
+    return { json, ok: true } as Response;
+}

--- a/app/entities/slot-time/model/use-slot-time.ts
+++ b/app/entities/slot-time/model/use-slot-time.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { type ConnectableUrl, shouldUseDirectRpc, useCluster } from '@entities/cluster/@x/slot-time';
+import { type Cluster } from '@utils/cluster';
+import useSWR from 'swr';
+
+import { fetchSlotTimeFromRoute, fetchSlotTimeFromRpc, isRetryableSlotTimeError } from '../api/fetch-slot-time';
+
+// Capped, because an endpoint that has failed this often will not answer on the next try either.
+export const ERROR_RETRY_COUNT = 3;
+
+/**
+ * Measured milliseconds per slot on the active cluster, or `undefined` until one is in hand.
+ *
+ * Undefined while loading and after a failure alike: a caller estimating a duration from slots has
+ * nothing honest to fall back on. Every cluster steps its own way through the SIMD-0525 gates, so a
+ * constant is wrong on some cluster whatever it is set to.
+ *
+ * `enabled: false` defers the request, for a caller that already knows it will render no duration —
+ * on a custom cluster that request would reach the visitor's own node for nothing.
+ */
+export function useSlotTime({ enabled = true }: { enabled?: boolean } = {}): number | undefined {
+    const { cluster, connectableUrl } = useCluster();
+
+    const direct = connectableUrl !== undefined && shouldUseDirectRpc(cluster, connectableUrl);
+
+    // A falsy key waits, which is what an unsettled custom URL should do. The endpoint belongs in the
+    // key because a known cluster can still point somewhere local.
+    const { data } = useSWR(
+        enabled && connectableUrl && (['slot-time', cluster, connectableUrl] as const),
+        ([, keyCluster, endpoint]: readonly ['slot-time', Cluster, ConnectableUrl]) =>
+            shouldUseDirectRpc(keyCluster, endpoint)
+                ? fetchSlotTimeFromRpc(endpoint)
+                : fetchSlotTimeFromRoute(keyCluster),
+        {
+            errorRetryCount: ERROR_RETRY_COUNT,
+            // Refreshing costs nothing behind the cache. A visitor's own node answers every time it is
+            // asked, and the rate it reports moves only when a feature gate activates.
+            revalidateIfStale: !direct,
+            revalidateOnFocus: !direct,
+            revalidateOnReconnect: !direct,
+            // Never at the visitor's own node, and elsewhere only what could answer differently: a
+            // refusal repeats, and every repeat would report it again.
+            shouldRetryOnError: direct ? false : isRetryableSlotTimeError,
+        },
+    );
+
+    return data;
+}

--- a/app/entities/slot-time/server.ts
+++ b/app/entities/slot-time/server.ts
@@ -1,0 +1,1 @@
+export { MEASURED_SAMPLES, toSlotTimePayload } from './lib/slot-time';

--- a/app/features/feature-gate/__tests__/epoch-countdown.spec.ts
+++ b/app/features/feature-gate/__tests__/epoch-countdown.spec.ts
@@ -1,13 +1,14 @@
 import { estimateTimeUntilEpoch } from '../lib/epoch-countdown';
 
 const SLOTS_PER_EPOCH = 432_000n;
-const MS_PER_SLOT = 400;
+// The rate every countdown used before it was measured per cluster.
+const LEGACY_MS_PER_SLOT = 400;
 
 describe('estimateTimeUntilEpoch', () => {
     it('should return undefined when the target epoch has already passed', () => {
         const result = estimateTimeUntilEpoch({
             currentEpoch: 800n,
-            msPerSlot: MS_PER_SLOT,
+            msPerSlot: LEGACY_MS_PER_SLOT,
             slotIndex: 0n,
             slotsInEpoch: SLOTS_PER_EPOCH,
             slotsPerEpoch: SLOTS_PER_EPOCH,
@@ -20,7 +21,7 @@ describe('estimateTimeUntilEpoch', () => {
     it('should return undefined when the target epoch equals the current epoch', () => {
         const result = estimateTimeUntilEpoch({
             currentEpoch: 800n,
-            msPerSlot: MS_PER_SLOT,
+            msPerSlot: LEGACY_MS_PER_SLOT,
             slotIndex: 100n,
             slotsInEpoch: SLOTS_PER_EPOCH,
             slotsPerEpoch: SLOTS_PER_EPOCH,
@@ -34,7 +35,7 @@ describe('estimateTimeUntilEpoch', () => {
         // 1000 slots remain in the current epoch → 1000 * 400 ms = 400 000 ms = 6m 40s
         const result = estimateTimeUntilEpoch({
             currentEpoch: 800n,
-            msPerSlot: MS_PER_SLOT,
+            msPerSlot: LEGACY_MS_PER_SLOT,
             slotIndex: SLOTS_PER_EPOCH - 1000n,
             slotsInEpoch: SLOTS_PER_EPOCH,
             slotsPerEpoch: SLOTS_PER_EPOCH,
@@ -44,13 +45,28 @@ describe('estimateTimeUntilEpoch', () => {
         expect(result).toBe('6m 40s');
     });
 
+    // The rate is the caller's to measure: clusters ran anywhere from 166 ms to 314 ms a slot as
+    // SIMD-0525 stepped through them, and the same slot count has to read differently at each.
+    it('should scale the estimate by the rate it is given', () => {
+        const input = {
+            currentEpoch: 800n,
+            slotIndex: SLOTS_PER_EPOCH - 1000n,
+            slotsInEpoch: SLOTS_PER_EPOCH,
+            slotsPerEpoch: SLOTS_PER_EPOCH,
+            targetEpoch: 801,
+        };
+
+        expect(estimateTimeUntilEpoch({ ...input, msPerSlot: 200 })).toBe('3m 20s');
+        expect(estimateTimeUntilEpoch({ ...input, msPerSlot: LEGACY_MS_PER_SLOT })).toBe('6m 40s');
+    });
+
     it('should add full future epochs when target is several epochs away', () => {
         // current: 0 slots in → 432 000 slots left this epoch.
         // 2 full future epochs before target → 2 * 432 000 = 864 000 slots.
         // total: 1 296 000 slots * 400 ms = 518 400 000 ms = 6 days.
         const result = estimateTimeUntilEpoch({
             currentEpoch: 800n,
-            msPerSlot: MS_PER_SLOT,
+            msPerSlot: LEGACY_MS_PER_SLOT,
             slotIndex: 0n,
             slotsInEpoch: SLOTS_PER_EPOCH,
             slotsPerEpoch: SLOTS_PER_EPOCH,

--- a/app/features/feature-gate/lib/epoch-countdown.ts
+++ b/app/features/feature-gate/lib/epoch-countdown.ts
@@ -1,4 +1,4 @@
-import { MS_PER_SLOT, slotsToHumanString } from '@/app/utils';
+import { slotsToHumanString } from '@/app/utils';
 
 type EpochCountdownInput = {
     targetEpoch: number;
@@ -6,7 +6,7 @@ type EpochCountdownInput = {
     slotIndex: bigint;
     slotsInEpoch: bigint;
     slotsPerEpoch: bigint;
-    msPerSlot?: number;
+    msPerSlot: number;
 };
 
 /**
@@ -15,7 +15,7 @@ type EpochCountdownInput = {
  * the future (already activated or activating in the current epoch).
  */
 export function estimateTimeUntilEpoch(input: EpochCountdownInput): string | undefined {
-    const { targetEpoch, currentEpoch, slotIndex, slotsInEpoch, slotsPerEpoch, msPerSlot = MS_PER_SLOT } = input;
+    const { targetEpoch, currentEpoch, slotIndex, slotsInEpoch, slotsPerEpoch, msPerSlot } = input;
 
     const target = BigInt(targetEpoch);
     if (target <= currentEpoch) return undefined;

--- a/app/features/feature-gate/ui/FeatureGatesView.tsx
+++ b/app/features/feature-gate/ui/FeatureGatesView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSlotTime } from '@entities/slot-time';
 import Link from 'next/link';
 import React, { useMemo, useState } from 'react';
 
@@ -20,16 +21,21 @@ import { EmptyStateCard, FeatureGateTable } from './FeatureGateTable';
 
 type TabValue = 'activated' | 'upcoming';
 
-type EpochScheduleInfo = {
+/** Everything a countdown needs but the target epoch. Absent until the whole set is in hand. */
+type CountdownInput = {
     currentEpoch: bigint;
     slotIndex: bigint;
     slotsInEpoch: bigint;
     slotsPerEpoch: bigint;
+    msPerSlot: number;
 };
 
 export function FeatureGatesView() {
     const { cluster } = useCluster();
     const clusterInfo = useClusterInfo();
+    // A custom cluster gets no table below, so its rate would be measured at the visitor's own node for
+    // a countdown nothing renders.
+    const msPerSlot = useSlotTime({ enabled: cluster !== Cluster.Custom });
     const { activated, upcoming } = useMemo(() => partitionFeatures(cluster), [cluster]);
     const [tab, setTab] = useState<TabValue>('activated');
 
@@ -49,14 +55,16 @@ export function FeatureGatesView() {
         );
     }
 
-    const epochScheduleInfo: EpochScheduleInfo | undefined = clusterInfo
-        ? {
-              currentEpoch: clusterInfo.epochInfo.epoch,
-              slotIndex: clusterInfo.epochInfo.slotIndex,
-              slotsInEpoch: clusterInfo.epochInfo.slotsInEpoch,
-              slotsPerEpoch: clusterInfo.epochSchedule.slotsPerEpoch,
-          }
-        : undefined;
+    const countdownInput: CountdownInput | undefined =
+        clusterInfo && msPerSlot !== undefined
+            ? {
+                  currentEpoch: clusterInfo.epochInfo.epoch,
+                  msPerSlot,
+                  slotIndex: clusterInfo.epochInfo.slotIndex,
+                  slotsInEpoch: clusterInfo.epochInfo.slotsInEpoch,
+                  slotsPerEpoch: clusterInfo.epochSchedule.slotsPerEpoch,
+              }
+            : undefined;
 
     return (
         <div className="mx-auto max-w-screen-xl px-4 py-4">
@@ -91,7 +99,7 @@ export function FeatureGatesView() {
                                 <ActivationCell
                                     cluster={cluster}
                                     epoch={feature.clusterActivationEpoch}
-                                    epochScheduleInfo={epochScheduleInfo}
+                                    countdownInput={countdownInput}
                                 />
                             ),
                         }}
@@ -123,15 +131,13 @@ export function FeatureGatesView() {
 function ActivationCell({
     cluster,
     epoch,
-    epochScheduleInfo,
+    countdownInput,
 }: {
     cluster: Cluster;
     epoch: number;
-    epochScheduleInfo: EpochScheduleInfo | undefined;
+    countdownInput: CountdownInput | undefined;
 }) {
-    const countdown = epochScheduleInfo
-        ? estimateTimeUntilEpoch({ ...epochScheduleInfo, targetEpoch: epoch })
-        : undefined;
+    const countdown = countdownInput ? estimateTimeUntilEpoch({ ...countdownInput, targetEpoch: epoch }) : undefined;
     return (
         <>
             <Link

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -5,11 +5,6 @@ import { HumanizeDuration, HumanizeDurationLanguage } from 'humanize-duration-ts
 export const LAMPORTS_PER_SOL = 1_000_000_000;
 export const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000;
 
-export const NUM_TICKS_PER_SECOND = 160;
-export const DEFAULT_TICKS_PER_SLOT = 64;
-export const NUM_SLOTS_PER_SECOND = NUM_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT;
-export const MS_PER_SLOT = 1000 / NUM_SLOTS_PER_SECOND;
-
 export const INNER_INSTRUCTIONS_START_SLOT = 46915769;
 
 export type SignatureProps = {
@@ -87,7 +82,8 @@ HUMANIZER.addLanguage('short', {
     y: () => 'y',
 });
 
-export function slotsToHumanString(slots: number, slotTime = MS_PER_SLOT): string {
+/** `slotTime` has no default: clusters run at different rates, and only measurement gives the rate. */
+export function slotsToHumanString(slots: number, slotTime: number): string {
     return HUMANIZER.humanize(slots * slotTime);
 }
 

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -39,6 +39,7 @@
 | Dynamic | `/api/ping/[network]` | — | — |
 | Dynamic | `/api/search` | — | — |
 | Dynamic | `/api/security-txt` | — | — |
+| Dynamic | `/api/slot-time` | — | — |
 | Dynamic | `/api/sns-domains/[address]` | — | — |
 | Dynamic | `/api/stake-rewards/[address]` | — | — |
 | Dynamic | `/api/supply` | — | — |


### PR DESCRIPTION
## Description

Feature gate countdowns estimated every duration at 400 ms a slot — the rate before SIMD-0525. Each cluster now steps through that ladder independently, so the figure was wrong on all three and off by roughly a factor of two on testnet.

Measured on 2026-09-02: testnet **190 ms**, devnet **166 ms**, mainnet **314 ms** a slot (`getRecentPerformanceSamples`, cross-checked against block timestamps 50 000 slots apart — the two agree within 1%). A pending feature on testnet read `~4h 18m remaining` at 400 ms where the cluster was 1h 46m away from the next epoch.

The rate is read through a new CDN-cached `GET /api/slot-time?cluster=<n>`, with a direct RPC path for endpoints the server cannot reach (a custom URL, or a known cluster pointed at a local validator). A new `slot-time` entity owns the wire contract, the fetchers and `useSlotTime()`.

**Why measured, and not the gate's own value.** Two reasons a reviewer will want:

1. The nominal value is a target the clusters run under, not the rate. Devnet ran 166 ms with the 200 ms gate active; mainnet 314 ms with the 300 ms gate.
2. `feature-gates.json` trails the chain. At the time of writing it was two weeks behind: devnet's 200 ms gate and mainnet's 300 ms gate were activated on chain and still `null` in the file.

**No rate, no estimate.** A countdown renders only once a measured figure is in hand — a constant is wrong on some cluster whatever it is set to, and the epoch link beside it still carries the useful information. `MS_PER_SLOT` and the tick constants it derived from are removed, and `slotsToHumanString` now takes a required rate, so no caller can inherit 400 ms unnoticed.

The request is made where a duration is about to render: the account card asks only for a pending feature, and the feature gates page defers it on a custom cluster, which shows no table.

## Type of change

-   [x] Bug fix

## Testing

Manual testing on the preview deployment:

- [Pending feature on testnet — the countdown, at ~190 ms a slot rather than 400](https://explorer-lkietb8vu-solana-foundation.vercel.app/address/txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL?cluster=testnet)
- [Pending feature on mainnet — the same line at ~314 ms a slot](https://explorer-lkietb8vu-solana-foundation.vercel.app/address/BY4JhHLahVzS9ynfDz4exzGPbVXhFmJvEyMWsXbDBqME)
- [Activated feature — epoch link, no countdown and no slot-time request](https://explorer-lkietb8vu-solana-foundation.vercel.app/address/iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW?cluster=testnet)
- [Feature gates page on testnet — every target epoch is in the past, so no countdown renders](https://explorer-lkietb8vu-solana-foundation.vercel.app/feature-gates?cluster=testnet)
- [The route itself, testnet](https://explorer-lkietb8vu-solana-foundation.vercel.app/api/slot-time?cluster=1) · [mainnet](https://explorer-lkietb8vu-solana-foundation.vercel.app/api/slot-time?cluster=0) · [devnet](https://explorer-lkietb8vu-solana-foundation.vercel.app/api/slot-time?cluster=2)

A countdown shows only while a feature is pending activation, so if one of the first two pages shows just an epoch link, that feature activated in the meantime.

## Related Issues

Closes [HOO-1412](https://linear.app/solana-fndn/issue/HOO-1412/account-for-200ms-slot-times-in-feature-gate-timer)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

The feature gates page renders no countdown today: no feature in `feature-gates.json` currently has an activation epoch above the current one, so every row's target is in the past. The line appears when the cron lands a scheduled one. The account card is where the change is visible now, and only while a feature is pending.

A feature that is already activated makes no slot-time request at all.

