### PR TITLE
feat(MCP/telemetry): mcp ga4 session params

### DIFF
--- a/packages/entity-inspector/TELEMETRY.md
+++ b/packages/entity-inspector/TELEMETRY.md
@@ -19,8 +19,9 @@ For where to obtain the Measurement ID and generate the API secret, see
 
 ## `client_id`
 
-Required on every request: `measurement_id` and `api_secret` go in the URL, `client_id` in the JSON body — all three
-sent by [`src/telemetry/providers/ga4.ts`](./src/telemetry/providers/ga4.ts). The host app supplies it as
+Required on every request: `measurement_id` and `api_secret` go in the URL, `client_id` in the JSON body, and
+`session_id` + `engagement_time_msec` in every event's params (next section) — all sent by
+[`src/telemetry/providers/ga4.ts`](./src/telemetry/providers/ga4.ts). The host app supplies `client_id` as
 `context.clientId`; this repo resolves it in `app/mcp/telemetry.ts`:
 
 | Source                             | Value sent                 |
@@ -38,6 +39,20 @@ Three limits to read reports against. GA4 counts users by `client_id`, so a call
 address" — NAT collapses several callers into one, a rotating IP fans one caller into several. Every caller on the
 `anon` branch collapses into a single GA4 user. And an unsalted SHA-256 over the 2³² IPv4 space is enumerable, so a
 hashed IP is pseudonymous, not anonymous. Event counts are the trustworthy figure; user counts are indicative.
+
+## `session_id` and `engagement_time_msec`
+
+Without both, GA4 shows Measurement Protocol events in Realtime but excludes them from processed reports — the event
+names never even appear in report filters or custom-definition pickers. Neither needs a custom definition: GA4 treats
+them as reserved parameters.
+
+`session_id` is derived in [`src/telemetry/providers/ga4.ts`](./src/telemetry/providers/ga4.ts) as FNV-1a over
+`client_id`: one long-lived GA4 session per client, deliberately not time-boxed. The `client_id` collapse/fan-out limits
+above therefore apply to session counts identically — sessions are not a meaningful figure here; event counts are.
+
+`engagement_time_msec` is a constant `1` — the minimum positive value (GA4 counts Active Users on nonzero engagement
+time, so `0` would zero out user-based reports). It deliberately makes no engagement claim: GA4's built-in _Average
+engagement time_ is meaningless on this property; latency questions are answered by the `duration_ms` custom metric.
 
 ## Events
 

--- a/packages/entity-inspector/src/telemetry/providers/__tests__/ga4.spec.ts
+++ b/packages/entity-inspector/src/telemetry/providers/__tests__/ga4.spec.ts
@@ -6,14 +6,24 @@ const OPTIONS = { apiSecret: 'secret&value', measurementId: 'G-TEST123' };
 const EVENT = { name: 'mcp_tool_call', params: { status: 'success', tool: 'ping' } };
 const CONTEXT = { clientId: 'client-1' };
 
+function stubFetch() {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+function sentParams(fetchMock: ReturnType<typeof vi.fn>, callIndex = 0) {
+    const [, init] = fetchMock.mock.calls[callIndex];
+    return JSON.parse(init.body).events[0].params;
+}
+
 describe('createGa4Provider', () => {
     afterEach(() => {
         vi.unstubAllGlobals();
     });
 
     it('should post the event to the Measurement Protocol collect endpoint', async () => {
-        const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
-        vi.stubGlobal('fetch', fetchMock);
+        const fetchMock = stubFetch();
         const provider = createGa4Provider(OPTIONS);
 
         await provider.send(EVENT, CONTEXT);
@@ -27,8 +37,62 @@ describe('createGa4Provider', () => {
         expect(init.headers).toEqual({ 'content-type': 'application/json' });
         expect(JSON.parse(init.body)).toEqual({
             client_id: 'client-1',
-            events: [{ name: 'mcp_tool_call', params: { status: 'success', tool: 'ping' } }],
+            events: [
+                {
+                    name: 'mcp_tool_call',
+                    params: {
+                        engagement_time_msec: 1,
+                        // FNV-1a of 'client-1' — pins that session_id stays a GA4-friendly decimal string.
+                        session_id: '3136858344',
+                        status: 'success',
+                        tool: 'ping',
+                    },
+                },
+            ],
         });
+    });
+
+    it('should send a constant engagement_time_msec of 1 and leave duration_ms untouched', async () => {
+        const fetchMock = stubFetch();
+        const provider = createGa4Provider(OPTIONS);
+
+        await provider.send({ name: 'mcp_tool_call', params: { duration_ms: 250, tool: 'ping' } }, CONTEXT);
+
+        expect(sentParams(fetchMock)).toEqual({
+            duration_ms: 250,
+            engagement_time_msec: 1,
+            session_id: '3136858344',
+            tool: 'ping',
+        });
+    });
+
+    it('should override caller-supplied session_id and engagement_time_msec with derived values', async () => {
+        const fetchMock = stubFetch();
+        const provider = createGa4Provider(OPTIONS);
+
+        await provider.send(
+            { name: 'mcp_tool_call', params: { engagement_time_msec: 999, session_id: 'caller', tool: 'ping' } },
+            CONTEXT,
+        );
+
+        expect(sentParams(fetchMock)).toEqual({
+            engagement_time_msec: 1,
+            session_id: '3136858344',
+            tool: 'ping',
+        });
+    });
+
+    it('should derive a session_id that is stable per client id and distinct across client ids', async () => {
+        const fetchMock = stubFetch();
+        const provider = createGa4Provider(OPTIONS);
+
+        await provider.send(EVENT, { clientId: 'client-1' });
+        await provider.send(EVENT, { clientId: 'client-1' });
+        await provider.send(EVENT, { clientId: 'client-2' });
+
+        const [first, second, third] = [0, 1, 2].map(index => sentParams(fetchMock, index).session_id);
+        expect(first).toBe(second);
+        expect(third).not.toBe(first);
     });
 
     it('should reject when the collect endpoint responds with a non-ok status', async () => {

--- a/packages/entity-inspector/src/telemetry/providers/ga4.ts
+++ b/packages/entity-inspector/src/telemetry/providers/ga4.ts
@@ -7,17 +7,38 @@ export type Ga4ProviderOptions = {
     apiSecret: string;
 };
 
-/** GA4 Measurement Protocol provider — `context.clientId` becomes the GA4 `client_id`. */
+// FNV-1a; GA4 needs a numeric-looking session_id and the client id is already pseudonymous, so a cheap stable hash suffices.
+function deriveSessionId(clientId: string): string {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < clientId.length; index += 1) {
+        hash ^= clientId.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return String(hash >>> 0);
+}
+
+/** GA4 Measurement Protocol provider — `context.clientId` becomes the GA4 `client_id`; injects `session_id` and `engagement_time_msec` into event params, overriding caller-supplied values. */
 export function createGa4Provider(options: Ga4ProviderOptions): TelemetryProvider {
     const query = new URLSearchParams({ api_secret: options.apiSecret, measurement_id: options.measurementId });
     const url = `${GA4_COLLECT_ENDPOINT}?${query.toString()}`;
     return {
         name: 'ga4',
         async send(event, context) {
+            // Without session_id + engagement_time_msec GA4 keeps MP events in Realtime only and drops them from processed reports.
             const response = await fetch(url, {
                 body: JSON.stringify({
                     client_id: context.clientId,
-                    events: [{ name: event.name, params: event.params }],
+                    events: [
+                        {
+                            name: event.name,
+                            params: {
+                                ...event.params,
+                                // Minimum positive value — no engagement claim; latency lives in the duration_ms metric.
+                                engagement_time_msec: 1,
+                                session_id: deriveSessionId(context.clientId),
+                            },
+                        },
+                    ],
                 }),
                 headers: { 'content-type': 'application/json' },
                 method: 'POST',


### PR DESCRIPTION
## Description

`mcp_*` events have been visible in GA4's Realtime overview for a month but never appeared in Admin → Events, report filters, or custom-definition pickers. Those surfaces read *processed* data, and GA4 silently excludes Measurement Protocol events that carry no `session_id` / `engagement_time_msec` — the provider sent neither, so every event lived in Realtime only and was dropped at processing.

- The GA4 provider injects both params into every event; caller-supplied values are overridden (reserved keys, not payload).
- `session_id` is a stable string-to-number conversion of the already-pseudonymous `client_id` — a numeric id GA4 accepts, one long-lived session per MCP client, no cross-request state, nothing new reaches Google. Session counts are meaningless here; event counts are the figure to read.
- `engagement_time_msec` is a constant `1`: the minimum positive value, no engagement claim (`0` would zero out Active Users; latency stays in the `duration_ms` custom metric).
- `TELEMETRY.md` documents both next to the `client_id` gotchas so they don't get "cleaned up" later.

Events sent before this fix are unrecoverable — GA4 does not reprocess; reportable data starts at deploy.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix

## Screenshots

Not a UI change.

## Testing

- Tests-first: the spec was extended to expect both params and observed red (4 failures, fields missing), then turned green by the provider change.
- Full package gate passes: `pnpm --filter @explorer/entity-inspector test` (typecheck, 480 tests, 100% coverage, tree-shakeability, node-esm). New coverage pins the exact payload (hardcoded expected `session_id`, so the decimal-string contract and the derivation both fail loudly if touched), session stability per client id and distinctness across client ids, `duration_ms` passing through untouched, and that injected params win over caller-supplied conflicting keys — the regression that would silently restore the Realtime-only behavior.
- Live verification is only possible post-deploy: events keep appearing in Realtime immediately; the `mcp_*` names should register in Admin → Events and report filters within 24–48h of the first processed batch (they never did before this change).

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #<issue-number>, Addresses #<issue-number> -->
n/a

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   ~~[ ] I have run `build:info` script to update build information~~
-   [x] CI/CD checks pass on the PR
-   ~~[ ] Screenshots included — required for protocol screens, recommended for other UI changes~~
-   ~~[ ] For security-related features, I have included links to related information~~

## Additional Notes

GA4 treats both params as reserved — neither needs a custom-definition registration, and the six dimensions + `duration_ms` metric from `TELEMETRY.md` are unaffected. The engagement metrics built into GA4 (_Average engagement time_, engaged sessions) are meaningless on this property by design; read event counts and `duration_ms` instead.
