### PR TITLE
fix(slot-time): measure the dashboard rate with the entity's formula

### DIFF
--- a/.storybook/__mocks__/MockStatsProvider.tsx
+++ b/.storybook/__mocks__/MockStatsProvider.tsx
@@ -9,8 +9,8 @@ import type { PerformanceInfo } from '@providers/stats/solanaPerformanceInfo';
 import type { ReactNode } from 'react';
 
 const defaultDashboard: DashboardInfo = {
-    avgSlotTime_1h: 0.42,
-    avgSlotTime_1min: 0.4,
+    msPerSlot_1h: 420,
+    msPerSlot_1min: 400,
     epochInfo: {
         absoluteSlot: 312_456_789n,
         blockHeight: 295_456_321n,

--- a/app/entities/slot-time/api/fetch-slot-time.ts
+++ b/app/entities/slot-time/api/fetch-slot-time.ts
@@ -64,7 +64,7 @@ export async function fetchSlotTimeFromRpc(url: ConnectableUrl): Promise<number>
         .getRecentPerformanceSamples(MEASURED_SAMPLES)
         .send({ abortSignal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) });
 
-    return toMsPerSlot(samples);
+    return toMsPerSlot(samples, MEASURED_SAMPLES);
 }
 
 // Asking again can only answer differently for these: the route's transient upstream error and its

--- a/app/entities/slot-time/index.ts
+++ b/app/entities/slot-time/index.ts
@@ -1,1 +1,2 @@
+export { measureMsPerSlot } from './lib/slot-time';
 export { useSlotTime } from './model/use-slot-time';

--- a/app/entities/slot-time/lib/__tests__/slot-time.spec.ts
+++ b/app/entities/slot-time/lib/__tests__/slot-time.spec.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { MEASURED_SAMPLES, parseSlotTimePayload, toMsPerSlot, toSlotTimePayload } from '../slot-time';
+import { MEASURED_SAMPLES, measureMsPerSlot, parseSlotTimePayload, toMsPerSlot, toSlotTimePayload } from '../slot-time';
 
 /** One minute of slots at a given rate, as `getRecentPerformanceSamples` reports it. */
 function sample(msPerSlot: number, samplePeriodSecs = 60) {
     return { numSlots: BigInt(Math.round((samplePeriodSecs * 1000) / msPerSlot)), samplePeriodSecs };
 }
 
-describe('toMsPerSlot', () => {
+describe('measureMsPerSlot', () => {
     it('should measure the rate a single sample states', () => {
-        expect(toMsPerSlot([sample(200)])).toBe(200);
+        expect(measureMsPerSlot([sample(200)], MEASURED_SAMPLES)).toBe(200);
     });
 
     // The bug this exists for: the countdown read a 400 ms constant while every cluster had already
@@ -20,7 +20,7 @@ describe('toMsPerSlot', () => {
         ['devnet at the 200 ms gate', 361n, 166],
         ['mainnet at the 300 ms gate', 191n, 314],
     ])('should measure %s', (_name, numSlots, expected) => {
-        expect(toMsPerSlot([{ numSlots, samplePeriodSecs: 60 }])).toBe(expected);
+        expect(measureMsPerSlot([{ numSlots, samplePeriodSecs: 60 }], MEASURED_SAMPLES)).toBe(expected);
     });
 
     // Total time over total slots, not the mean of the per-sample rates: a sample covering a longer
@@ -28,18 +28,27 @@ describe('toMsPerSlot', () => {
     it('should weigh each sample by the time it covers', () => {
         const samples = [sample(200, 30), sample(400, 90)];
 
-        expect(toMsPerSlot(samples)).toBe(Math.round(120_000 / (150 + 225)));
+        expect(measureMsPerSlot(samples, MEASURED_SAMPLES)).toBe(Math.round(120_000 / (150 + 225)));
     });
 
-    it('should ignore samples beyond the measured window', () => {
+    // Mainnet at the 300 ms gate with one degraded minute. Samples of equal length still weigh
+    // unequally: the slow minute produced 100 of the 864 slots, so it is 11.57% of the answer and not
+    // the 20% an unweighted mean of the five rates would give it (which lands at 371 ms).
+    it('should weigh a degraded minute by the slots it produced, not by its share of the samples', () => {
+        const samples = [...Array.from({ length: 4 }, () => ({ numSlots: 191n, samplePeriodSecs: 60 })), sample(600)];
+
+        expect(measureMsPerSlot(samples, 5)).toBe(347);
+    });
+
+    it('should ignore samples beyond the window it is asked for', () => {
         const samples = [...Array.from({ length: MEASURED_SAMPLES }, () => sample(200)), sample(4000)];
 
-        expect(toMsPerSlot(samples)).toBe(200);
+        expect(measureMsPerSlot(samples, MEASURED_SAMPLES)).toBe(200);
     });
 
     // A sample that covers no slot states no rate, and dividing by it would yield Infinity.
     it('should skip a sample covering no slot', () => {
-        expect(toMsPerSlot([{ numSlots: 0n, samplePeriodSecs: 60 }, sample(200)])).toBe(200);
+        expect(measureMsPerSlot([{ numSlots: 0n, samplePeriodSecs: 60 }, sample(200)], MEASURED_SAMPLES)).toBe(200);
     });
 
     it.each([
@@ -50,7 +59,21 @@ describe('toMsPerSlot', () => {
         ['a slot count that is not a bigint', { numSlots: 300 as unknown as bigint, samplePeriodSecs: 60 }],
         ['a period that is not a number', { numSlots: 300n, samplePeriodSecs: '60' as unknown as number }],
     ])('should skip a sample with %s', (_reason, broken) => {
-        expect(toMsPerSlot([broken, sample(200)])).toBe(200);
+        expect(measureMsPerSlot([broken, sample(200)], MEASURED_SAMPLES)).toBe(200);
+    });
+
+    it.each([
+        ['no samples at all', []],
+        ['no sample that states a rate', [{ numSlots: 0n, samplePeriodSecs: 60 }]],
+        ['no sample inside the window that states a rate', [{ numSlots: 0n, samplePeriodSecs: 60 }, sample(200)]],
+    ])('should state no rate when a node reports %s', (_reason, samples) => {
+        expect(measureMsPerSlot(samples, 1)).toBeUndefined();
+    });
+});
+
+describe('toMsPerSlot', () => {
+    it('should carry the measured rate', () => {
+        expect(toMsPerSlot([sample(200)], MEASURED_SAMPLES)).toBe(200);
     });
 
     // Throws rather than returning a fallback: a countdown built on a rate nothing measured is a
@@ -59,13 +82,19 @@ describe('toMsPerSlot', () => {
         ['no samples at all', []],
         ['no sample that states a rate', [{ numSlots: 0n, samplePeriodSecs: 60 }]],
     ])('should throw when a node reports %s', (_reason, samples) => {
-        expect(() => toMsPerSlot(samples)).toThrow('no sample states a rate');
+        expect(() => toMsPerSlot(samples, MEASURED_SAMPLES)).toThrow('no sample states a rate');
     });
 });
 
 describe('toSlotTimePayload', () => {
     it('should carry the measured rate', () => {
         expect(toSlotTimePayload([sample(200)])).toEqual({ msPerSlot: 200 });
+    });
+
+    it('should measure over the samples the countdown is meant to see', () => {
+        const samples = [...Array.from({ length: MEASURED_SAMPLES }, () => sample(200)), sample(4000)];
+
+        expect(toSlotTimePayload(samples)).toEqual({ msPerSlot: 200 });
     });
 });
 

--- a/app/entities/slot-time/lib/slot-time.ts
+++ b/app/entities/slot-time/lib/slot-time.ts
@@ -9,28 +9,33 @@ type PerformanceSample = Readonly<{
 type SlotTimePayload = Infer<typeof SlotTimePayloadStruct>;
 
 /**
- * How many of the most recent samples (one minute each) the rate is measured over. Wide enough that one
- * odd minute cannot move it, narrow enough that a slot-time feature gate shows up within minutes of
- * activating.
+ * How many of the most recent samples (one minute each) the feature-gate countdown measures over. Wide
+ * enough that one odd minute cannot move it, narrow enough that a slot-time feature gate shows up within
+ * minutes of activating.
  */
 export const MEASURED_SAMPLES = 5;
 
 export function toSlotTimePayload(samples: readonly PerformanceSample[]): SlotTimePayload {
-    return { msPerSlot: toMsPerSlot(samples) };
+    return { msPerSlot: toMsPerSlot(samples, MEASURED_SAMPLES) };
 }
 
 /**
- * The boundary constructor: wall-clock time the cluster spent per slot, over the samples it reports.
+ * Wall-clock time the cluster spent per slot over the newest `sampleCount` samples, or `undefined` when
+ * none of them states a rate.
+ *
+ * Total time over total slots, not the mean of the per-sample rates. A slow minute produces fewer slots
+ * by definition, so weighting every sample alike gives the slow minutes more than their share and the
+ * answer only ever runs high.
  *
  * Rounded to whole milliseconds so both fetch paths agree on the figure and the cached body stays stable.
  * At epoch scale that costs well under a minute, against a rate that moves by a hundred milliseconds a
  * slot when a SIMD-0525 gate activates.
  */
-export function toMsPerSlot(samples: readonly PerformanceSample[]): number {
+export function measureMsPerSlot(samples: readonly PerformanceSample[], sampleCount: number): number | undefined {
     let slots = 0n;
     let seconds = 0;
 
-    for (const sample of samples.slice(0, MEASURED_SAMPLES)) {
+    for (const sample of samples.slice(0, sampleCount)) {
         // Kit types these without checking them, and a sample that covers no slot cannot state a rate.
         if (typeof sample.numSlots !== 'bigint' || sample.numSlots <= 0n) continue;
         if (typeof sample.samplePeriodSecs !== 'number' || !Number.isFinite(sample.samplePeriodSecs)) continue;
@@ -40,11 +45,20 @@ export function toMsPerSlot(samples: readonly PerformanceSample[]): number {
         seconds += sample.samplePeriodSecs;
     }
 
-    if (slots === 0n) {
+    if (slots === 0n) return undefined;
+
+    return Math.round((seconds * 1000) / Number(slots));
+}
+
+/** The boundary constructor, for the callers that answer a request: absence becomes an error there. */
+export function toMsPerSlot(samples: readonly PerformanceSample[], sampleCount: number): number {
+    const msPerSlot = measureMsPerSlot(samples, sampleCount);
+
+    if (msPerSlot === undefined) {
         throw new Error('[slot-time] no sample states a rate');
     }
 
-    return Math.round((seconds * 1000) / Number(slots));
+    return msPerSlot;
 }
 
 /** Throws rather than handing back a rate it cannot vouch for, which every countdown would then use. */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,12 +65,10 @@ function StatsCardBody() {
         return <StatsNotReady error={error} />;
     }
 
-    const { avgSlotTime_1h, avgSlotTime_1min, epochInfo, blockTime } = dashboardInfo;
-    const hourlySlotTime = Math.round(1000 * avgSlotTime_1h);
-    const averageSlotTime = Math.round(1000 * avgSlotTime_1min);
+    const { msPerSlot_1h, msPerSlot_1min, epochInfo, blockTime } = dashboardInfo;
     const { slotIndex, slotsInEpoch } = epochInfo;
     const epochProgress = `${percentage(slotIndex, slotsInEpoch, 2).toFixed(1)}%`;
-    const epochTimeRemaining = slotsToHumanString(Number(slotsInEpoch - slotIndex), hourlySlotTime);
+    const epochTimeRemaining = slotsToHumanString(Number(slotsInEpoch - slotIndex), msPerSlot_1h);
     const { blockHeight, absoluteSlot } = epochInfo;
 
     return (
@@ -105,11 +103,11 @@ function StatsCardBody() {
                 )}
                 <tr>
                     <td className="w-full">Slot time (1min average)</td>
-                    <td className="text-right font-mono">{averageSlotTime}ms</td>
+                    <td className="text-right font-mono">{msPerSlot_1min}ms</td>
                 </tr>
                 <tr>
                     <td className="w-full">Slot time (1hr average)</td>
-                    <td className="text-right font-mono">{hourlySlotTime}ms</td>
+                    <td className="text-right font-mono">{msPerSlot_1h}ms</td>
                 </tr>
                 <tr>
                     <td className="w-full">Epoch</td>

--- a/app/providers/stats/__tests__/solanaDashboardInfo.test.ts
+++ b/app/providers/stats/__tests__/solanaDashboardInfo.test.ts
@@ -13,8 +13,6 @@ import { PerformanceSample } from '../solanaPerformanceInfo';
 
 describe('dashboardInfoReducer', () => {
     const createInitialState = (overrides?: Partial<DashboardInfo>): DashboardInfo => ({
-        avgSlotTime_1h: 0,
-        avgSlotTime_1min: 0,
         epochInfo: {
             absoluteSlot: BigInt(0),
             blockHeight: BigInt(0),
@@ -22,6 +20,8 @@ describe('dashboardInfoReducer', () => {
             slotIndex: BigInt(0),
             slotsInEpoch: BigInt(0),
         },
+        msPerSlot_1h: 0,
+        msPerSlot_1min: 0,
         status: ClusterStatsStatus.Loading,
         ...overrides,
     });
@@ -124,7 +124,7 @@ describe('dashboardInfoReducer', () => {
             expect(result).toBe(initialState);
         });
 
-        it('should calculate avgSlotTime_1h and avgSlotTime_1min correctly with single sample', () => {
+        it('should calculate msPerSlot_1h and msPerSlot_1min correctly with single sample', () => {
             const initialState = createInitialState();
             const action: DashboardInfoAction = {
                 data: [
@@ -139,12 +139,12 @@ describe('dashboardInfoReducer', () => {
 
             const result = dashboardInfoReducer(initialState, action);
 
-            expect(result.avgSlotTime_1h).toBe(6); // 60 / 10
-            expect(result.avgSlotTime_1min).toBe(6); // 60 / 10
+            expect(result.msPerSlot_1h).toBe(6000); // 60 s / 10 slots
+            expect(result.msPerSlot_1min).toBe(6000); // 60 s / 10 slots
             expect(result.status).toBe(ClusterStatsStatus.Loading); // epochInfo.absoluteSlot is 0
         });
 
-        it('should calculate avgSlotTime_1h as average of all samples when less than 60', () => {
+        it('should measure msPerSlot_1h over all samples when less than 60', () => {
             const initialState = createInitialState({
                 epochInfo: {
                     absoluteSlot: BigInt(1000),
@@ -177,34 +177,66 @@ describe('dashboardInfoReducer', () => {
 
             const result = dashboardInfoReducer(initialState, action);
 
-            // (60/10 + 60/20 + 60/30) / 3 = (6 + 3 + 2) / 3 = 11/3 ≈ 3.667
-            expect(result.avgSlotTime_1h).toBeCloseTo(11 / 3, 5);
-            expect(result.avgSlotTime_1min).toBe(6); // First sample: 60/10
+            // 180 s over 60 slots. Not the mean of the three rates, (6000 + 3000 + 2000) / 3 = 3667 ms:
+            // the slow minute produced 10 of the 60 slots, so it is a sixth of the answer, not a third.
+            expect(result.msPerSlot_1h).toBe(3000);
+            expect(result.msPerSlot_1min).toBe(6000); // Newest sample: 60 s / 10 slots
             expect(result.status).toBe(ClusterStatsStatus.Ready); // epochInfo.absoluteSlot is not 0
         });
 
         it('should limit samples to 60 when more than 60 samples provided', () => {
             const initialState = createInitialState();
-            const samples: PerformanceSample[] = Array.from({ length: 100 }, () => ({
+            const withinTheHour: PerformanceSample[] = Array.from({ length: 60 }, () => ({
                 numSlots: BigInt(10),
+                numTransactions: BigInt(100),
+                samplePeriodSecs: 60,
+            }));
+            const older: PerformanceSample[] = Array.from({ length: 40 }, () => ({
+                numSlots: BigInt(1),
                 numTransactions: BigInt(100),
                 samplePeriodSecs: 60,
             }));
 
             const action: DashboardInfoAction = {
-                data: samples,
+                data: [...withinTheHour, ...older],
                 type: DashboardInfoActionType.SetPerfSamples,
             };
 
             const result = dashboardInfoReducer(initialState, action);
 
-            // Should only use first 60 samples, all with same value
-            expect(result.avgSlotTime_1h).toBe(6); // 60/10
-            expect(result.avgSlotTime_1min).toBe(6); // First sample: 60/10
+            // The 40 older minutes would drag the rate up if the window did not stop at 60.
+            expect(result.msPerSlot_1h).toBe(6000); // 60 s / 10 slots
+            expect(result.msPerSlot_1min).toBe(6000); // Newest sample: 60 s / 10 slots
         });
 
-        it('should filter out samples with zero numSlots', () => {
+        it('should skip a minute that produced no slot', () => {
             const initialState = createInitialState();
+            const action: DashboardInfoAction = {
+                data: [
+                    {
+                        numSlots: BigInt(10),
+                        numTransactions: BigInt(100),
+                        samplePeriodSecs: 60,
+                    },
+                    {
+                        numSlots: BigInt(0),
+                        numTransactions: BigInt(200),
+                        samplePeriodSecs: 60,
+                    },
+                ],
+                type: DashboardInfoActionType.SetPerfSamples,
+            };
+
+            const result = dashboardInfoReducer(initialState, action);
+
+            expect(result.msPerSlot_1h).toBe(6000); // 60 s / 10 slots
+            expect(result.msPerSlot_1min).toBe(6000); // 60 s / 10 slots
+        });
+
+        // Reporting the minute before it as the "1min" figure would label a measurement as something it
+        // is not, so the last poll's figures stand until the next one.
+        it('should keep the previous figures when the newest minute produced no slot', () => {
+            const initialState = createInitialState({ msPerSlot_1h: 400, msPerSlot_1min: 400 });
             const action: DashboardInfoAction = {
                 data: [
                     {
@@ -217,20 +249,13 @@ describe('dashboardInfoReducer', () => {
                         numTransactions: BigInt(200),
                         samplePeriodSecs: 60,
                     },
-                    {
-                        numSlots: BigInt(0),
-                        numTransactions: BigInt(300),
-                        samplePeriodSecs: 60,
-                    },
                 ],
                 type: DashboardInfoActionType.SetPerfSamples,
             };
 
             const result = dashboardInfoReducer(initialState, action);
 
-            // Should only use the sample with numSlots = 10
-            expect(result.avgSlotTime_1h).toBe(6); // 60/10
-            expect(result.avgSlotTime_1min).toBe(6); // 60/10
+            expect(result).toBe(initialState);
         });
 
         it('should set status to Ready when epochInfo.absoluteSlot is not zero', () => {
@@ -287,8 +312,8 @@ describe('dashboardInfoReducer', () => {
     });
 
     describe('SetEpochInfo', () => {
-        it('should update epochInfo and set status to Ready when avgSlotTime_1h is not zero', () => {
-            const initialState = createInitialState({ avgSlotTime_1h: 0.5 });
+        it('should update epochInfo and set status to Ready when msPerSlot_1h is not zero', () => {
+            const initialState = createInitialState({ msPerSlot_1h: 500 });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000),
                 blockHeight: BigInt(500),
@@ -307,8 +332,8 @@ describe('dashboardInfoReducer', () => {
             expect(result.status).toBe(ClusterStatsStatus.Ready);
         });
 
-        it('should set status to Loading when avgSlotTime_1h is zero', () => {
-            const initialState = createInitialState({ avgSlotTime_1h: 0 });
+        it('should set status to Loading when msPerSlot_1h is zero', () => {
+            const initialState = createInitialState({ msPerSlot_1h: 0 });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000),
                 blockHeight: BigInt(500),
@@ -329,8 +354,8 @@ describe('dashboardInfoReducer', () => {
 
         it('should preserve existing blockTime when interpolation conditions are not met', () => {
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1234567890,
+                msPerSlot_1h: 500,
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000),
@@ -355,9 +380,9 @@ describe('dashboardInfoReducer', () => {
                 slot: BigInt(500),
             };
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1000000000,
-                lastBlockTime, // 500ms per slot
+                lastBlockTime,
+                msPerSlot_1h: 500, // 500ms per slot
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000), // 500 slots ahead
@@ -384,9 +409,9 @@ describe('dashboardInfoReducer', () => {
                 slot: BigInt(1000),
             };
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1000000000,
                 lastBlockTime,
+                msPerSlot_1h: 500,
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(500), // Less than lastBlockTime.slot
@@ -405,15 +430,15 @@ describe('dashboardInfoReducer', () => {
             expect(result.blockTime).toBe(1000000000); // Preserved, no interpolation
         });
 
-        it('should not interpolate when avgSlotTime_1h is zero', () => {
+        it('should not interpolate when msPerSlot_1h is zero', () => {
             const lastBlockTime: BlockTimeInfo = {
                 blockTime: 1000000000,
                 slot: BigInt(500),
             };
             const initialState = createInitialState({
-                avgSlotTime_1h: 0,
                 blockTime: 1000000000,
                 lastBlockTime,
+                msPerSlot_1h: 0,
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000),
@@ -434,9 +459,9 @@ describe('dashboardInfoReducer', () => {
 
         it('should not interpolate when lastBlockTime is not set', () => {
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1000000000,
                 lastBlockTime: undefined,
+                msPerSlot_1h: 500,
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(1000),
@@ -461,9 +486,9 @@ describe('dashboardInfoReducer', () => {
                 slot: BigInt(500),
             };
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1000000000,
                 lastBlockTime,
+                msPerSlot_1h: 500,
             });
             const epochInfo: EpochInfo = {
                 absoluteSlot: BigInt(500), // Same as lastBlockTime.slot
@@ -503,9 +528,9 @@ describe('dashboardInfoReducer', () => {
 
         it('should preserve all other state properties', () => {
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
-                avgSlotTime_1min: 0.6,
                 blockTime: 1234567890,
+                msPerSlot_1h: 500,
+                msPerSlot_1min: 600,
                 status: ClusterStatsStatus.Loading,
             });
             const action: DashboardInfoAction = {
@@ -516,8 +541,8 @@ describe('dashboardInfoReducer', () => {
             const result = dashboardInfoReducer(initialState, action);
 
             expect(result.status).toBe(ClusterStatsStatus.Error);
-            expect(result.avgSlotTime_1h).toBe(0.5);
-            expect(result.avgSlotTime_1min).toBe(0.6);
+            expect(result.msPerSlot_1h).toBe(500);
+            expect(result.msPerSlot_1min).toBe(600);
             expect(result.blockTime).toBe(1234567890);
         });
     });
@@ -525,13 +550,11 @@ describe('dashboardInfoReducer', () => {
     describe('Reset', () => {
         it('should replace entire state with action data', () => {
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
-                avgSlotTime_1min: 0.6,
+                msPerSlot_1h: 500,
+                msPerSlot_1min: 600,
                 status: ClusterStatsStatus.Ready,
             });
             const newState: DashboardInfo = {
-                avgSlotTime_1h: 0.7,
-                avgSlotTime_1min: 0.8,
                 blockTime: 9876543210,
                 epochInfo: {
                     absoluteSlot: BigInt(2000),
@@ -540,6 +563,8 @@ describe('dashboardInfoReducer', () => {
                     slotIndex: BigInt(200),
                     slotsInEpoch: BigInt(432000),
                 },
+                msPerSlot_1h: 700,
+                msPerSlot_1min: 800,
                 status: ClusterStatsStatus.Loading,
             };
             const action: DashboardInfoAction = {
@@ -555,17 +580,15 @@ describe('dashboardInfoReducer', () => {
 
         it('should completely replace state even with partial data', () => {
             const initialState = createInitialState({
-                avgSlotTime_1h: 0.5,
                 blockTime: 1234567890,
                 lastBlockTime: {
                     blockTime: 1234567890,
                     slot: BigInt(1000),
                 },
+                msPerSlot_1h: 500,
                 status: ClusterStatsStatus.Ready,
             });
             const newState: DashboardInfo = {
-                avgSlotTime_1h: 0,
-                avgSlotTime_1min: 0,
                 epochInfo: {
                     absoluteSlot: BigInt(0),
                     blockHeight: BigInt(0),
@@ -573,6 +596,8 @@ describe('dashboardInfoReducer', () => {
                     slotIndex: BigInt(0),
                     slotsInEpoch: BigInt(0),
                 },
+                msPerSlot_1h: 0,
+                msPerSlot_1min: 0,
                 status: ClusterStatsStatus.Error,
             };
             const action: DashboardInfoAction = {

--- a/app/providers/stats/solanaClusterStats.tsx
+++ b/app/providers/stats/solanaClusterStats.tsx
@@ -42,8 +42,6 @@ const initialPerformanceInfo: PerformanceInfo = {
 };
 
 const initialDashboardInfo: DashboardInfo = {
-    avgSlotTime_1h: 0,
-    avgSlotTime_1min: 0,
     epochInfo: {
         absoluteSlot: BigInt(0),
         blockHeight: BigInt(0),
@@ -51,6 +49,8 @@ const initialDashboardInfo: DashboardInfo = {
         slotIndex: BigInt(0),
         slotsInEpoch: BigInt(0),
     },
+    msPerSlot_1h: 0,
+    msPerSlot_1min: 0,
     status: ClusterStatsStatus.Loading,
 };
 

--- a/app/providers/stats/solanaDashboardInfo.tsx
+++ b/app/providers/stats/solanaDashboardInfo.tsx
@@ -1,10 +1,15 @@
+import { measureMsPerSlot } from '@entities/slot-time';
+
 import { ClusterStatsStatus } from './solanaClusterStats';
 import { PerformanceSample } from './solanaPerformanceInfo';
 
+/** Each sample covers one minute, so an hour of history is 60 of them. */
+const SAMPLES_PER_HOUR = 60;
+
 export type DashboardInfo = {
     status: ClusterStatsStatus;
-    avgSlotTime_1h: number;
-    avgSlotTime_1min: number;
+    msPerSlot_1h: number;
+    msPerSlot_1min: number;
     epochInfo: EpochInfo;
     blockTime?: number;
     lastBlockTime?: BlockTimeInfo;
@@ -75,55 +80,40 @@ export function dashboardInfoReducer(state: DashboardInfo, action: DashboardInfo
         }
 
         case DashboardInfoActionType.SetPerfSamples: {
-            if (action.data.length < 1) {
+            const msPerSlot_1h = measureMsPerSlot(action.data, SAMPLES_PER_HOUR);
+            const msPerSlot_1min = measureMsPerSlot(action.data, 1);
+
+            // Rather than label an older minute "1min" when the newest one produced no slot, the last
+            // figures stand until the next poll.
+            if (msPerSlot_1h === undefined || msPerSlot_1min === undefined) {
                 return state;
             }
-
-            const samples = action.data
-                .filter(sample => {
-                    return sample.numSlots !== BigInt(0);
-                })
-                .map(sample => {
-                    return sample.samplePeriodSecs / Number(sample.numSlots);
-                })
-                .slice(0, 60);
-
-            if (samples.length === 0) {
-                return state;
-            }
-
-            const samplesInHour = samples.length < 60 ? samples.length : 60;
-            const avgSlotTime_1h =
-                samples.reduce((sum: number, cur: number) => {
-                    return sum + cur;
-                }, 0) / samplesInHour;
 
             const status =
                 state.epochInfo.absoluteSlot !== BigInt(0) ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
 
             return {
                 ...state,
-                avgSlotTime_1h,
-                avgSlotTime_1min: samples[0],
+                msPerSlot_1h,
+                msPerSlot_1min,
                 status,
             };
         }
 
         case DashboardInfoActionType.SetEpochInfo: {
-            const status = state.avgSlotTime_1h !== 0 ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
+            const status = state.msPerSlot_1h !== 0 ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
 
             let blockTime = state.blockTime;
 
             // interpolate blocktime based on last known blocktime and average slot time
             if (
                 state.lastBlockTime &&
-                state.avgSlotTime_1h !== 0 &&
+                state.msPerSlot_1h !== 0 &&
                 action.data.absoluteSlot >= state.lastBlockTime.slot
             ) {
                 blockTime = Number(
                     BigInt(state.lastBlockTime.blockTime) +
-                        (action.data.absoluteSlot - state.lastBlockTime.slot) *
-                            BigInt(Math.floor(state.avgSlotTime_1h * 1000)),
+                        (action.data.absoluteSlot - state.lastBlockTime.slot) * BigInt(state.msPerSlot_1h),
                 );
             }
 

--- a/app/providers/stats/solanaDashboardInfo.tsx
+++ b/app/providers/stats/solanaDashboardInfo.tsx
@@ -5,6 +5,7 @@ import { PerformanceSample } from './solanaPerformanceInfo';
 
 /** Each sample covers one minute, so an hour of history is 60 of them. */
 const SAMPLES_PER_HOUR = 60;
+const SAMPLES_PER_MINUTE = 1;
 
 export type DashboardInfo = {
     status: ClusterStatsStatus;
@@ -81,7 +82,7 @@ export function dashboardInfoReducer(state: DashboardInfo, action: DashboardInfo
 
         case DashboardInfoActionType.SetPerfSamples: {
             const msPerSlot_1h = measureMsPerSlot(action.data, SAMPLES_PER_HOUR);
-            const msPerSlot_1min = measureMsPerSlot(action.data, 1);
+            const msPerSlot_1min = measureMsPerSlot(action.data, SAMPLES_PER_MINUTE);
 
             // Rather than label an older minute "1min" when the newest one produced no slot, the last
             // figures stand until the next poll.


### PR DESCRIPTION
## Description

The home page measured milliseconds per slot with its own formula, which disagreed with the one the feature-gate countdown uses. It read high, so the epoch countdown built on it overstated the time remaining.

`solanaDashboardInfo` averaged the per-sample rates unweighted. A slow minute produces fewer slots by definition, so weighting every sample alike gives the slow minutes more than their share. On five mainnet samples at the 300 ms gate with one degraded minute it returned 371 ms where the cluster ran at 347 ms — 2.88 h apart over a full epoch.

### The fix

-   **Measure the dashboard rate with the slot-time entity.** `measureMsPerSlot` divides total time by total slots once, so both home-page figures agree with the feature-gate countdown.
-   **Make the sample window a parameter.** The dashboard measures over 60 samples and over 1, the countdown keeps its 5, and the entity no longer hardcodes one window.
-   **Name the unit in the fields.** `avgSlotTime_1h` and `avgSlotTime_1min` held seconds and became `msPerSlot_1h` and `msPerSlot_1min`, which drops three unit conversions at the call sites.
-   **Hold the figures when the newest minute produced no slot.** The old code labelled an older minute "1min average"; nothing new is reported until the next poll.

## Type of change

-   [x] Bug fix

## Testing

-   **The 1hr average no longer runs high.** Read `Slot time (1hr average)` in `Live Cluster Stats` — [preview](https://explorer-git-fork-hoodieshq-fix-unify-69ae0a-solana-foundation.vercel.app) · [production](https://explorer.solana.com). Expect a figure at or below production's, matching `Slot time (1min average)` on a steady cluster; production reads high whenever any recent minute was slow.
-   **Epoch time remaining shortens to match.** Read `Epoch time remaining (approx.)` in the same card — [preview](https://explorer-git-fork-hoodieshq-fix-unify-69ae0a-solana-foundation.vercel.app) · [production](https://explorer.solana.com). Expect it to agree with the `Cluster Activation` countdown on a feature-gate account; production overstates it by the same proportion the rate is inflated.

## Related Issues

Closes [HOO-1416](https://linear.app/solana-fndn/issue/HOO-1416/unify-slot-time-measurement-two-formulas-disagree)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

`build:info` regenerates `bench/BUILD.md` with a first-load shift across the `/address/*` routes, but a build of `master` with no changes produces the same table, so the drift predates this PR and is left out of the diff.

The two countdowns now share a formula, not a window: the home page measures over 60 samples and the feature-gate countdown over 5, so they can still differ slightly on a cluster whose rate is moving.

