### PR TITLE
fix(cluster): keep getRpc callable from route handlers

### DIFF
--- a/app/api/ans-domains/[address]/route.ts
+++ b/app/api/ans-domains/[address]/route.ts
@@ -1,4 +1,4 @@
-import { fetchAnsDomains } from '@entities/domain/api/fetch-ans-domains';
+import { fetchAnsDomains } from '@entities/domain/server';
 import { PublicKey } from '@solana/web3.js';
 import { NextResponse } from 'next/server';
 

--- a/app/api/domain-info/[domain]/route.ts
+++ b/app/api/domain-info/[domain]/route.ts
@@ -1,4 +1,4 @@
-import { Domain, resolveDomain } from '@entities/domain';
+import { Domain, resolveDomain } from '@entities/domain/server';
 import { NextResponse } from 'next/server';
 import { is } from 'superstruct';
 

--- a/app/api/geo-location/route.ts
+++ b/app/api/geo-location/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { isGDPRCountry } from '@/app/entities/geo-location';
+import { isGDPRCountry } from '@/app/entities/geo-location/server';
 
 export async function GET(request: NextRequest) {
     const country = request.headers.get('x-vercel-ip-country');

--- a/app/api/idl-latest/route.ts
+++ b/app/api/idl-latest/route.ts
@@ -1,7 +1,7 @@
-import { getRpc, serverClusterUrlFromParam } from '@entities/cluster/server';
+import { serverClusterUrlFromParam } from '@entities/cluster/server';
 import { resolveProgramIdls } from '@entities/idl/server';
 import { isRetryableError } from '@shared/lib/errors';
-import { type Address, address } from '@solana/kit';
+import { type Address, address, createSolanaRpc } from '@solana/kit';
 import { NextResponse } from 'next/server';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -14,6 +14,8 @@ const CACHE_HEADERS = {
 
 // Resolve IDLs with a few retries. The RPC itself is reliable, but resolving a large IDL through the
 // server runtime occasionally premature-closes the response body; a fresh client per attempt clears it.
+// That is why this constructs its own client rather than taking the shared one from `getRpc` — reusing
+// the cached client would retry through the transport that just failed.
 async function resolveProgramIdlsWithRetry(
     url: string,
     programId: Address,
@@ -22,7 +24,7 @@ async function resolveProgramIdlsWithRetry(
     let lastError: unknown;
     for (let attempt = 0; attempt < attempts; attempt++) {
         try {
-            return await resolveProgramIdls(getRpc(url), programId);
+            return await resolveProgramIdls(createSolanaRpc(url), programId);
         } catch (error) {
             lastError = error;
             if (attempt < attempts - 1 && isRetryableError(error)) {

--- a/app/api/idl-latest/route.ts
+++ b/app/api/idl-latest/route.ts
@@ -1,7 +1,7 @@
-import { serverClusterUrlFromParam } from '@entities/cluster/server';
+import { getRpc, serverClusterUrlFromParam } from '@entities/cluster/server';
 import { resolveProgramIdls } from '@entities/idl/server';
 import { isRetryableError } from '@shared/lib/errors';
-import { type Address, address, createSolanaRpc } from '@solana/kit';
+import { type Address, address } from '@solana/kit';
 import { NextResponse } from 'next/server';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -22,7 +22,7 @@ async function resolveProgramIdlsWithRetry(
     let lastError: unknown;
     for (let attempt = 0; attempt < attempts; attempt++) {
         try {
-            return await resolveProgramIdls(createSolanaRpc(url), programId);
+            return await resolveProgramIdls(getRpc(url), programId);
         } catch (error) {
             lastError = error;
             if (attempt < attempts - 1 && isRetryableError(error)) {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -3,7 +3,7 @@ import { PUBLIC_KEY_LENGTH } from '@solana/web3.js';
 import { Cluster, clusterFromSlug, clusterSlug, type ServerCluster } from '@utils/cluster';
 import { NextResponse } from 'next/server';
 
-import { GENESIS_HASHES } from '@/app/entities/chain-id/lib/const';
+import { GENESIS_HASHES } from '@/app/entities/chain-id/server';
 import { resolveSearchTokens, SEARCH_CACHE_HEADERS } from '@/app/features/search/server';
 import { NO_STORE_HEADERS } from '@/app/shared/lib/http-utils';
 

--- a/app/api/security-txt/route.ts
+++ b/app/api/security-txt/route.ts
@@ -1,7 +1,7 @@
-import { serverClusterUrlFromParam } from '@entities/cluster/server';
+import { getRpc, serverClusterUrlFromParam } from '@entities/cluster/server';
 import { errors } from '@entities/program-metadata/server';
 import { isRetryableError } from '@shared/lib/errors';
-import { type Address, address, createSolanaRpc } from '@solana/kit';
+import { type Address, address } from '@solana/kit';
 import { fetchSecurityTxt, type SecurityTxtFields, type SecurityTxtSource } from '@solana/security-txt';
 import { NextResponse } from 'next/server';
 
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
     const context = { cluster: clusterProp, programAddress };
 
     try {
-        const rpc = createSolanaRpc(url);
+        const rpc = getRpc(url);
         let securityTxt: { type: SecurityTxtSource; fields: SecurityTxtFields } | undefined;
         // eslint-disable-next-line unicorn/no-null -- library API: null = canonical-only PMP lookup (no fndn fallback)
         const result = await fetchSecurityTxt(rpc, programId, { authority: null });

--- a/app/api/slot-time/route.ts
+++ b/app/api/slot-time/route.ts
@@ -1,10 +1,9 @@
-import { resolveServerClusterUrl } from '@entities/cluster/server';
+import { getRpc, resolveServerClusterUrl } from '@entities/cluster/server';
 import { MEASURED_SAMPLES, toSlotTimePayload } from '@entities/slot-time/server';
 import { isRetryableError, isRpcMisconfigError } from '@shared/lib/errors';
 import { ERROR_CACHE_HEADERS, isTimeoutError, NO_STORE_HEADERS } from '@shared/lib/http-utils';
 import { Logger } from '@shared/lib/logger';
 import { UPSTREAM_TIMEOUT_MS } from '@shared/lib/timeouts';
-import { createSolanaRpc } from '@solana/kit';
 import { NextResponse } from 'next/server';
 
 // The rate moves only when a slot-time feature gate activates, at an epoch boundary. A few minutes of
@@ -51,7 +50,7 @@ export async function GET(request: Request) {
     }
 
     try {
-        const rpc = createSolanaRpc(resolved.url);
+        const rpc = getRpc(resolved.url);
         const samples = await rpc
             .getRecentPerformanceSamples(MEASURED_SAMPLES)
             // A wedged node would otherwise hold the function open long past any useful answer.

--- a/app/api/sns-domains/[address]/route.ts
+++ b/app/api/sns-domains/[address]/route.ts
@@ -1,4 +1,4 @@
-import { fetchSnsDomains } from '@entities/domain/api/fetch-sns-domains';
+import { fetchSnsDomains } from '@entities/domain/server';
 import { PublicKey } from '@solana/web3.js';
 import { NextResponse } from 'next/server';
 

--- a/app/api/supply/route.ts
+++ b/app/api/supply/route.ts
@@ -1,6 +1,5 @@
-import { resolveServerClusterUrl } from '@entities/cluster/server';
+import { getRpc, resolveServerClusterUrl } from '@entities/cluster/server';
 import { isRetryableError, isRpcMisconfigError } from '@shared/lib/errors';
-import { createSolanaRpc } from '@solana/kit';
 import { NextResponse } from 'next/server';
 
 import { toSupplyPayload } from '@/app/features/supply/server';
@@ -52,7 +51,7 @@ export async function GET(request: Request) {
     }
 
     try {
-        const rpc = createSolanaRpc(resolved.url);
+        const rpc = getRpc(resolved.url);
         // A wedged node would otherwise hold the function open long past any useful answer.
         const { value } = await rpc
             .getSupply({ commitment: 'finalized', excludeNonCirculatingAccountsList: true })

--- a/app/entities/chain-id/server.ts
+++ b/app/entities/chain-id/server.ts
@@ -1,0 +1,1 @@
+export { GENESIS_HASHES } from './lib/const';

--- a/app/entities/chain-id/server.ts
+++ b/app/entities/chain-id/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { GENESIS_HASHES } from './lib/const';

--- a/app/entities/cluster/api/__tests__/get-rpc.spec.ts
+++ b/app/entities/cluster/api/__tests__/get-rpc.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 // The client cache is module state, so each test loads a fresh copy of the module.
@@ -7,6 +10,18 @@ async function loadModule() {
 }
 
 describe('getRpc', () => {
+    // A client boundary here makes every server caller — the receipt OG route among them — throw
+    // "getRpc is on the client" instead of fetching. Vitest cannot enforce the boundary, so assert
+    // on the source.
+    it('should stay callable from server code', () => {
+        const source = readFileSync(path.resolve(__dirname, '../get-rpc.ts'), 'utf8');
+        const lines = source.split('\n').map(line => line.trim());
+        // A directive only takes effect as the module's first statement, so that is what to inspect.
+        const firstStatement = lines.find(line => line !== '' && !line.startsWith('//')) ?? '';
+
+        expect(firstStatement).not.toContain('use client');
+    });
+
     it('should return the same client for repeated calls with the same URL', async () => {
         const { getRpc } = await loadModule();
         expect(getRpc('http://localhost:8899')).toBe(getRpc('http://localhost:8899'));

--- a/app/entities/cluster/api/get-rpc.ts
+++ b/app/entities/cluster/api/get-rpc.ts
@@ -1,11 +1,13 @@
-'use client';
+// Deliberately no 'use client': route handlers call this too, and the directive turns those calls
+// into a client-reference error at runtime.
+import { createSolanaRpc, type Rpc, type SolanaRpcApi } from '@solana/kit';
 
-import { createSolanaRpc } from '@solana/kit';
-
-export type SolanaRpc = ReturnType<typeof createSolanaRpc>;
+// Not `ReturnType<typeof createSolanaRpc>`: that resolves against the branded-cluster-URL overload
+// and yields a union that no narrower rpc parameter accepts.
+export type SolanaRpc = Rpc<SolanaRpcApi>;
 
 // Generous bound relative to real usage (a handful of known clusters plus the occasional custom URL);
-// it only exists so free-form custom endpoints can't grow the cache for the life of the tab.
+// it only exists so free-form custom endpoints can't grow the cache without limit.
 export const MAX_CACHED_RPCS = 25;
 
 const rpcByUrl = new Map<string, SolanaRpc>();

--- a/app/entities/cluster/server.ts
+++ b/app/entities/cluster/server.ts
@@ -1,3 +1,4 @@
+export { getRpc, type SolanaRpc } from './api/get-rpc';
 export {
     clusterFromParam,
     resolveServerClusterUrl,

--- a/app/entities/cluster/server.ts
+++ b/app/entities/cluster/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { getRpc, type SolanaRpc } from './api/get-rpc';
 export {
     clusterFromParam,

--- a/app/entities/coingecko/server.ts
+++ b/app/entities/coingecko/server.ts
@@ -1,2 +1,4 @@
+import 'server-only';
+
 export { CoinGeckoMarketDataSchema, HasUsdMarketDataSchema } from './coingecko-coins-schema';
 export { CoinGeckoVerificationSchema } from './coingecko-token-info-schema';

--- a/app/entities/digital-asset/server.ts
+++ b/app/entities/digital-asset/server.ts
@@ -1,2 +1,4 @@
+import 'server-only';
+
 export { getAssetBatch } from './api';
 export type { DigitalAsset } from './types';

--- a/app/entities/domain/server.ts
+++ b/app/entities/domain/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { fetchAnsDomains } from './api/fetch-ans-domains';
 export { fetchSnsDomains } from './api/fetch-sns-domains';
 export { ResolvedDomainInfoSchema, resolveDomain, type ResolvedDomainInfo } from './api/resolve-domain';

--- a/app/entities/domain/server.ts
+++ b/app/entities/domain/server.ts
@@ -1,0 +1,5 @@
+export { fetchAnsDomains } from './api/fetch-ans-domains';
+export { fetchSnsDomains } from './api/fetch-sns-domains';
+export { ResolvedDomainInfoSchema, resolveDomain, type ResolvedDomainInfo } from './api/resolve-domain';
+export { Domain } from './lib/domain-struct';
+export type { DomainInfo } from './model/types';

--- a/app/entities/feature-gate/server.ts
+++ b/app/entities/feature-gate/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import featureGatesJson from './feature-gates.json';
 import type { FeatureGate } from './lib/feature-gates-schema';
 

--- a/app/entities/geo-location/server.ts
+++ b/app/entities/geo-location/server.ts
@@ -1,0 +1,1 @@
+export { isGDPRCountry } from './lib/geo-location';

--- a/app/entities/geo-location/server.ts
+++ b/app/entities/geo-location/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { isGDPRCountry } from './lib/geo-location';

--- a/app/entities/idl/server.ts
+++ b/app/entities/idl/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { resolveProgramIdls } from './api/resolve-program-idls';

--- a/app/entities/program-metadata/server.ts
+++ b/app/entities/program-metadata/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { errors } from './api/constants';

--- a/app/entities/slot-time/server.ts
+++ b/app/entities/slot-time/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { MEASURED_SAMPLES, toSlotTimePayload } from './lib/slot-time';

--- a/app/entities/stake-rewards/server.ts
+++ b/app/entities/stake-rewards/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { fetchTotalStakeReward, type StakeRewardTotal } from './api/fetch-total-stake-reward';
 export { isStakeAccount } from './api/is-stake-account';
 export { getSolscanApiKey, isStakeTotalRewardEnabled } from './env';

--- a/app/entities/token-info/server.ts
+++ b/app/entities/token-info/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { UTL_API_BASE_URL } from './env';
 export { getTokenInfosFromMetaplex } from './api/fetch-token-metaplex';
 export { getTokenInfo, getTokenInfos } from './api/fetch-token-mints';

--- a/app/entities/transaction-data/client.ts
+++ b/app/entities/transaction-data/client.ts
@@ -1,0 +1,5 @@
+import 'client-only';
+
+// Off `index.ts` so that barrel stays universal: `fetchTransactionDetails` is reached from the
+// `/og/receipt` route handler, and a hook re-exported alongside it lands in the server graph.
+export { useResolvedInstructionNames, useResolvedSummaryNames } from './model/use-resolved-instruction-names';

--- a/app/entities/transaction-data/index.ts
+++ b/app/entities/transaction-data/index.ts
@@ -6,7 +6,7 @@ export { getProgramName } from './lib/get-program-name';
 export { getInstructionSummaries, resolveInstructionNames, resolveNamesFromData } from './lib/instruction-summary';
 export { mergeTransactionMap } from './lib/merge-transaction-map';
 export type { InstructionSummary, NamedInstruction } from './lib/types';
-// The second half of instruction naming; the first is `resolveInstructionNames` / `resolveNamesFromData`
-// above. README.md has the whole flow and the invariants it holds to.
-export { useResolvedInstructionNames, useResolvedSummaryNames } from './model/use-resolved-instruction-names';
+// The second half of instruction naming — `resolveInstructionNames` / `resolveNamesFromData` above —
+// is on `client.ts`, since the hooks cannot join a server caller of this barrel. README.md has the
+// whole flow and the invariants it holds to.
 export type { RawTransaction, TransactionConfig, TransactionWithMeta } from './model/types';

--- a/app/features/cu-profiling/ui/CUProfilingSection.tsx
+++ b/app/features/cu-profiling/ui/CUProfilingSection.tsx
@@ -1,11 +1,7 @@
 import { CollapsibleCard } from '@components/shared/ui/collapsible-card';
 import { BaseCUProfilingCard, formatInstructionLogs } from '@entities/compute-unit';
-import {
-    type NamedInstruction,
-    resolveInstructionNames,
-    type TransactionWithMeta,
-    useResolvedInstructionNames,
-} from '@entities/transaction-data';
+import { type NamedInstruction, resolveInstructionNames, type TransactionWithMeta } from '@entities/transaction-data';
+import { useResolvedInstructionNames } from '@entities/transaction-data/client';
 import { useCluster, useClusterInfoResult } from '@providers/cluster';
 import { useTransactionDetails } from '@providers/transactions';
 import type { Cluster } from '@utils/cluster';

--- a/app/features/feature-gate/server.ts
+++ b/app/features/feature-gate/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { fetchFeatureGateInformation } from './api/fetch-feature-gate-information';
 export { isFeatureGateOgEnabled } from './env';
 export { isFeatureActivated } from './lib/is-feature-activated';

--- a/app/features/instruction-simulation/model/use-simulation-instruction-names.ts
+++ b/app/features/instruction-simulation/model/use-simulation-instruction-names.ts
@@ -1,4 +1,5 @@
-import { type NamedInstruction, resolveNamesFromData, useResolvedInstructionNames } from '@entities/transaction-data';
+import { type NamedInstruction, resolveNamesFromData } from '@entities/transaction-data';
+import { useResolvedInstructionNames } from '@entities/transaction-data/client';
 import type { PublicKey, VersionedMessage } from '@solana/web3.js';
 import { useEffect, useMemo } from 'react';
 

--- a/app/features/receipt/index.ts
+++ b/app/features/receipt/index.ts
@@ -1,4 +1,3 @@
 export { isReceiptEnabled } from './env';
 export { Receipt } from './receipt-page';
 export { ViewReceiptButton } from './ui/ViewReceiptButton';
-export { getClusterParam } from './model/cluster';

--- a/app/features/receipt/server.ts
+++ b/app/features/receipt/server.ts
@@ -1,5 +1,6 @@
 export { ReceiptError } from './api/errors';
-export { isReceiptEnabled } from './env';
+export { isReceiptEnabled, RECEIPT_BASE_URL, RECEIPT_OG_IMAGE_VERSION } from './env';
+export { getClusterParam } from './model/cluster';
 export { createReceipt } from './model/create-receipt';
 export { buildCompositeSignature, parseCompositeSignature } from './model/composite-signature';
 export { IMAGE_SIZE as OG_IMAGE_SIZE, BaseReceiptImage } from './ui/BaseReceiptImage';

--- a/app/features/receipt/server.ts
+++ b/app/features/receipt/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { ReceiptError } from './api/errors';
 export { isReceiptEnabled, RECEIPT_BASE_URL, RECEIPT_OG_IMAGE_VERSION } from './env';
 export { getClusterParam } from './model/cluster';

--- a/app/features/search/server.ts
+++ b/app/features/search/server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export { discoverWithJupiter } from './api/discover-with-jupiter';
 export { discoverWithUtl } from './api/discover-with-utl';
 export { resolveSearchTokens, SEARCH_CACHE_HEADERS } from './api/resolve-search-tokens';

--- a/app/features/supply/server.ts
+++ b/app/features/supply/server.ts
@@ -1,1 +1,3 @@
+import 'server-only';
+
 export { toSupplyPayload } from './lib/supply';

--- a/app/features/transaction-history/model/use-resolved-instruction-summaries.ts
+++ b/app/features/transaction-history/model/use-resolved-instruction-summaries.ts
@@ -1,4 +1,5 @@
-import { type InstructionSummary, useResolvedSummaryNames } from '@entities/transaction-data';
+import { type InstructionSummary } from '@entities/transaction-data';
+import { useResolvedSummaryNames } from '@entities/transaction-data/client';
 
 import { useInstructionSummaries } from './use-instruction-summaries';
 

--- a/app/tx/[signature]/page.tsx
+++ b/app/tx/[signature]/page.tsx
@@ -1,8 +1,12 @@
 import '../../styles/styles.css';
 
-import { getClusterParam } from '@features/receipt';
-import { isReceiptEnabled, RECEIPT_BASE_URL, RECEIPT_OG_IMAGE_VERSION } from '@features/receipt/env';
-import { buildCompositeSignature } from '@features/receipt/server';
+import {
+    buildCompositeSignature,
+    getClusterParam,
+    isReceiptEnabled,
+    RECEIPT_BASE_URL,
+    RECEIPT_OG_IMAGE_VERSION,
+} from '@features/receipt/server';
 import { Cluster, CLUSTERS, clusterSlug } from '@utils/cluster';
 import { SignatureProps } from '@utils/index';
 import { Metadata } from 'next/types';

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -5,7 +5,7 @@
 | Static | `/` | 130 kB | 530 kB |
 | Static | `/_not-found` | 0 B | 410 kB |
 | Dynamic | `/address/[address]` | 500 kB | 900 kB |
-| Dynamic | `/address/[address]/account-data` | 510 kB | 910 kB |
+| Dynamic | `/address/[address]/account-data` | 510 kB | 920 kB |
 | Dynamic | `/address/[address]/anchor-account` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/anchor-program` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/attestation` | 470 kB | 870 kB |
@@ -22,14 +22,14 @@
 | Dynamic | `/address/[address]/nftoken-collection-nfts` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/program-multisig` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/rewards` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/security` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]/security` | 470 kB | 880 kB |
 | Dynamic | `/address/[address]/slot-hashes` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/stake-history` | 470 kB | 870 kB |
 | Dynamic | `/address/[address]/subscriptions` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/token-extensions` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/tokens` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/token-extensions` | 470 kB | 880 kB |
+| Dynamic | `/address/[address]/tokens` | 480 kB | 890 kB |
 | Dynamic | `/address/[address]/transfers` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/verified-build` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]/verified-build` | 470 kB | 880 kB |
 | Dynamic | `/address/[address]/vote-history` | 470 kB | 870 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
@@ -51,12 +51,12 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 250 kB | 660 kB |
+| Dynamic | `/block/[slot]` | 260 kB | 660 kB |
 | Dynamic | `/block/[slot]/accounts` | 250 kB | 650 kB |
 | Dynamic | `/block/[slot]/programs` | 250 kB | 650 kB |
 | Dynamic | `/block/[slot]/rewards` | 250 kB | 650 kB |
-| Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
-| Static | `/feature-gates` | 40 kB | 440 kB |
+| Dynamic | `/epoch/[epoch]` | 10 kB | 420 kB |
+| Static | `/feature-gates` | 40 kB | 450 kB |
 | Dynamic | `/mcp` | — | — |
 | Static | `/mcp/start` | 20 kB | 420 kB |
 | Dynamic | `/og/feature-gate/[address]` | — | — |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -555,6 +555,25 @@ export default tseslint.config(
         },
     },
 
+    // A `server.ts` barrel declares which exports are for server consumers; without the marker that
+    // declaration is unenforced, and a client importer is only found at runtime. Universal code stays
+    // reachable through the slice's `index.ts`.
+    {
+        files: ['app/**/server.[jt]s?(x)'],
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                ...NO_REGEXP_SELECTORS,
+                CLIENT_MARKER_CONFLICT,
+                {
+                    selector: "Program:not(:has(ImportDeclaration[source.value='server-only']))",
+                    message:
+                        "A `server.ts` barrel must `import 'server-only'` so a client importer fails `next build` instead of at runtime.",
+                },
+            ],
+        },
+    },
+
     // TODO: `boundaries/dependencies` cleanup. Each path below crosses an FSD boundary
     // (cross-feature, cross-entity without `@x`, reverse-layer, or deep import bypassing the
     // barrel). Per-file so any *new* file in these areas is still subject to the rule. Remove a

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,15 @@ const NO_REGEXP_SELECTORS = [
     },
 ];
 
+// `'use client'` turns the module into a client reference, which silently neutralises `client-only`:
+// the pair reads as guarded while a server caller still fails at runtime instead of at build time.
+const CLIENT_MARKER_CONFLICT = {
+    selector:
+        "Program:has(ExpressionStatement > Literal[value='use client']):has(ImportDeclaration[source.value='client-only'])",
+    message:
+        "Do not combine 'use client' with `import 'client-only'` — the directive makes the module a client reference, so the marker stops failing the build and a server caller degrades to a runtime error instead. Keep the directive for components; keep only the marker for hooks and plain modules.",
+};
+
 export default tseslint.config(
     // Global ignores.
     // packages/* are intentionally not ignored: root `eslint .` (like prettier's `**/*.ts` glob) lints their source with this shared config — only built output is excluded.
@@ -116,7 +125,7 @@ export default tseslint.config(
             'no-unused-vars': 'off',
             'simple-import-sort/imports': 'error',
             'no-restricted-globals': ['error', 'RegExp'],
-            'no-restricted-syntax': ['error', ...NO_REGEXP_SELECTORS],
+            'no-restricted-syntax': ['error', ...NO_REGEXP_SELECTORS, CLIENT_MARKER_CONFLICT],
             'sort-keys-fix/sort-keys-fix': 'error',
             '@eslint-community/eslint-comments/no-unlimited-disable': 'error',
             'no-console': 'error',
@@ -433,6 +442,7 @@ export default tseslint.config(
             'no-restricted-syntax': [
                 'error',
                 ...NO_REGEXP_SELECTORS,
+                CLIENT_MARKER_CONFLICT,
                 {
                     selector: "ExpressionStatement > Literal[value='use client']",
                     message:
@@ -855,6 +865,7 @@ export default tseslint.config(
             'no-restricted-syntax': [
                 'error',
                 ...NO_REGEXP_SELECTORS,
+                CLIENT_MARKER_CONFLICT,
                 {
                     selector: 'ImportExpression',
                     message:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,21 @@ const TEST_AND_STORY_FILES = [
     '**/*.stories.[jt]s?(x)',
 ];
 
+// Flat config replaces `no-restricted-syntax` options wholesale, so every override must spread these
+// back in or it silently drops the RegExp ban for its own files.
+const NO_REGEXP_SELECTORS = [
+    {
+        selector: 'Literal[regex]',
+        message:
+            'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
+    },
+    {
+        selector: 'RegExpLiteral',
+        message:
+            'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
+    },
+];
+
 export default tseslint.config(
     // Global ignores.
     // packages/* are intentionally not ignored: root `eslint .` (like prettier's `**/*.ts` glob) lints their source with this shared config — only built output is excluded.
@@ -101,19 +116,7 @@ export default tseslint.config(
             'no-unused-vars': 'off',
             'simple-import-sort/imports': 'error',
             'no-restricted-globals': ['error', 'RegExp'],
-            'no-restricted-syntax': [
-                'error',
-                {
-                    selector: 'Literal[regex]',
-                    message:
-                        'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
-                },
-                {
-                    selector: 'RegExpLiteral',
-                    message:
-                        'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
-                },
-            ],
+            'no-restricted-syntax': ['error', ...NO_REGEXP_SELECTORS],
             'sort-keys-fix/sort-keys-fix': 'error',
             '@eslint-community/eslint-comments/no-unlimited-disable': 'error',
             'no-console': 'error',
@@ -429,6 +432,7 @@ export default tseslint.config(
         rules: {
             'no-restricted-syntax': [
                 'error',
+                ...NO_REGEXP_SELECTORS,
                 {
                     selector: "ExpressionStatement > Literal[value='use client']",
                     message:
@@ -850,16 +854,7 @@ export default tseslint.config(
         rules: {
             'no-restricted-syntax': [
                 'error',
-                {
-                    selector: 'Literal[regex]',
-                    message:
-                        'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
-                },
-                {
-                    selector: 'RegExpLiteral',
-                    message:
-                        'RegExps are not recommended. If you sure regexp is needed - please use eslint-disable-next no-restricted-syntax -- %comment%  to explain why',
-                },
+                ...NO_REGEXP_SELECTORS,
                 {
                     selector: 'ImportExpression',
                     message:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -329,6 +329,10 @@ export default tseslint.config(
         plugins: { boundaries },
         settings: {
             'boundaries/elements': [
+                // Route handlers only. Pages are excluded on purpose: a server page may import a
+                // client component to render it, which is the intended RSC pattern, while a handler
+                // renders nothing and only ever calls what it imports.
+                { type: 'route', pattern: 'app/**/route.[jt]s?(x)', mode: 'file' },
                 { type: 'feature', pattern: 'app/features/*', mode: 'folder', capture: ['name'] },
                 // Must precede the broader `entity` pattern — element types are matched in
                 // declaration order, so `@x` folders would otherwise be classified as `entity`.
@@ -348,6 +352,21 @@ export default tseslint.config(
                 {
                     default: 'disallow',
                     rules: [
+                        {
+                            // Only through `server.ts` — that barrel exists to declare what a slice
+                            // offers the server. `index.ts` is server-safe only by accident: add one
+                            // client export to it later and a client boundary lands on a server call
+                            // path silently. A deep path into `api/` or `lib/` drags in whatever that
+                            // module happens to import, with the same result.
+                            from: { type: 'route' },
+                            allow: {
+                                to: [
+                                    { type: 'shared' },
+                                    { type: 'entity', internalPath: 'server.ts' },
+                                    { type: 'feature', internalPath: 'server.ts' },
+                                ],
+                            },
+                        },
                         {
                             from: { type: 'feature' },
                             allow: {
@@ -393,6 +412,29 @@ export default tseslint.config(
         files: TEST_AND_STORY_FILES,
         rules: {
             'boundaries/dependencies': 'off',
+        },
+    },
+
+    // A slice's data-access layer is shared by both graphs: route handlers call it on the server,
+    // components call it in the browser. `'use client'` here compiles fine and then throws
+    // "is on the client" the first time a server caller invokes it. Put the boundary on the hook or
+    // component that consumes the module instead.
+    {
+        files: [
+            'app/entities/*/api/**/*.[jt]s?(x)',
+            'app/entities/*/@x/**/*.[jt]s?(x)',
+            'app/features/*/api/**/*.[jt]s?(x)',
+        ],
+        ignores: TEST_AND_STORY_FILES,
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: "ExpressionStatement > Literal[value='use client']",
+                    message:
+                        "Do not mark a slice's api/ or @x/ module 'use client' — server code imports it, and the directive turns those calls into a client-reference error at runtime. Move the boundary to the consuming hook or component.",
+                },
+            ],
         },
     },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,98 @@ const CLIENT_MARKER_CONFLICT = {
         "Do not combine 'use client' with `import 'client-only'` — the directive makes the module a client reference, so the marker stops failing the build and a server caller degrades to a runtime error instead. Keep the directive for components; keep only the marker for hooks and plain modules.",
 };
 
+// Hooks still on `'use client'`. Per-file so any *new* hook is subject to the rule. This list only
+// ever shrinks — a PR that adds an entry is opting a new hook out of the one guard that catches a
+// server caller at build time. Removing an entry means swapping the directive for
+// `import 'client-only'` and confirming `next build` still passes; a failure names a barrel that
+// re-exports the hook onto a server path.
+const HOOKS_PENDING_CLIENT_ONLY = [
+    'app/entities/account/model/use-account-query.ts',
+    'app/entities/cluster/model/use-cluster-connection-failed.ts',
+    'app/entities/cluster/model/use-cluster-info.ts',
+    'app/entities/cluster/model/use-cluster-modal.ts',
+    'app/entities/cluster/model/use-cluster-resource-search.ts',
+    'app/entities/cluster/model/use-cluster-url.ts',
+    'app/entities/cluster/model/use-cluster.ts',
+    'app/entities/cluster/model/use-solana-rpc.ts',
+    'app/entities/domain/model/use-user-ans-domains.ts',
+    'app/entities/domain/model/use-user-sns-domains.ts',
+    'app/entities/idl/model/anchor/use-anchor-program.ts',
+    'app/entities/idl/model/anchor/use-format-anchor-idl.ts',
+    'app/entities/idl/model/use-format-codama-idl.ts',
+    'app/entities/idl/model/use-program-idl-names.ts',
+    'app/entities/idl/model/use-program-idls.ts',
+    'app/entities/nft/model/use-token-metadata.ts',
+    'app/entities/program-metadata/model/use-program-metadata-idl.tsx',
+    'app/entities/slot-time/model/use-slot-time.ts',
+    'app/entities/token-info/model/use-token-info.ts',
+    'app/entities/transaction-data/model/use-resolved-instruction-names.ts',
+    'app/features/cluster-switcher/model/use-cluster-href.ts',
+    'app/features/cluster-switcher/model/use-custom-url-draft.ts',
+    'app/features/cookie/model/use-analytics-consent.ts',
+    'app/features/decode-account-pmp/model/use-decode-buffer-payload.ts',
+    'app/features/decode-account-pmp/model/use-decode-metadata-payload.ts',
+    'app/features/decode-account-pmp/model/use-resolve-buffer-config-from-bytes.ts',
+    'app/features/decode-account-pmp/model/use-resolve-buffer-config-onchain.ts',
+    'app/features/idl/interactive-idl/model/transaction/use-execute-transaction.ts',
+    'app/features/idl/interactive-idl/model/transaction/use-simulate-transaction.ts',
+    'app/features/idl/interactive-idl/model/use-instruction.ts',
+    'app/features/idl/model/use-tabs.tsx',
+    'app/features/instruction-simulation/model/use-simulation.ts',
+    'app/features/nicknames/model/use-nickname.ts',
+    'app/features/receipt/lib/use-primary-domain.ts',
+    'app/features/stake/model/use-total-reward.ts',
+    'app/features/supply/model/use-supply.ts',
+    'app/features/token-batch/model/use-sub-instruction-mint-info.ts',
+    'app/features/transaction-history/model/use-account-history.ts',
+    'app/features/transaction-history/model/use-fetch-account-history.ts',
+    'app/features/transaction/model/use-cluster-transaction-search.ts',
+    'app/providers/wallet/use-logged-wallet-error.ts',
+    'app/providers/wallet/use-wallet.ts',
+    'app/shared/lib/use-auto-refresh.ts',
+    'app/shared/lib/use-breakpoint.ts',
+    'app/shared/lib/use-can-native-share.ts',
+    'app/shared/lib/use-hydrated.ts',
+    'app/shared/lib/use-reduced-motion.ts',
+];
+
+// A hook is never a component, so it never needs to *be* a client boundary — and `'use client'` costs
+// it the only build-time guard available: a server caller of a directive-carrying module gets a
+// client reference and fails at runtime, while `client-only` fails `next build` with an import trace.
+const clientBoundaryPlugin = {
+    rules: {
+        'prefer-client-only-in-hooks': {
+            create(context) {
+                return {
+                    Program(node) {
+                        for (const statement of node.body) {
+                            // Directives only count in the leading prologue, so stop at the first real statement.
+                            if (statement.type !== 'ExpressionStatement' || statement.expression.type !== 'Literal') {
+                                return;
+                            }
+                            if (statement.expression.value !== 'use client') continue;
+                            context.report({
+                                messageId: 'preferClientOnly',
+                                node: statement,
+                            });
+                            return;
+                        }
+                    },
+                };
+            },
+            meta: {
+                docs: { description: "Suggest `import 'client-only'` over 'use client' for hook modules." },
+                messages: {
+                    preferClientOnly:
+                        "Prefer `import 'client-only'` over 'use client' in a hook module: a server caller then fails `next build` with an import trace instead of throwing at runtime. Verify with a build — a failure means something in the server graph reaches this module, usually a barrel re-export worth splitting.",
+                },
+                schema: [],
+                type: 'suggestion',
+            },
+        },
+    },
+};
+
 export default tseslint.config(
     // Global ignores.
     // packages/* are intentionally not ignored: root `eslint .` (like prettier's `**/*.ts` glob) lints their source with this shared config — only built output is excluded.
@@ -449,6 +541,17 @@ export default tseslint.config(
                         "Do not mark a slice's api/ or @x/ module 'use client' — server code imports it, and the directive turns those calls into a client-reference error at runtime. Move the boundary to the consuming hook or component.",
                 },
             ],
+        },
+    },
+
+    // Deliberately its own rule name: configuring `no-restricted-syntax` here would replace the
+    // error-level selectors for these files and silently downgrade them.
+    {
+        files: ['app/**/use-*.[jt]s?(x)'],
+        ignores: [...TEST_AND_STORY_FILES, ...HOOKS_PENDING_CLIENT_ONLY],
+        plugins: { boundary: clientBoundaryPlugin },
+        rules: {
+            'boundary/prefer-client-only-in-hooks': 'error',
         },
     },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -477,6 +477,9 @@ export default tseslint.config(
                                 to: [
                                     { type: 'shared' },
                                     { type: 'entity', internalPath: 'index.ts' },
+                                    // Hooks an entity keeps off `index.ts` so that barrel stays callable
+                                    // from a route handler; the `client-only` marker on it catches misuse.
+                                    { type: 'entity', internalPath: 'client.ts' },
                                     { type: 'entity-public-api' },
                                     { type: 'feature', captured: { name: '{{ name }}' } },
                                 ],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -56,6 +56,10 @@ export default defineConfig({
             '@utils': path.resolve(__dirname, './app/utils'),
             '@storybook-config': path.resolve(__dirname, './.storybook'),
             '@validators': path.resolve(__dirname, './app/validators'),
+
+            // `server-only` throws under the `default` condition set below; only Next's RSC build
+            // resolves it to a no-op, so specs importing a `server.ts` barrel need the stub.
+            'server-only': path.resolve(__dirname, './empty.ts'),
         },
         conditions: ['browser', 'default'],
     },


### PR DESCRIPTION
## Description

The kit migration in #1270 broke `/og/receipt/<signature>` — every request returned a 502. It routed `getTx` through `fetchTransactionDetails`, which calls `getRpc`, and `app/entities/cluster/api/get-rpc.ts` was marked `'use client'`. Every server caller got a client reference instead of the accessor:

```
Attempted to call getRpc() from the server but getRpc is on the client.
```

### The fix

- **Drop `'use client'` from `get-rpc.ts`.** The module is pure — `createSolanaRpc` plus a bounded `Map` — and the `rpc-access` spec already names `getRpc(url)` the accessor for route handlers.
- **Declare `SolanaRpc` as `Rpc<SolanaRpcApi>`.** `ReturnType<typeof createSolanaRpc>` resolved against the branded-cluster-URL overload, yielding a union no narrower rpc parameter accepts.
- **Route handlers import slices only through `server.ts`.** Adds one to `domain`, `chain-id` and `geo-location`, and moves `getClusterParam`, `RECEIPT_BASE_URL` and `RECEIPT_OG_IMAGE_VERSION` onto the receipt barrel. `/api/domain-info` had been importing the `domain` client barrel and calling into it.
- **`supply`, `security-txt` and `slot-time` take their rpc from `getRpc`.** `idl-latest` keeps `createSolanaRpc` — it builds a client inside its retry loop, where a fresh client per attempt is the point.
- **Two eslint rules**, so this cannot come back: `'use client'` is banned in a slice's `api/` and `@x/` layers, and a new `route` boundaries element limits handlers to `server.ts` plus `shared`. Pages are excluded — a server page may import a client component to render it.

`fetchTransactionDetails` keeps `@entities/cluster/@x/transaction-data`: entity→entity must cross via `@x`.

## Type of change

-   [x] Bug fix
-   [x] Other (please describe): enforces the server entrypoint convention for route handlers, with eslint rules to hold it

## Testing

Manual testing on the preview deployment:

- [OG image — the reported failure, now the rendered receipt PNG instead of a 502](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/og/receipt/4QhofknVDuMVGvheiB8Zu9uWvvZJGVSCsykJkpdiqSG4vrXsHCkTV9wa6fHWm16uqovqs1kHUvPcP5Bu7YFaYD56-1)
- [OG image, no version suffix — the same route through the bare-signature path](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/og/receipt/4QhofknVDuMVGvheiB8Zu9uWvvZJGVSCsykJkpdiqSG4vrXsHCkTV9wa6fHWm16uqovqs1kHUvPcP5Bu7YFaYD56)
- [Receipt view — the page that advertises that image](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/tx/4QhofknVDuMVGvheiB8Zu9uWvvZJGVSCsykJkpdiqSG4vrXsHCkTV9wa6fHWm16uqovqs1kHUvPcP5Bu7YFaYD56?view=receipt)
- [`/api/slot-time`](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/api/slot-time?cluster=0) and [`/api/supply`](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/api/supply?cluster=0) — handlers moved onto the rpc accessor
- [`/api/idl-latest`](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/api/idl-latest?cluster=0&programAddress=TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA) — the retry loop kept on its own per-attempt client
- [`/api/domain-info`](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/api/domain-info/toly.sol) and [`/api/geo-location`](https://explorer-git-fork-hoodieshq-fix-server-57eae7-solana-foundation.vercel.app/api/geo-location) — handlers moved onto a slice `server.ts`

## Related Issues

Closes [HOO-1410](https://linear.app/solana-fndn/issue/HOO-1410/investigate-elevated-errors-on-receipt-endpoint)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

- `bench/BUILD.md` shifts first-load size by ~10 kB on a few `/address/[address]/*` routes: dropping the directive takes `get-rpc` out of the client-reference graph, so it bundles into its importers instead of its own chunk.
- Left out on purpose: `fetchReceiptTransaction` re-wraps its own 404 as a 502, but `get-tx.spec.ts` pins that wrapping.
- No CI gate executes a route handler, which is why nothing caught this. A step that boots the build and probes the dynamic routes would.




