### PR TITLE
chore(bench): regenerate the route size table

### DIFF
--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -4,33 +4,33 @@
 |------|-------|------|---------------|
 | Static | `/` | 130 kB | 530 kB |
 | Static | `/_not-found` | 0 B | 410 kB |
-| Dynamic | `/address/[address]` | 500 kB | 900 kB |
-| Dynamic | `/address/[address]/account-data` | 510 kB | 920 kB |
-| Dynamic | `/address/[address]/anchor-account` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/anchor-program` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/attestation` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/attributes` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/blockhashes` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/compression` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/concurrent-merkle-tree` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/domains` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/entries` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/feature-gate` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/idl` | 590 kB | 990 kB |
-| Dynamic | `/address/[address]/instructions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/metadata` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/program-multisig` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/rewards` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/security` | 470 kB | 880 kB |
-| Dynamic | `/address/[address]/slot-hashes` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/stake-history` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/subscriptions` | 470 kB | 870 kB |
-| Dynamic | `/address/[address]/token-extensions` | 470 kB | 880 kB |
-| Dynamic | `/address/[address]/tokens` | 480 kB | 890 kB |
-| Dynamic | `/address/[address]/transfers` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/verified-build` | 470 kB | 880 kB |
-| Dynamic | `/address/[address]/vote-history` | 470 kB | 870 kB |
+| Dynamic | `/address/[address]` | 520 kB | 920 kB |
+| Dynamic | `/address/[address]/account-data` | 520 kB | 920 kB |
+| Dynamic | `/address/[address]/anchor-account` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/anchor-program` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/attestation` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/attributes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/blockhashes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/compression` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/concurrent-merkle-tree` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/domains` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/entries` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/feature-gate` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/idl` | 600 kB | 0.97 MB |
+| Dynamic | `/address/[address]/instructions` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/metadata` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/program-multisig` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/rewards` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/security` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/slot-hashes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/stake-history` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/subscriptions` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/token-extensions` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/tokens` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/transfers` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/verified-build` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/vote-history` | 480 kB | 880 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
 | Dynamic | `/api/geo-location` | — | — |
@@ -51,18 +51,19 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 260 kB | 660 kB |
-| Dynamic | `/block/[slot]/accounts` | 250 kB | 650 kB |
-| Dynamic | `/block/[slot]/programs` | 250 kB | 650 kB |
-| Dynamic | `/block/[slot]/rewards` | 250 kB | 650 kB |
-| Dynamic | `/epoch/[epoch]` | 10 kB | 420 kB |
-| Static | `/feature-gates` | 40 kB | 450 kB |
+| Dynamic | `/block/[slot]` | 240 kB | 640 kB |
+| Dynamic | `/block/[slot]/accounts` | 240 kB | 640 kB |
+| Dynamic | `/block/[slot]/programs` | 240 kB | 640 kB |
+| Dynamic | `/block/[slot]/rewards` | 230 kB | 640 kB |
+| Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
+| Static | `/feature-gates` | 40 kB | 440 kB |
 | Dynamic | `/mcp` | — | — |
+| Static | `/mcp/docs` | 20 kB | 420 kB |
 | Static | `/mcp/start` | 20 kB | 420 kB |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 410 kB |
-| Dynamic | `/tx/[signature]` | 510 kB | 910 kB |
+| Dynamic | `/tx/[signature]` | 530 kB | 930 kB |
 | Dynamic | `/tx/[signature]/inspect` | 440 kB | 840 kB |
 | Static | `/tx/inspector` | 440 kB | 840 kB |

--- a/scripts/update-sitemap.ts
+++ b/scripts/update-sitemap.ts
@@ -46,8 +46,8 @@ const STATIC_OVERRIDES: Record<string, RouteOverride> = {
     '/tx/inspector': { priority: 0.3, changefreq: 'weekly' },
 };
 
-// `/mcp/start` is excluded until the MCP endpoint is announced — drop the entry to list it again.
-const EXCLUDED_STATIC_ROUTES = ['/_not-found', '/opengraph-image.png', '/mcp/start'];
+// The MCP pages stay out until the MCP endpoint is announced — drop an entry to list it again.
+const EXCLUDED_STATIC_ROUTES = ['/_not-found', '/opengraph-image.png', '/mcp/start', '/mcp/docs'];
 
 // Collect all known program addresses from programs.ts (MainnetBeta only)
 const MAINNET_PROGRAM_IDS = Object.entries(PROGRAM_INFO_BY_ID)


### PR DESCRIPTION
## Description

`bench/BUILD.md` records the size of the client bundle for every route. It last moved in #1282. Eight PRs have landed since, and none of them regenerated it.

CI never runs `build:info`; the PR template asks the author to. So the table drifts silently, and the next author who regenerates it inherits eight PRs' worth of movement they cannot explain.

### The change

- **Regenerate the table.** `pnpm build:info` on `master`, committed unmodified.
- **List `/mcp/docs`.** #1267 added the page and the table never picked it up. Static, 20 kB, 420 kB first load.
- **Keep `/mcp/docs` out of the sitemap.** `scripts/update-sitemap.ts` derives its static pages from this table, so listing the route puts it in `public/default-sitemap.xml` and fails `Sitemap-Check` on the drift — `/mcp/start` is already held back until the MCP endpoint is announced, and `/mcp/docs` now joins it.
- **Record size drift in both directions.** Address and `/tx/[signature]` routes gain 10–20 kB; `/block/[slot]` routes drop 10–20 kB. This is chunk re-splitting across eight PRs, not one regression.

## Type of change

-   [x] Other (please describe): regenerate the tracked route/size table

## Testing

- **The committed table matches a clean build.** Check out this branch, run `pnpm build:info`, and expect `git status` to report no change to `bench/BUILD.md`.

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information


