### PR TITLE
fix(feature-gates): keep the update script runnable outside Next

### DIFF
--- a/.github/workflows/update-feature-gates.yml
+++ b/.github/workflows/update-feature-gates.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
 
-      # scripts/update-feature-gates.ts imports app/entities/feature-gate/server, which reaches the
-      # built @explorer/parsers through app/validators/pubkey.ts.
+      # scripts/update-feature-gates.ts imports the feature-gate schema, which reaches the built
+      # @explorer/parsers through app/validators/pubkey.ts.
       - name: Build workspace packages
         run: pnpm build:packages
 

--- a/app/entities/feature-gate/feature-gates.json
+++ b/app/entities/feature-gate/feature-gates.json
@@ -2206,7 +2206,7 @@
     "description": "Reduce lamports_per_byte incrementally from 6960 to 696 via five steps: 6333, 5080, 2575, 1322, and 696. This proposal supersedes SIMD-0436, providing a more granular reduction schedule.",
     "devnet_activation_epoch": 1137,
     "key": "4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC",
-    "mainnet_activation_epoch": null,
+    "mainnet_activation_epoch": 1028,
     "min_agave_versions": [
       "v4.2.0-beta.1"
     ],
@@ -2230,7 +2230,7 @@
   {
     "comms_required": null,
     "description": "The current live transaction formats, v0 and legacy, have a number of limitations that make them unsuitable for efficient ingestion, processing, and unable to support developer features that are required for today's applications.",
-    "devnet_activation_epoch": null,
+    "devnet_activation_epoch": 1140,
     "key": "txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL",
     "mainnet_activation_epoch": null,
     "min_agave_versions": [
@@ -2282,7 +2282,7 @@
   {
     "comms_required": null,
     "description": "Reduce lamports_per_byte incrementally from 6960 to 696 via five steps: 6333, 5080, 2575, 1322, and 696. This proposal supersedes SIMD-0436, providing a more granular reduction schedule.",
-    "devnet_activation_epoch": null,
+    "devnet_activation_epoch": 1141,
     "key": "61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81",
     "mainnet_activation_epoch": null,
     "min_agave_versions": [
@@ -2302,7 +2302,7 @@
     "simds": [
       "0437"
     ],
-    "testnet_activation_epoch": null,
+    "testnet_activation_epoch": 1026,
     "title": "SIMD-0437-2: Set lamports per byte to 5080"
   }
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -642,6 +642,33 @@ export default tseslint.config(
         },
     },
 
+    // `scripts/**` runs as a plain Node process, where a slice's `server.ts` / `client.ts` barrel is
+    // the wrong door: the `server-only` / `client-only` marker on it resolves to its throwing
+    // `default` export outside Next's build, so the script dies on import. No green gate catches it —
+    // vite aliases both markers to a stub, so the specs pass and the cron is where it surfaces.
+    {
+        files: ['scripts/**/*.[jt]s?(x)'],
+        rules: {
+            'no-restricted-imports': [
+                'error',
+                {
+                    patterns: [
+                        {
+                            group: [
+                                '**/app/**/server',
+                                '**/app/**/server.ts',
+                                '**/app/**/client',
+                                '**/app/**/client.ts',
+                            ],
+                            message:
+                                "A slice's `server.ts`/`client.ts` barrel carries a `server-only`/`client-only` marker that throws outside Next's build. Import the module that owns the export instead.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+
     // Allow type assertions in tests, mocks, fixtures, and Storybook stories — they routinely fake
     // partial shapes to exercise component/module surfaces and shouldn't be held to the production
     // typecast prohibition.

--- a/scripts/feature-gates/lib/__tests__/merge.spec.ts
+++ b/scripts/feature-gates/lib/__tests__/merge.spec.ts
@@ -1,4 +1,4 @@
-import type { FeatureGateDraft } from '../../../../app/entities/feature-gate/server';
+import type { FeatureGateDraft } from '../../../../app/entities/feature-gate/lib/feature-gates-schema';
 import { appendNewFeatures, hasDescription, resolveEpoch } from '../merge';
 import type { FeatureProbeResult } from '../rpc';
 

--- a/scripts/feature-gates/lib/__tests__/module-graph.spec.ts
+++ b/scripts/feature-gates/lib/__tests__/module-graph.spec.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+// The entry script is excluded on purpose: it calls `main()` at module scope, so importing it would
+// run the whole pipeline against live RPC and GitHub.
+const PIPELINE_MODULES = [
+    './scripts/feature-gates/lib/feature-store.ts',
+    './scripts/feature-gates/lib/http.ts',
+    './scripts/feature-gates/lib/merge.ts',
+    './scripts/feature-gates/lib/rpc.ts',
+    './scripts/feature-gates/lib/schedule.ts',
+    './scripts/feature-gates/lib/simd-proposals.ts',
+    './scripts/feature-gates/lib/simd-summary.ts',
+];
+
+/**
+ * The cron runs the pipeline under plain `tsx`, where `server-only` and `client-only` resolve to a
+ * bare `throw`. This suite cannot see that: `vite.config.mts` aliases both markers to a stub, so a
+ * module that kills the cron on import still passes every spec. Load the graph in a child process to
+ * get the resolution the cron gets.
+ *
+ * The eslint rule on `scripts/**` bans the `server.ts`/`client.ts` barrels that carry the marker by
+ * convention; this catches the rest, including a marker added to a plain module the pipeline already
+ * imports.
+ */
+describe('feature-gate pipeline module graph', () => {
+    it('should load under plain Node, where the server-only marker throws', () => {
+        // `tsx --eval` compiles to CJS, so no top-level await. A rejection has to exit non-zero
+        // explicitly for `execFileSync` to see the failure.
+        const imports = PIPELINE_MODULES.map(modulePath => `import('${modulePath}')`).join(', ');
+        const program = `Promise.all([${imports}]).then(() => process.exit(0), error => { console.error(error); process.exit(1); })`;
+
+        expect(() =>
+            execFileSync('pnpm', ['exec', 'tsx', '--eval', program], {
+                cwd: REPO_ROOT,
+                encoding: 'utf8',
+                stdio: 'pipe',
+            }),
+        ).not.toThrow();
+    }, 120_000);
+});

--- a/scripts/feature-gates/lib/feature-store.ts
+++ b/scripts/feature-gates/lib/feature-store.ts
@@ -8,7 +8,7 @@ import {
     type FeatureGate,
     type FeatureGateDraft,
     FeatureGatesArraySchema,
-} from '../../../app/entities/feature-gate/server';
+} from '../../../app/entities/feature-gate/lib/feature-gates-schema';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, '..', '..', '..');

--- a/scripts/feature-gates/lib/merge.ts
+++ b/scripts/feature-gates/lib/merge.ts
@@ -1,4 +1,4 @@
-import type { FeatureGateDraft } from '../../../app/entities/feature-gate/server';
+import type { FeatureGateDraft } from '../../../app/entities/feature-gate/lib/feature-gates-schema';
 import type { FeatureProbeResult } from './rpc';
 
 export type RefreshMode = 'default' | 'refresh-activated';

--- a/scripts/feature-gates/lib/schedule.ts
+++ b/scripts/feature-gates/lib/schedule.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/no-null -- null literals match the nullable feature-gate schema fields */
 import { array, assert, type Infer, nullable, number, record, string, type, union, unknown } from 'superstruct';
 
-import type { FeatureGateDraft } from '../../../app/entities/feature-gate/server';
+import type { FeatureGateDraft } from '../../../app/entities/feature-gate/lib/feature-gates-schema';
 import { fetchSimdProposals, resolveSimdLinks } from './simd-proposals';
 
 const SCHEDULE_URL = 'https://raw.githubusercontent.com/wiki/anza-xyz/agave/feature-gate-tracker-schedule.json';

--- a/scripts/update-feature-gates.ts
+++ b/scripts/update-feature-gates.ts
@@ -28,7 +28,7 @@
  *       on the daily cron.
  */
 
-import type { FeatureGateDraft } from '../app/entities/feature-gate/server';
+import type { FeatureGateDraft } from '../app/entities/feature-gate/lib/feature-gates-schema';
 import { readFeatureGates, writeFeatureGates } from './feature-gates/lib/feature-store';
 import { appendNewFeatures, hasDescription, type RefreshMode, resolveEpoch } from './feature-gates/lib/merge';
 import { connectCluster, type FeatureProbeResult, probeFeatureActivation } from './feature-gates/lib/rpc';


### PR DESCRIPTION
## Description

The daily `update-feature-gates` cron has produced nothing since #1282. Every run failed on import, so the data behind `/feature-gates` went stale.

`scripts/feature-gates/lib/feature-store.ts` read `FeatureGatesArraySchema` from the slice's `server.ts` barrel, and #1282 added `import 'server-only'` to that barrel. The package resolves to a no-op under the `react-server` condition and to a bare `throw` under `default`. Next's build sets that condition; a plain `tsx` process does not, so the cron got the throwing copy:

    Error: This module cannot be imported from a Client Component module.
        at app/entities/feature-gate/server.ts:1:8
        at scripts/feature-gates/lib/feature-store.ts:11

### The fix

- **Take the schema from the module that owns it.** `feature-store.ts` and four `import type` sites now read `lib/feature-gates-schema` rather than a Next barrel. The cron is neither a client nor a server component, so the barrel was never the right door.
- **Test the pipeline the way the cron loads it.** A new spec imports the pipeline's modules in a child `tsx` process, where the marker resolves as it does in production. `vite.config.mts` aliases `server-only` to a stub, so the existing specs passed against a barrel that throws.
- **Ban the barrels from `scripts/**` in ESLint.** The spec catches a marker on any module the pipeline imports; the rule catches the `server.ts`/`client.ts` barrels that carry one by convention.
- **Refresh the data.** One run of the fixed pipeline: SIMD-0437 reached mainnet epoch 1028, plus three devnet/testnet epochs.

## Type of change

-   [x] Bug fix
-   [x] Other (please describe): adds two guards for a failure mode no green test run can see

## Testing

- **The cron script completes.** Run `pnpm build:packages && pnpm exec tsx scripts/update-feature-gates.ts`. Expect exit 0, a per-cluster probe log, and any epoch changes written to `app/entities/feature-gate/feature-gates.json`. On `master` it exits 1 on the first import with no probes logged.
- **The new spec catches the regression.** Run `pnpm vitest --project specs run scripts/feature-gates/lib/__tests__/module-graph.spec.ts`. Expect it to pass, and to fail with the error above if `feature-store.ts` is pointed back at `@entities/feature-gate/server`.

## Related Issues

Closes [HOO-1558](https://linear.app/solana-fndn/issue/HOO-1558/fix-failing-feature-gate-updates)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

`build:info` leaves `bench/BUILD.md` unchanged for this PR — verified by building `upstream/master` alone and diffing the two tables, which come out identical. The committed table is stale from #1267: regenerating it adds `/mcp/docs` and shifts first-load across most routes. That belongs to #1267, so it is not folded in here.

The four refreshed rows in `feature-gates.json` are pipeline output, not hand edits. Happy to drop them and let the next cron run open its own data PR if you would rather review the fix alone.
