### PR TITLE
chore(cluster): remove the SIMD-296 cluster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,6 @@ MCP_GA_API_SECRET=
 MCP_SOLANA_RPC_URL_MAINNET_BETA=
 MCP_SOLANA_RPC_URL_DEVNET=
 MCP_SOLANA_RPC_URL_TESTNET=
-MCP_SOLANA_RPC_URL_SIMD296=
 ## Configuration for Sentry feature enabled
 ### Sentry is disabled by default. To enable error reporting, set SENTRY_DSN to
 ### your project's DSN (found in Sentry under Settings > Projects > Client Keys).

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -349,14 +349,5 @@ describe('GET /api/search', () => {
             expect(data.results.tokens).toHaveLength(1);
             expect(res.headers.get('Cache-Control')).toContain('s-maxage=30');
         });
-
-        it('should short-circuit Simd296 with empty result and no-store headers', async () => {
-            const res = await GET(makeRequest('sol', 'simd296'));
-            expect(res.status).toBe(200);
-            const data = await res.json();
-            expect(data).toMatchObject({ results: { tokens: [] }, success: true });
-            expect(res.headers.get('Cache-Control')).toContain('no-store');
-            expect(fetchMock).not.toHaveBeenCalled();
-        });
     });
 });

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -83,20 +83,6 @@ export async function GET(request: Request) {
         );
     }
 
-    // SIMD-296 is an experimental cluster not covered by Jupiter/UTL token lists.
-    if (cluster === Cluster.Simd296) {
-        return NextResponse.json(
-            {
-                meta: { total: 0 },
-                query: trimmed,
-                queryType: detectQueryType(trimmed),
-                results: { tokens: [] },
-                success: true,
-            },
-            { headers: NO_STORE_HEADERS },
-        );
-    }
-
     const queryType = detectQueryType(trimmed);
     const tokens = await resolveSearchTokens(trimmed, cluster, { filterUnverified });
 

--- a/app/entities/chain-id/lib/__tests__/get-chain-id.spec.ts
+++ b/app/entities/chain-id/lib/__tests__/get-chain-id.spec.ts
@@ -24,7 +24,9 @@ describe('getChainId', () => {
         });
     });
 
-    describe.each([Cluster.Simd296, Cluster.Custom])('%s cluster', cluster => {
+    describe('Custom cluster', () => {
+        const cluster = Cluster.Custom;
+
         it('should return undefined when no genesisHash provided', () => {
             expect(getChainId(cluster)).toBeUndefined();
         });

--- a/app/entities/chain-id/lib/get-chain-id.ts
+++ b/app/entities/chain-id/lib/get-chain-id.ts
@@ -24,7 +24,6 @@ export function getChainId(cluster: Cluster, genesisHash?: string): ChainId | un
             return ChainId.TESTNET;
         case Cluster.Devnet:
             return ChainId.DEVNET;
-        case Cluster.Simd296:
         case Cluster.Custom:
             return genesisHash ? getChainIdFromGenesisHash(genesisHash) : undefined;
         default:

--- a/app/entities/cluster/lib/__tests__/cluster-from-param.spec.ts
+++ b/app/entities/cluster/lib/__tests__/cluster-from-param.spec.ts
@@ -12,12 +12,11 @@ describe('clusterFromParam', () => {
         expect(clusterFromParam('0')).toBe(Cluster.MainnetBeta);
         expect(clusterFromParam('1')).toBe(Cluster.Testnet);
         expect(clusterFromParam('2')).toBe(Cluster.Devnet);
-        expect(clusterFromParam('3')).toBe(Cluster.Simd296);
-        expect(clusterFromParam('4')).toBe(Cluster.Custom);
+        expect(clusterFromParam('3')).toBe(Cluster.Custom);
     });
 
     it('should return undefined for out-of-range numbers', () => {
-        expect(clusterFromParam('5')).toBeUndefined();
+        expect(clusterFromParam('4')).toBeUndefined();
         expect(clusterFromParam('-1')).toBeUndefined();
         expect(clusterFromParam('999')).toBeUndefined();
     });
@@ -41,7 +40,7 @@ describe('resolveServerClusterUrl', () => {
     });
 
     it.each([
-        ['the custom cluster', '4'],
+        ['the custom cluster', '3'],
         ['an unknown cluster', '999'],
         ['a malformed param', '01'],
     ])('should refuse %s as the caller’s input', (_reason, value) => {
@@ -63,7 +62,7 @@ describe('serverClusterUrlFromParam', () => {
 
     it('should return undefined for a custom cluster (no server endpoint)', () => {
         // Custom short-circuits before `serverClusterUrl`, which cannot resolve it. Custom is client-only.
-        expect(serverClusterUrlFromParam('4')).toBeUndefined();
+        expect(serverClusterUrlFromParam('3')).toBeUndefined();
     });
 
     it('should return undefined when the cluster env var is set to an empty string', () => {

--- a/app/entities/cluster/lib/__tests__/cluster.spec.ts
+++ b/app/entities/cluster/lib/__tests__/cluster.spec.ts
@@ -18,7 +18,6 @@ const BLANKABLE_ENDPOINTS: [string, ServerCluster, string][] = [
     ['mainnet-beta', Cluster.MainnetBeta, 'NEXT_PUBLIC_MAINNET_RPC_URL'],
     ['testnet', Cluster.Testnet, 'NEXT_PUBLIC_TESTNET_RPC_URL'],
     ['devnet', Cluster.Devnet, 'NEXT_PUBLIC_DEVNET_RPC_URL'],
-    ['simd296', Cluster.Simd296, 'NEXT_PUBLIC_SIMD296_RPC_URL'],
 ];
 
 describe('ClusterSelection', () => {
@@ -46,7 +45,7 @@ describe('clusterUrl', () => {
     });
 
     it('should resolve every known cluster to its own endpoint, ignoring any custom URL', () => {
-        const clusters: ServerCluster[] = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet, Cluster.Simd296];
+        const clusters: ServerCluster[] = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet];
 
         for (const cluster of clusters) {
             const url = clusterUrl({ cluster });
@@ -89,7 +88,7 @@ describe('clusterSelection', () => {
 
 describe('serverClusterUrl', () => {
     it('should resolve each non-custom cluster to its own valid endpoint', () => {
-        const clusters: ServerCluster[] = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet, Cluster.Simd296];
+        const clusters: ServerCluster[] = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet];
         const urls = clusters.map(serverClusterUrl);
 
         for (const url of urls) {

--- a/app/entities/cluster/lib/cluster.ts
+++ b/app/entities/cluster/lib/cluster.ts
@@ -10,11 +10,10 @@ export enum Cluster {
     MainnetBeta,
     Testnet,
     Devnet,
-    Simd296,
     Custom,
 }
 
-export const CLUSTERS = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet, Cluster.Simd296, Cluster.Custom];
+export const CLUSTERS = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet, Cluster.Custom];
 
 export function clusterSlug(cluster: Cluster): string {
     switch (cluster) {
@@ -24,8 +23,6 @@ export function clusterSlug(cluster: Cluster): string {
             return 'testnet';
         case Cluster.Devnet:
             return 'devnet';
-        case Cluster.Simd296:
-            return 'simd296';
         case Cluster.Custom:
             return 'custom';
     }
@@ -39,8 +36,6 @@ export function clusterName(cluster: Cluster): string {
             return 'Testnet';
         case Cluster.Devnet:
             return 'Devnet';
-        case Cluster.Simd296:
-            return 'SIMD-296';
         case Cluster.Custom:
             return 'Custom';
     }
@@ -49,7 +44,6 @@ export function clusterName(cluster: Cluster): string {
 export const MAINNET_BETA_URL = 'https://api.mainnet-beta.solana.com';
 export const TESTNET_URL = 'https://api.testnet.solana.com';
 export const DEVNET_URL = 'https://api.devnet.solana.com';
-export const SIMD296_URL = 'https://simd-0296.surfnet.dev:8899';
 
 // On localhost we use the default public Solana RPCs (e.g. api.mainnet-beta.solana.com)
 // unless custom ones (server + client) are specified via env vars.
@@ -92,8 +86,6 @@ export function clusterUrl(selection: ClusterSelection): string {
             return process.env.NEXT_PUBLIC_MAINNET_RPC_URL || modifyUrl(MAINNET_BETA_URL);
         case Cluster.Testnet:
             return process.env.NEXT_PUBLIC_TESTNET_RPC_URL || modifyUrl(TESTNET_URL);
-        case Cluster.Simd296:
-            return process.env.NEXT_PUBLIC_SIMD296_RPC_URL || SIMD296_URL;
         case Cluster.Custom:
             // No fallback branch: the type guarantees an endpoint here.
             return selection.endpoint.href;
@@ -123,8 +115,6 @@ export function serverClusterUrl(cluster: ServerCluster): string {
             return process.env.MAINNET_RPC_URL ?? modifyUrl(MAINNET_BETA_URL);
         case Cluster.Testnet:
             return process.env.TESTNET_RPC_URL ?? modifyUrl(TESTNET_URL);
-        case Cluster.Simd296:
-            return process.env.SIMD296_RPC_URL ?? SIMD296_URL;
     }
 }
 

--- a/app/entities/cluster/model/__tests__/use-explorer-link.spec.ts
+++ b/app/entities/cluster/model/__tests__/use-explorer-link.spec.ts
@@ -17,7 +17,6 @@ describe('buildExplorerLink', () => {
         it.each([
             { cluster: Cluster.Devnet, expectedParam: 'cluster=devnet' },
             { cluster: Cluster.Testnet, expectedParam: 'cluster=testnet' },
-            { cluster: Cluster.Simd296, expectedParam: 'cluster=simd296' },
         ])('should append $expectedParam for $cluster', ({ cluster, expectedParam }) => {
             const result = buildExplorerLink(clusterSelection(cluster), '/tx/abc');
             expect(result).toBe(`${BASE}/tx/abc?${expectedParam}`);

--- a/app/entities/cluster/model/use-cluster-resource-search.ts
+++ b/app/entities/cluster/model/use-cluster-resource-search.ts
@@ -17,8 +17,8 @@ export interface ClusterResourceSearch {
  */
 export type ClusterResourceProbe = (url: string, resourceId: string) => Promise<boolean>;
 
-// The clusters this searches, and the only ones it may. Cluster.Simd296 is a temporary surfnet, so matches
-// there aren't linkable later. Cluster.Custom is absent on purpose — see `getSelectionsToProbe`.
+// The clusters this searches, and the only ones it may. Cluster.Custom is absent on purpose — see
+// `getSelectionsToProbe`.
 const PUBLIC_CLUSTERS: ServerCluster[] = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet];
 const PROBE_DELAY_MS = 700;
 

--- a/app/entities/cluster/model/use-explorer-link.ts
+++ b/app/entities/cluster/model/use-explorer-link.ts
@@ -15,7 +15,6 @@ export function buildExplorerLink(selection: ClusterSelection, path: string): st
     switch (selection.cluster) {
         case Cluster.Testnet:
         case Cluster.Devnet:
-        case Cluster.Simd296:
             params.append('cluster', clusterSlug(selection.cluster));
             break;
         case Cluster.Custom:

--- a/app/entities/compute-unit/lib/compute-units-schedule.ts
+++ b/app/entities/compute-unit/lib/compute-units-schedule.ts
@@ -47,7 +47,6 @@ interface ComputeUnitReserveConfig {
         readonly [Cluster.MainnetBeta]: number;
         readonly [Cluster.Devnet]: number;
         readonly [Cluster.Testnet]: number;
-        readonly [Cluster.Simd296]: number;
     };
     /** Function to get reserved compute units for a given program */
     readonly getReservedUnits: (programId: string) => number;
@@ -74,7 +73,6 @@ const COMPUTE_UNIT_RESERVE_CONFIGS: readonly ComputeUnitReserveConfig[] = [
             [Cluster.MainnetBeta]: 0,
             [Cluster.Devnet]: 0,
             [Cluster.Testnet]: 0,
-            [Cluster.Simd296]: 0,
         },
         description: 'Initial configuration - no built-in program optimization',
         getReservedUnits: (_programId: string) => DEFAULT_COMPUTE_UNITS,
@@ -84,7 +82,6 @@ const COMPUTE_UNIT_RESERVE_CONFIGS: readonly ComputeUnitReserveConfig[] = [
             [Cluster.MainnetBeta]: 759,
             [Cluster.Devnet]: 842,
             [Cluster.Testnet]: 750,
-            [Cluster.Simd296]: 0,
         },
         description: 'Built-in programs use minimal compute units',
         featureAccount: 'C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH',

--- a/app/entities/idl/api/config.ts
+++ b/app/entities/idl/api/config.ts
@@ -8,8 +8,8 @@ import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 import { LOADER_IDS, ZK_ELGAMAL_PROOF_PROGRAM_ID } from '@/app/utils/programs';
 
 // Programs that definitionally have no Anchor IDL. Skip the IDL PDA lookup so we don't depend on the
-// RPC returning `null` for it — some (e.g. the SIMD-296 testnet) return transient errors instead,
-// which used to Sentry-panic on every transaction touching a builtin. Curated behavioral list, not the
+// RPC returning `null` for it — some RPCs return transient errors instead, which used to Sentry-panic
+// on every transaction touching a builtin. Curated behavioral list, not the
 // `@/app/utils/programs` display registry: reuse canonical exports where they exist, literals otherwise.
 export const NON_ANCHOR_PROGRAMS = new Set<string>([
     SYSTEM_PROGRAM_ADDRESS,

--- a/app/entities/idl/api/resolve-program-idls.ts
+++ b/app/entities/idl/api/resolve-program-idls.ts
@@ -21,8 +21,8 @@ export type ResolvedProgramIdls = ProgramIdlSources<unknown>;
  *
  * Both come from `fetchLatestIdls` — the package's own `GET /api/latest` resolver (PMP canonical →
  * fndn fallback, Anchor PDA, side by side). Native/builtin programs skip the Anchor leg (PMP only via
- * `fetchPmpIdl`): they can't have an Anchor IDL and some RPCs (SIMD-296) throw, instead of returning
- * absent, for the derived PDA (see NON_ANCHOR_PROGRAMS).
+ * `fetchPmpIdl`): they can't have an Anchor IDL and some RPCs throw, instead of returning absent, for the
+ * derived PDA (see NON_ANCHOR_PROGRAMS).
  *
  * Every `@solana/idl` fetcher surfaces absent/undecodable as a value and throws **only on RPC
  * failure**, so a blip propagates to the caller (retryable 502 / SWR retry) and is never cached as a
@@ -30,7 +30,7 @@ export type ResolvedProgramIdls = ProgramIdlSources<unknown>;
  */
 export async function resolveProgramIdls(rpc: IdlRpc, programId: Address): Promise<ResolvedProgramIdls> {
     // Native/builtin programs can't have an Anchor IDL — skip the PDA lookup (see NON_ANCHOR_PROGRAMS);
-    // some RPCs even throw (SIMD-296) for the derived PDA, so we must not attempt it.
+    // some RPCs even throw for the derived PDA, so we must not attempt it.
     const resolveAnchor = !NON_ANCHOR_PROGRAMS.has(programId);
 
     let anchorContent: string | undefined;

--- a/app/entities/token-info/lib/is-valid-cluster.ts
+++ b/app/entities/token-info/lib/is-valid-cluster.ts
@@ -1,10 +1,7 @@
 import { getChainId } from '@entities/chain-id/@x/token-info';
 import { Cluster } from '@utils/cluster';
 
-type SupportedCluster = Extract<
-    Cluster,
-    Cluster.MainnetBeta | Cluster.Testnet | Cluster.Devnet | Cluster.Simd296 | Cluster.Custom
->;
+type SupportedCluster = Extract<Cluster, Cluster.MainnetBeta | Cluster.Testnet | Cluster.Devnet | Cluster.Custom>;
 
 export function isValidCluster(value: unknown, genesisHash?: string): value is SupportedCluster {
     return typeof value === 'number' && getChainId(value as Cluster, genesisHash) !== undefined;

--- a/app/features/mcp-docs/lib/setup-clients.ts
+++ b/app/features/mcp-docs/lib/setup-clients.ts
@@ -128,7 +128,7 @@ Prefer the \`solana-explorer\` MCP tools over model memory for any on-chain fact
    call \`inspect_entity\` with the base58 identifier — do not guess account contents,
    token decimals, authorities, or transaction outcomes from memory.
 2. Pass \`cluster\` explicitly when the user is not on mainnet-beta
-   (\`devnet\`, \`testnet\`, \`simd296\`).
+   (\`devnet\`, \`testnet\`).
 3. Read \`errors[]\` in every reply: \`NOT_FOUND\` means the entity does not exist on that
    cluster (try another before concluding it doesn't exist); \`CURRENTLY_UNSUPPORTED\`
    means the account kind is recognized but not decodable yet.

--- a/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
+++ b/app/features/mcp-docs/ui/McpDocsOverviewView.tsx
@@ -110,7 +110,7 @@ export function McpDocsOverviewView() {
                         )}
                     </HeroFact>
                     <HeroFact label="Clusters">
-                        <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
+                        <span className="text-sm">mainnet-beta · devnet · testnet</span>
                     </HeroFact>
                     <HeroFact label="Tools">
                         <span className="text-sm">inspect_entity · ping</span>

--- a/app/features/mcp-docs/ui/ToolsShowcase.tsx
+++ b/app/features/mcp-docs/ui/ToolsShowcase.tsx
@@ -110,8 +110,7 @@ function InspectEntityDoc() {
                     </ToolParam>
                     <ToolParam name="cluster">
                         One of <InlineCode>mainnet-beta</InlineCode>, <InlineCode>devnet</InlineCode>,{' '}
-                        <InlineCode>testnet</InlineCode>, <InlineCode>simd296</InlineCode>. Defaults to{' '}
-                        <InlineCode>mainnet-beta</InlineCode>.
+                        <InlineCode>testnet</InlineCode>. Defaults to <InlineCode>mainnet-beta</InlineCode>.
                     </ToolParam>
                 </div>
             </ToolDocSection>

--- a/app/features/mcp-docs/ui/__stories__/HeroFact.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/HeroFact.stories.tsx
@@ -30,7 +30,7 @@ export const Grid: Story = {
                 <span className="text-sm">Open — no key required</span>
             </HeroFact>
             <HeroFact label="Clusters">
-                <span className="text-sm">mainnet-beta · devnet · testnet · simd296</span>
+                <span className="text-sm">mainnet-beta · devnet · testnet</span>
             </HeroFact>
             <HeroFact label="Tools">
                 <span className="text-sm">inspect_entity · ping</span>

--- a/app/features/mcp-docs/ui/__stories__/InlineCode.stories.tsx
+++ b/app/features/mcp-docs/ui/__stories__/InlineCode.stories.tsx
@@ -22,7 +22,7 @@ export const InSentence: Story = {
         <p className="m-0 text-sm text-neutral-300">
             Pass <InlineCode>cluster</InlineCode> explicitly when the user is not on{' '}
             <InlineCode>mainnet-beta</InlineCode> — one of <InlineCode>devnet</InlineCode>,{' '}
-            <InlineCode>testnet</InlineCode> or <InlineCode>simd296</InlineCode>.
+            <InlineCode>testnet</InlineCode>.
         </p>
     ),
 };

--- a/app/features/receipt/model/__tests__/cluster.spec.ts
+++ b/app/features/receipt/model/__tests__/cluster.spec.ts
@@ -34,13 +34,12 @@ describe('parseClusterId', () => {
     it.each([
         ['1', Cluster.Testnet],
         ['2', Cluster.Devnet],
-        ['3', Cluster.Simd296],
     ])('should return cluster for valid id "%s"', (input, expected) => {
         expect(parseClusterId(input)).toBe(expected);
     });
 
-    // '0' is mainnet (not allowed), '4'/'999' out of range, 'devnet' → NaN, '' → 0 (mainnet)
-    it.each(['0', '4', '999', 'devnet', ''])('should return undefined for invalid cluster id "%s"', input => {
+    // '0' is mainnet (not allowed), '3' is custom (client-only), '999' out of range, 'devnet' → NaN, '' → 0 (mainnet)
+    it.each(['0', '3', '999', 'devnet', ''])('should return undefined for invalid cluster id "%s"', input => {
         expect(parseClusterId(input)).toBe(undefined);
     });
 });

--- a/app/features/receipt/model/cluster.ts
+++ b/app/features/receipt/model/cluster.ts
@@ -4,7 +4,7 @@ import type { SearchParams } from '../lib/normalize-search-params';
 import { normalizeSearchParams } from '../lib/normalize-search-params';
 
 // Clusters that can be specified via URL query param (non-mainnet)
-export type QueryCluster = Cluster.Devnet | Cluster.Testnet | Cluster.Simd296;
+export type QueryCluster = Cluster.Devnet | Cluster.Testnet;
 
 export function getClusterParam(searchParams: SearchParams): string | undefined {
     const normalized = normalizeSearchParams(searchParams);
@@ -15,7 +15,7 @@ export function getClusterParam(searchParams: SearchParams): string | undefined 
 export function parseClusterId(value: string | undefined): QueryCluster | undefined {
     if (value === undefined) return value;
     const id = Number(value);
-    if (id === Cluster.Devnet || id === Cluster.Testnet || id === Cluster.Simd296) {
+    if (id === Cluster.Devnet || id === Cluster.Testnet) {
         return id;
     }
     return undefined;

--- a/app/features/transaction/ui/TokenBalancesCard.tsx
+++ b/app/features/transaction/ui/TokenBalancesCard.tsx
@@ -63,7 +63,7 @@ export function TokenBalancesCardInner({ rows }: TokenBalancesCardInnerProps) {
     const [tokenSymbols, setTokenSymbols] = useState<Map<string, string>>(new Map());
     const mintKey = rows.map(r => r.mint).join(',');
 
-    // genesisHash is required to derive a chainId on Custom/Simd296 clusters - without it getTokenInfos returns [].
+    // genesisHash is required to derive a chainId on the Custom cluster - without it getTokenInfos returns [].
     useAsyncEffect(
         async isMounted => {
             const mints = rows.map(r => new PublicKey(r.mint));

--- a/app/mcp/README.md
+++ b/app/mcp/README.md
@@ -81,8 +81,8 @@ secret from **Project Settings → Deployment Protection**, as an `x-vercel-prot
 
 Inert by default (`503`). Keys documented inline in [`.env.example`](../../.env.example): `MCP_ENDPOINT_ENABLED`,
 `MCP_ACCESS_KEYS`, `MCP_BLOCKED_IPS`, `MCP_GA_MEASUREMENT_ID`, `MCP_GA_API_SECRET`, and
-`MCP_SOLANA_RPC_URL_MAINNET_BETA` / `_DEVNET` / `_TESTNET` / `_SIMD296`. Set them in **Project Settings → Environment
-Variables**, then redeploy — keys and blocklist are parsed at module scope, so a change needs one.
+`MCP_SOLANA_RPC_URL_MAINNET_BETA` / `_DEVNET` / `_TESTNET`. Set them in **Project Settings → Environment Variables**,
+then redeploy — keys and blocklist are parsed at module scope, so a change needs one.
 
 Analytics stay off unless an API secret and a measurement id both resolve. Events are sent after the response via Next's
 `after()`. Event names and the custom dimensions that must be registered in the GA4 property are in

--- a/app/mcp/dependencies.ts
+++ b/app/mcp/dependencies.ts
@@ -58,12 +58,11 @@ const logger: EntityInspectorConfig['logger'] = {
 
 // Resolved at handler init (cold start), not module scope, so key-bearing URLs come from runtime env, never a build artifact.
 // Unset falls back to the app's own server RPC config (`serverClusterUrl` → `*_RPC_URL` env), which is the proxied
-// default for every cluster except simd296. Every supported cluster gets an entry whether or not it is enabled.
+// default for every cluster. Every supported cluster gets an entry whether or not it is enabled.
 function resolveRpcEndpoints(): EntityInspectorConfig['rpcEndpoints'] {
     return {
         devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || serverClusterUrl(Cluster.Devnet),
         'mainnet-beta': process.env.MCP_SOLANA_RPC_URL_MAINNET_BETA || serverClusterUrl(Cluster.MainnetBeta),
-        simd296: process.env.MCP_SOLANA_RPC_URL_SIMD296 || serverClusterUrl(Cluster.Simd296),
         testnet: process.env.MCP_SOLANA_RPC_URL_TESTNET || serverClusterUrl(Cluster.Testnet),
     };
 }

--- a/app/providers/wallet/__tests__/cluster-chain.spec.ts
+++ b/app/providers/wallet/__tests__/cluster-chain.spec.ts
@@ -13,10 +13,7 @@ describe('clusterToWalletChain', () => {
         expect(clusterToWalletChain(cluster)).toBe(expected);
     });
 
-    it.each([Cluster.Custom, Cluster.Simd296])(
-        'should map cluster %s to localnet, since it points at an arbitrary endpoint',
-        cluster => {
-            expect(clusterToWalletChain(cluster)).toBe('solana:localnet');
-        },
-    );
+    it('should map the Custom cluster to localnet, since it points at an arbitrary endpoint', () => {
+        expect(clusterToWalletChain(Cluster.Custom)).toBe('solana:localnet');
+    });
 });

--- a/app/providers/wallet/cluster-chain.ts
+++ b/app/providers/wallet/cluster-chain.ts
@@ -6,12 +6,12 @@ export type WalletChain = 'solana:devnet' | 'solana:localnet' | 'solana:mainnet'
  * Maps a cluster to the Wallet Standard chain identifier the wallet plugin is configured with.
  *
  * The identifier is not only a discovery filter: it is sent with every signature request, and
- * wallets use it to decide which network to preview the transaction against. Custom and SIMD-296
- * clusters point at arbitrary endpoints, so they map to `solana:localnet` — claiming mainnet would
- * make wallets simulate against the wrong network and warn about transactions that are fine.
+ * wallets use it to decide which network to preview the transaction against. A Custom cluster points at
+ * an arbitrary endpoint, so it maps to `solana:localnet` — claiming mainnet would make wallets simulate
+ * against the wrong network and warn about transactions that are fine.
  *
  * The cost is narrower discovery: a wallet that does not advertise `solana:localnet` will not be
- * offered on those clusters.
+ * offered there.
  */
 export function clusterToWalletChain(cluster: Cluster): WalletChain {
     switch (cluster) {

--- a/app/shared/config/mcp-clusters.ts
+++ b/app/shared/config/mcp-clusters.ts
@@ -3,9 +3,4 @@ import type { EnabledClusterNames } from '@explorer/entity-inspector';
 // Cluster names /mcp accepts, and the single source the landing page reads. Listed rather than aliased to
 // SUPPORTED_CLUSTERS so a newly supported cluster is opt-in here instead of going live with the package bump.
 // Type-only import keeps the MCP runtime out of any bundle that reads this; `satisfies` keeps the literals readable.
-export const MCP_ENABLED_CLUSTER_NAMES = [
-    'mainnet-beta',
-    'devnet',
-    'testnet',
-    'simd296',
-] as const satisfies EnabledClusterNames;
+export const MCP_ENABLED_CLUSTER_NAMES = ['mainnet-beta', 'devnet', 'testnet'] as const satisfies EnabledClusterNames;

--- a/app/utils/__tests__/epoch-schedule.test.ts
+++ b/app/utils/__tests__/epoch-schedule.test.ts
@@ -142,11 +142,4 @@ describe('getMaxComputeUnitsForEpoch', () => {
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: undefined })).toEqual(100_000_000);
         expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Custom, epoch: -1n })).toEqual(100_000_000);
     });
-
-    // Every config activates at epoch 0 on the Simd296 surfnet, so the latest config must win.
-    it('should return the latest max compute units on simd296', () => {
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: 0n })).toEqual(100_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: 1009n })).toEqual(100_000_000);
-        expect(getMaxComputeUnitsInBlock({ cluster: Cluster.Simd296, epoch: undefined })).toEqual(100_000_000);
-    });
 });

--- a/app/utils/cluster.ts
+++ b/app/utils/cluster.ts
@@ -17,6 +17,5 @@ export {
     MAINNET_BETA_URL,
     type ServerCluster,
     serverClusterUrl,
-    SIMD296_URL,
     TESTNET_URL,
 } from '@entities/cluster/lib/cluster';

--- a/app/utils/epoch-schedule.ts
+++ b/app/utils/epoch-schedule.ts
@@ -96,7 +96,6 @@ interface ComputeUnitConfigEntry {
         readonly [Cluster.MainnetBeta]: number;
         readonly [Cluster.Devnet]: number;
         readonly [Cluster.Testnet]: number;
-        readonly [Cluster.Simd296]: number;
     };
 }
 
@@ -110,7 +109,6 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
             [Cluster.MainnetBeta]: 0,
             [Cluster.Devnet]: 0,
             [Cluster.Testnet]: 0,
-            [Cluster.Simd296]: 0,
         },
         maxComputeUnits: 48_000_000,
     },
@@ -119,7 +117,6 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
             [Cluster.MainnetBeta]: 770,
             [Cluster.Devnet]: 857,
             [Cluster.Testnet]: 764,
-            [Cluster.Simd296]: 0,
         },
         featureAccount: '5oMCU3JPaFLr8Zr4ct7yFA7jdk6Mw1RmB8K4u9ZbS42z',
         maxComputeUnits: 50_000_000,
@@ -130,7 +127,6 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
             [Cluster.MainnetBeta]: 822,
             [Cluster.Devnet]: 915,
             [Cluster.Testnet]: 812,
-            [Cluster.Simd296]: 0,
         },
         featureAccount: '6oMCUgfY6BzZ6jwB681J6ju5Bh6CjVXbd7NeWYqiXBSu',
         maxComputeUnits: 60_000_000,
@@ -141,7 +137,6 @@ const COMPUTE_UNIT_CONFIGS: readonly ComputeUnitConfigEntry[] = [
             [Cluster.MainnetBeta]: 1009,
             [Cluster.Devnet]: 1100,
             [Cluster.Testnet]: 983,
-            [Cluster.Simd296]: 0,
         },
         featureAccount: 'P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz',
         maxComputeUnits: 100_000_000,
@@ -168,8 +163,7 @@ export function getMaxComputeUnitsInBlock({ epoch = 0n, cluster }: { epoch?: big
 
     for (const config of COMPUTE_UNIT_CONFIGS) {
         const activationEpoch = config.activations[cluster];
-        // `>=` so that on clusters where several configs share an activation epoch (e.g. the
-        // Simd296 surfnet, where every config activates at epoch 0) the latest config wins.
+        // `>=` so that when several configs share an activation epoch on a cluster, the latest one wins.
         if (activationEpoch <= epochNumber && activationEpoch >= highestActivationEpoch) {
             applicableConfig = config;
             highestActivationEpoch = activationEpoch;

--- a/app/utils/token-info.ts
+++ b/app/utils/token-info.ts
@@ -129,7 +129,7 @@ export function isRedactedTokenAddress(address: string): boolean {
  * The UTL SDK only returns the most common fields, we sometimes need eg extensions
  * @param address Public key of the token
  * @param cluster Cluster to fetch the token info for
- * @param genesisHash Genesis hash for cluster identification (required for SIMD-296)
+ * @param genesisHash Genesis hash for cluster identification (required for the Custom cluster)
  */
 export type FullTokenInfoSwrKey = ['get-full-token-info', string, Cluster, string, string | undefined];
 

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -21,7 +21,7 @@ export function supportsVerifiedBuilds(cluster: Cluster): boolean {
     return getOsecRegistryUrl(cluster) !== undefined;
 }
 
-// OSEC hosts a separate verified-builds registry per cluster; Testnet/Custom/SIMD-296 have none.
+// OSEC hosts a separate verified-builds registry per cluster; Testnet/Custom have none.
 export function getOsecRegistryUrl(cluster: Cluster): string | undefined {
     switch (cluster) {
         case Cluster.MainnetBeta:

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -26,8 +26,8 @@
 | Dynamic | `/address/[address]/slot-hashes` | 480 kB | 880 kB |
 | Dynamic | `/address/[address]/stake-history` | 480 kB | 880 kB |
 | Dynamic | `/address/[address]/subscriptions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/token-extensions` | 480 kB | 880 kB |
-| Dynamic | `/address/[address]/tokens` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/token-extensions` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/tokens` | 490 kB | 900 kB |
 | Dynamic | `/address/[address]/transfers` | 490 kB | 890 kB |
 | Dynamic | `/address/[address]/verified-build` | 480 kB | 880 kB |
 | Dynamic | `/address/[address]/vote-history` | 480 kB | 880 kB |

--- a/packages/entity-inspector/src/__tests__/config.spec.ts
+++ b/packages/entity-inspector/src/__tests__/config.spec.ts
@@ -4,7 +4,7 @@ import { defaultCluster, SUPPORTED_CLUSTERS } from '../config.js';
 
 describe('SUPPORTED_CLUSTERS', () => {
     it('should list the clusters the inspector can query', () => {
-        expect(SUPPORTED_CLUSTERS).toEqual(['mainnet-beta', 'devnet', 'testnet', 'simd296']);
+        expect(SUPPORTED_CLUSTERS).toEqual(['mainnet-beta', 'devnet', 'testnet']);
     });
 });
 

--- a/packages/entity-inspector/src/config.ts
+++ b/packages/entity-inspector/src/config.ts
@@ -1,5 +1,5 @@
 // Clusters the inspector can query — the single source of truth for the SupportedCluster type.
-export const SUPPORTED_CLUSTERS = ['mainnet-beta', 'devnet', 'testnet', 'simd296'] as const;
+export const SUPPORTED_CLUSTERS = ['mainnet-beta', 'devnet', 'testnet'] as const;
 
 export type SupportedCluster = (typeof SUPPORTED_CLUSTERS)[number];
 

--- a/packages/entity-inspector/src/enrichments/__tests__/idl-clients.spec.ts
+++ b/packages/entity-inspector/src/enrichments/__tests__/idl-clients.spec.ts
@@ -36,7 +36,6 @@ vi.mock('../../shared/constants.js', async importOriginal => ({
 const RPC_ENDPOINTS = {
     devnet: 'https://devnet.rpc.address',
     'mainnet-beta': 'https://mainnet-beta.rpc.address',
-    simd296: 'https://simd296.rpc.address',
     testnet: 'https://testnet.rpc.address',
 };
 

--- a/packages/entity-inspector/src/enrichments/__tests__/pmp-security.spec.ts
+++ b/packages/entity-inspector/src/enrichments/__tests__/pmp-security.spec.ts
@@ -26,7 +26,6 @@ const PROGRAM_ADDRESS = gen.tokenProgram;
 const RPC_ENDPOINTS = {
     devnet: 'https://devnet.rpc.address',
     'mainnet-beta': 'https://mainnet-beta.rpc.address',
-    simd296: 'https://simd296.rpc.address',
     testnet: 'https://testnet.rpc.address',
 };
 

--- a/packages/entity-inspector/src/enrichments/__tests__/security.spec.ts
+++ b/packages/entity-inspector/src/enrichments/__tests__/security.spec.ts
@@ -17,7 +17,6 @@ const PROGRAM_ADDRESS = gen.tokenProgram;
 const RPC_ENDPOINTS = {
     devnet: 'https://devnet.rpc.address',
     'mainnet-beta': 'https://mainnet-beta.rpc.address',
-    simd296: 'https://simd296.rpc.address',
     testnet: 'https://testnet.rpc.address',
 };
 

--- a/packages/entity-inspector/src/enrichments/programs-without-anchor-idl.ts
+++ b/packages/entity-inspector/src/enrichments/programs-without-anchor-idl.ts
@@ -1,7 +1,7 @@
 // Programs that definitionally have no Anchor IDL. Skipping their IDL-PDA lookup is not just a saved
-// read: it removes a dependency on the RPC answering `null` for the derived address, and some (the
-// SIMD-296 cluster among them) answer a transient error instead — which would turn "no IDL" into a
-// retryable failure on every transaction touching a builtin. Behavioural list, not a display registry.
+// read: it removes a dependency on the RPC answering `null` for the derived address, and some answer a
+// transient error instead — which would turn "no IDL" into a retryable failure on every transaction
+// touching a builtin. Behavioural list, not a display registry.
 import {
     ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     BPF_LOADER_2_PROGRAM_ID,

--- a/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
@@ -12,7 +12,6 @@ const TEST_CONFIG: EntityInspectorConfig = {
     rpcEndpoints: {
         devnet: 'https://devnet.rpc.address',
         'mainnet-beta': 'https://mainnet-beta.rpc.address',
-        simd296: 'https://simd296.rpc.address',
         testnet: 'https://testnet.rpc.address',
     },
 };

--- a/packages/entity-inspector/src/mcp/__tests__/schemas.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/schemas.spec.ts
@@ -15,7 +15,7 @@ describe('inspectEntityInputSchema', () => {
     it('should reject a cluster the deployment has not enabled', () => {
         const schema = inspectEntityInputSchema(['mainnet-beta', 'devnet']);
 
-        expect(() => schema.parse({ cluster: 'simd296', identifier: 'abc' })).toThrow();
+        expect(() => schema.parse({ cluster: 'testnet', identifier: 'abc' })).toThrow();
     });
 
     it('should default to the enabled cluster when none is given', () => {

--- a/packages/entity-inspector/src/mcp/__tests__/server.error-guard.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/server.error-guard.spec.ts
@@ -17,7 +17,6 @@ const TEST_CONFIG: EntityInspectorConfig = {
     rpcEndpoints: {
         devnet: 'https://devnet.rpc.address',
         'mainnet-beta': ENDPOINT_WITH_KEY,
-        simd296: 'https://simd296.rpc.address',
         testnet: 'https://testnet.rpc.address',
     },
 };

--- a/packages/entity-inspector/src/rpc/__tests__/resolve-rpc-endpoint.spec.ts
+++ b/packages/entity-inspector/src/rpc/__tests__/resolve-rpc-endpoint.spec.ts
@@ -5,13 +5,12 @@ import { resolveRpcEndpoint } from '../resolve-rpc-endpoint.js';
 const RPC_ENDPOINTS = {
     devnet: 'https://devnet.rpc.address',
     'mainnet-beta': 'https://mainnet-beta.rpc.address',
-    simd296: 'https://simd296.rpc.address',
     testnet: 'https://testnet.rpc.address',
 };
 
 describe('resolveRpcEndpoint', () => {
     it('should resolve the endpoint configured for the cluster', () => {
         expect(resolveRpcEndpoint('mainnet-beta', RPC_ENDPOINTS)).toBe('https://mainnet-beta.rpc.address');
-        expect(resolveRpcEndpoint('simd296', RPC_ENDPOINTS)).toBe('https://simd296.rpc.address');
+        expect(resolveRpcEndpoint('testnet', RPC_ENDPOINTS)).toBe('https://testnet.rpc.address');
     });
 });

--- a/packages/entity-inspector/src/rpc/__tests__/rpc.spec.ts
+++ b/packages/entity-inspector/src/rpc/__tests__/rpc.spec.ts
@@ -23,7 +23,6 @@ const createSolanaRpcMock = vi.mocked(createSolanaRpc);
 const RPC_ENDPOINTS = {
     devnet: 'https://devnet.rpc.address',
     'mainnet-beta': 'https://mainnet-beta.rpc.address',
-    simd296: 'https://simd296.rpc.address',
     testnet: 'https://testnet.rpc.address',
 };
 


### PR DESCRIPTION
## Description

The Explorer offers SIMD-296 as a fifth cluster, backed by a surfnet at `simd-0296.surfnet.dev`.

That surfnet is unreliable, and the feature it previewed now runs on devnet. The cluster forced a branch in almost every place that maps a cluster to something else: chain id, token lists, both compute-unit schedules, the Wallet Standard chain, the MCP endpoint table.

### The change

- **Drop the cluster.** Removes `Cluster.Simd296`, the `simd296` slug, the `SIMD-296` switcher entry and the surfnet endpoint. A `?cluster=simd296` link now falls back to mainnet.
- **Stop advertising it over MCP.** `/mcp` no longer accepts `simd296`, and `MCP_SOLANA_RPC_URL_SIMD296` is gone from `.env.example`, the docs and the entity-inspector supported clusters.
- **Remove its per-cluster branches.** The search route loses the short-circuit that answered with an empty token list, and both compute-unit schedules lose their `Simd296` activation column.
- **Keep the comments true.** Ten files cited SIMD-296 as an example; each keeps its rule and drops the example.

## Type of change

-   [x] Other (please describe): removes a cluster the Explorer no longer supports

## Testing

- **The cluster switcher offers four clusters.** Open the home page — [preview](https://explorer-git-fork-hoodieshq-chore-remo-37e220-solana-foundation.vercel.app/) · [production](https://explorer.solana.com/) — and open the cluster switcher in the page header. Expect Mainnet Beta, Testnet, Devnet and Custom. Production lists SIMD-296 as a fifth row.
- **A `simd296` link falls back to mainnet.** Open the Token program on the retired cluster — [preview](https://explorer-git-fork-hoodieshq-chore-remo-37e220-solana-foundation.vercel.app/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA?cluster=simd296) · [production](https://explorer.solana.com/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA?cluster=simd296) — and read the switcher label. Expect Mainnet Beta and the mainnet account page. Production reads the same link as SIMD-296 and queries the surfnet.
- **Devnet and testnet still resolve.** Open the same address on devnet — [preview](https://explorer-git-fork-hoodieshq-chore-remo-37e220-solana-foundation.vercel.app/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA?cluster=devnet) · [production](https://explorer.solana.com/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA?cluster=devnet) — then swap `cluster=devnet` for `cluster=testnet`. Expect the switcher to name the cluster in the link, on both hosts.
- **The MCP docs list three clusters.** Open the MCP docs — [preview](https://explorer-git-fork-hoodieshq-chore-remo-37e220-solana-foundation.vercel.app/mcp/docs) · [production](https://explorer.solana.com/mcp/docs) — and read the `cluster` request parameter under `inspect_entity`. Expect `mainnet-beta`, `devnet` and `testnet`. Production also lists `simd296`.

## Related Issues

Closes [HOO-1565](https://linear.app/solana-fndn/issue/HOO-1565/remove-cluster-simd-926-everywhere)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information

## Additional Notes

`Cluster.Custom` shifts from 4 to 3 in the numeric enum. The client sends that number only to our own API routes, which refuse Custom on either value, and receipt links carry devnet and testnet only. Explorer links are built from the slug, not the number.

`bench/BUILD.md` moves two `/address/[address]` routes up by 10 kB. The change only deletes code, so this is chunk re-splitting rather than a regression.

The Linear issue is titled SIMD-926. The cluster in the code is SIMD-296, and nothing matches 926.

