### PR TITLE
feat: add common page components

### DIFF
--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -10,6 +10,7 @@ import { notFound } from 'next/navigation';
 import React, { PropsWithChildren, use } from 'react';
 
 import { type NavigationTab, NavigationTabs } from '@/app/shared/ui/navigation-tabs';
+import { PageHeader, PageLayout, PageSections } from '@/app/shared/ui/page-layout';
 import { getEpochForSlot } from '@/app/utils/epoch-schedule';
 import { useBuildClusterPath } from '@/app/utils/url';
 
@@ -63,18 +64,10 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
         );
     }
     return (
-        // Translucent-green text-selection highlight, matched exactly to the transaction page
-        // (app/tx/[signature]/page-client.tsx). `#13d89b` is a one-off selection colour (not a token),
-        // and `40` is its alpha (25%), kept as a literal so both pages stay visually in step.
-        <div className="mx-auto flex max-w-5xl flex-col px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:px-6 lg:pt-5">
-            <header className="mb-3 flex flex-col gap-1.5 py-6">
-                <span className="text-xs font-normal uppercase text-muted">Details</span>
-                <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Block</h1>
-            </header>
-            {/* Section rhythm lives on this inner wrapper so the header sits outside the `space-y` and its
-                own `mb-3` controls the gap to the first section — mirroring the inspector page. */}
-            <div className="flex flex-col space-y-9 lg:space-y-12">{content}</div>
-        </div>
+        <PageLayout className="selection:bg-[#13d89b40] selection:text-inherit">
+            <PageHeader eyebrow="Details" spacing="standalone" title="Block" />
+            <PageSections>{content}</PageSections>
+        </PageLayout>
     );
 }
 
@@ -106,11 +99,15 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
 
     return (
         <>
-            {/* Full-bleed sticky tab bar, mirroring the transaction page: the negative margins stretch the
-                background edge-to-edge while the matching padding pulls the tabs back onto the content column. */}
-            <div className="sticky top-0 z-10 ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] overflow-x-auto bg-heavy-metal-900 pl-[calc(50vw-50%)] pr-[calc(50vw-50%)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <NavigationTabs buildHref={buildHref} tabs={TABS} className="gap-5" />
-            </div>
+            {/* Sticky, full-bleed tab bar with a shadow on stuck — the same wrapper the transaction page
+                gets from `scrollSpy`, shared here via `sticky` so both pages pin and shadow identically. */}
+            <NavigationTabs
+                buildHref={buildHref}
+                className="gap-5"
+                sticky
+                tabs={TABS}
+                wrapperClassName="bg-heavy-metal-900"
+            />
             {children}
         </>
     );

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -55,9 +55,6 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
                     childSlot={childSlot}
                     childLeader={childLeader}
                     parentLeader={parentLeader}
-                    // Tighten the mobile gap down to the tab bar. `!` overrides the `space-y-9`
-                    // margin-bottom:0 set on non-first children; reset at `lg`.
-                    className="!-mb-6 lg:!mb-0"
                 />
                 <MoreSection slot={slotNumber}>{children}</MoreSection>
             </>

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -96,9 +96,7 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
 
     return (
         <>
-            {/* Sticky, full-bleed tab bar with a shadow on stuck — the same wrapper the transaction page
-                gets from `scrollSpy`, shared here via `sticky` so both pages pin and shadow identically. */}
-            <NavigationTabs buildHref={buildHref} className="gap-5" sticky tabs={TABS} />
+            <NavigationTabs buildHref={buildHref} sticky tabs={TABS} />
             {children}
         </>
     );

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -64,8 +64,8 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
         );
     }
     return (
-        <PageLayout className="selection:bg-[#13d89b40] selection:text-inherit">
-            <PageHeader eyebrow="Details" spacing="standalone" title="Block" />
+        <PageLayout>
+            <PageHeader eyebrow="Details" title="Block" />
             <PageSections>{content}</PageSections>
         </PageLayout>
     );
@@ -101,13 +101,7 @@ function MoreSection({ children, slot }: { children: React.ReactNode; slot: numb
         <>
             {/* Sticky, full-bleed tab bar with a shadow on stuck — the same wrapper the transaction page
                 gets from `scrollSpy`, shared here via `sticky` so both pages pin and shadow identically. */}
-            <NavigationTabs
-                buildHref={buildHref}
-                className="gap-5"
-                sticky
-                tabs={TABS}
-                wrapperClassName="bg-heavy-metal-900"
-            />
+            <NavigationTabs buildHref={buildHref} className="gap-5" sticky tabs={TABS} />
             {children}
         </>
     );

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -655,7 +655,6 @@ function LoadedView({
                 scrollSpy
                 tabs={tabs}
                 buildHref={path => `#${path}`}
-                className="gap-5"
                 disabledHint="Run the simulation to load this tab's content."
             />
             {signatures && (

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -39,7 +39,7 @@ import {
 } from '@/app/shared/lib/v1-message-bridge';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseNavigationTabs } from '@/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs';
-import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
+import { PageHeader, PageLayout, PageSections } from '@/app/shared/ui/page-layout';
 import { useClusterPath } from '@/app/utils/url';
 
 import { AccountsCard } from './AccountsCard';
@@ -448,31 +448,30 @@ export function TransactionInspectorPage({
     }, [currentPathname, currentSearchParams, router]);
 
     return (
-        <PageContainer width="fluid" className="mt-6 [&_.border-dk-card-outline-dark]:border-outer-space-800">
-            <header className="mb-3 mt-4 flex flex-col gap-1.5 py-6">
-                <span className="text-xs font-normal uppercase text-muted">Transaction</span>
-                <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Inspector</h1>
-            </header>
-            {signature ? (
-                <PermalinkView
-                    signature={signature}
-                    reset={resetToInspectorPage}
-                    showTokenBalanceChanges={showTokenBalanceChanges}
-                />
-            ) : inspectorData ? (
-                isSquadsProposalAccountData(inspectorData) ? (
-                    <SquadsProposalInspectorCard account={inspectorData.account} onClear={resetParams} />
-                ) : (
-                    <LoadedView
-                        transaction={inspectorData}
-                        onClear={resetParams}
+        <PageLayout>
+            <PageHeader eyebrow="Transaction" title="Inspector" />
+            <PageSections>
+                {signature ? (
+                    <PermalinkView
+                        signature={signature}
+                        reset={resetToInspectorPage}
                         showTokenBalanceChanges={showTokenBalanceChanges}
                     />
-                )
-            ) : (
-                <RawInput value={paramString} setTransactionData={setInspectorData} />
-            )}
-        </PageContainer>
+                ) : inspectorData ? (
+                    isSquadsProposalAccountData(inspectorData) ? (
+                        <SquadsProposalInspectorCard account={inspectorData.account} onClear={resetParams} />
+                    ) : (
+                        <LoadedView
+                            transaction={inspectorData}
+                            onClear={resetParams}
+                            showTokenBalanceChanges={showTokenBalanceChanges}
+                        />
+                    )
+                ) : (
+                    <RawInput value={paramString} setTransactionData={setInspectorData} />
+                )}
+            </PageSections>
+        </PageLayout>
     );
 }
 
@@ -656,39 +655,36 @@ function LoadedView({
                 scrollSpy
                 tabs={tabs}
                 buildHref={path => `#${path}`}
-                wrapperClassName="mt-3 bg-heavy-metal-900 lg:mt-0"
                 className="gap-5"
                 disabledHint="Run the simulation to load this tab's content."
             />
-            <div className="mt-9 flex flex-col space-y-9 lg:mt-12 lg:space-y-12">
-                {signatures && (
-                    <div id="signatures">
-                        <TransactionSignatures message={message} signatures={signatures} rawMessage={rawMessage} />
-                    </div>
-                )}
-                {/* Account List with the SOL Balance Changes merged in as a "Change" column; the per-row
-                    Simulate affordance drives the same simulation the panel below uses. */}
-                <div id="accounts">
-                    <AccountsCard message={message} simulation={simulation} />
+            {signatures && (
+                <div id="signatures">
+                    <TransactionSignatures message={message} signatures={signatures} rawMessage={rawMessage} />
                 </div>
-                {/* Token balance changes from the simulation. TokenBalancesCardInner brings its own
+            )}
+            {/* Account List with the SOL Balance Changes merged in as a "Change" column; the per-row
+                    Simulate affordance drives the same simulation the panel below uses. */}
+            <div id="accounts">
+                <AccountsCard message={message} simulation={simulation} />
+            </div>
+            {/* Token balance changes from the simulation. TokenBalancesCardInner brings its own
                     `#tokens` section anchor; it renders only once a run has produced token rows (matching
                     the gated Tokens tab above). */}
-                {tokenBalanceRows && tokenBalanceRows.length > 0 && <TokenBalancesCardInner rows={tokenBalanceRows} />}
-                {/* Renders (with its own `#address-lookups` anchor) only when the message references lookup
+            {tokenBalanceRows && tokenBalanceRows.length > 0 && <TokenBalancesCardInner rows={tokenBalanceRows} />}
+            {/* Renders (with its own `#address-lookups` anchor) only when the message references lookup
                     tables — otherwise it returns null, matching the gated tab above. A v1 message carries
                     static accounts only, so there are no lookups to render. */}
-                {version !== 1 && <AddressTableLookupsCard message={message} />}
-                {/* Programs & Logs — the two-column row copied from the TX details page. At xxl it goes
+            {version !== 1 && <AddressTableLookupsCard message={message} />}
+            {/* Programs & Logs — the two-column row copied from the TX details page. At xxl it goes
                     full-bleed to the viewport: Instructions (Programs) on the left, and the Simulation
                     control + Logs + CU profiling in the sticky right column. */}
-                <div className="flex flex-col space-y-9 pb-10 xxl:relative xxl:left-1/2 xxl:w-screen xxl:-translate-x-1/2 xxl:flex-row xxl:items-start xxl:gap-6 xxl:space-y-0 xxl:px-6">
-                    <div id="programs" className="xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-hidden">
-                        <InstructionsSection message={message} compiledInnerInstructions={compiledInnerInstructions} />
-                    </div>
-                    <div className="scrollbar-hide xxl:sticky xxl:top-[70px] xxl:max-h-[calc(100vh-90px)] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-y-auto xxl:rounded-b-lg">
-                        <InspectorSimulationPanel simulation={simulation} message={message} />
-                    </div>
+            <div className="flex flex-col space-y-9 pb-10 xxl:relative xxl:left-1/2 xxl:w-screen xxl:-translate-x-1/2 xxl:flex-row xxl:items-start xxl:gap-6 xxl:space-y-0 xxl:px-6">
+                <div id="programs" className="xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-hidden">
+                    <InstructionsSection message={message} compiledInnerInstructions={compiledInnerInstructions} />
+                </div>
+                <div className="scrollbar-hide xxl:sticky xxl:top-[70px] xxl:max-h-[calc(100vh-90px)] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-y-auto xxl:rounded-b-lg">
+                    <InspectorSimulationPanel simulation={simulation} message={message} />
                 </div>
             </div>
         </>

--- a/app/components/inspector/InspectorSimulationPanel.tsx
+++ b/app/components/inspector/InspectorSimulationPanel.tsx
@@ -30,9 +30,6 @@ function SimulatedTitle({ children }: { children: React.ReactNode }) {
     );
 }
 
-// Card surface for the simulation-derived blocks (Logs / CU profiling): the card OUTLINE with no
-// filled backing — border only, transparent inside. `border-outer-space-800` matches the other
-// card outlines on the page.
 const OUTLINE_ONLY_CARD = 'rounded-lg border border-solid border-outer-space-800';
 
 // Empty state for a Logs / CU profiling card before a simulation has run: the card exists so its tab has

--- a/app/components/inspector/InspectorSimulationPanel.tsx
+++ b/app/components/inspector/InspectorSimulationPanel.tsx
@@ -30,10 +30,10 @@ function SimulatedTitle({ children }: { children: React.ReactNode }) {
     );
 }
 
-// Card surface for the simulation-derived blocks (Logs / CU profiling): the dashkit card OUTLINE with no
-// filled backing — border only, transparent inside. The page container remaps
-// `border-dk-card-outline-dark` → `border-outer-space-800`, so this matches the other outlines.
-const OUTLINE_ONLY_CARD = 'rounded-lg border border-solid border-dk-card-outline-dark';
+// Card surface for the simulation-derived blocks (Logs / CU profiling): the card OUTLINE with no
+// filled backing — border only, transparent inside. `border-outer-space-800` matches the other
+// card outlines on the page.
+const OUTLINE_ONLY_CARD = 'rounded-lg border border-solid border-outer-space-800';
 
 // Empty state for a Logs / CU profiling card before a simulation has run: the card exists so its tab has
 // a scroll target. The Simulate button is revealed on hover/focus of the enclosing card (the `group`).

--- a/app/components/inspector/inspector-table.ts
+++ b/app/components/inspector/inspector-table.ts
@@ -15,6 +15,6 @@ export const CARD_TABLE_HEADER = cn(
 // add a card surface there (otherwise per-row cards sit inside a second card). At lg+ the rows form a
 // grid table, so the dashkit card surface frames it. Used by the Account List and Address Lookups.
 export const LG_ONLY_CARD = cn(
-    'lg:rounded-lg lg:border lg:border-solid lg:border-dk-card-outline-dark',
+    'lg:rounded-lg lg:border lg:border-solid lg:border-outer-space-800',
     'lg:bg-dk-gray-800-dark lg:shadow-dk-card',
 );

--- a/app/components/shared/ui/badge.responsive.stories.tsx
+++ b/app/components/shared/ui/badge.responsive.stories.tsx
@@ -22,7 +22,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const TableRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">In-table status (parent 13px → badge ≈10px)</h3>
         <BaseTable ui="dashkit" variant="card" nowrap>
             <BaseTable.Head>
@@ -54,7 +54,7 @@ const TableRow = () => (
 );
 
 const InlineMetaRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Inline meta tags (wrap)</h3>
         <div className="flex flex-col gap-2">
             <div>
@@ -82,7 +82,7 @@ const InlineMetaRow = () => (
 );
 
 const HeaderPillsRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Header pills (solid, e.g. NFT metadata)</h3>
         <div className="flex flex-wrap gap-1.5">
             <Badge ui="dashkit" variant="dark" tone="solid">
@@ -105,7 +105,7 @@ const HeaderPillsRow = () => (
 );
 
 const StatusToggleRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Feature activation status (solid)</h3>
         <div className="flex flex-wrap gap-1.5">
             <Badge ui="dashkit" variant="success" tone="solid">
@@ -119,7 +119,7 @@ const StatusToggleRow = () => (
 );
 
 const TitleBadgeRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Title with leading index badge (truncation)</h3>
         <div className="flex min-w-0 items-center">
             <Badge ui="dashkit" variant="info" className="mr-1.5 flex-none">

--- a/app/components/shared/ui/button.responsive.stories.tsx
+++ b/app/components/shared/ui/button.responsive.stories.tsx
@@ -21,7 +21,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ToolbarRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Card-header toolbar</h3>
         <div className="flex flex-wrap items-center gap-1.5">
             <span className="mr-auto text-dk-h4 font-medium">Program Account</span>
@@ -39,7 +39,7 @@ const ToolbarRow = () => (
 );
 
 const ToggleRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Toggle group</h3>
         <div className="flex flex-wrap gap-1.5">
             <Button ui="dashkit" variant="black" active size="sm">
@@ -59,7 +59,7 @@ const ToggleRow = () => (
 );
 
 const FooterRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Footer (full-width Load More)</h3>
         <Button ui="dashkit" variant="primary" className="w-full">
             Load More
@@ -68,7 +68,7 @@ const FooterRow = () => (
 );
 
 const DropdownTriggerRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Dropdown triggers</h3>
         <div className="flex flex-wrap gap-1.5">
             <Button ui="dashkit" variant="dark" size="sm" className="w-[150px]">
@@ -82,7 +82,7 @@ const DropdownTriggerRow = () => (
 );
 
 const ModalFooterRow = () => (
-    <div className="rounded-dk border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark p-3">
+    <div className="rounded-dk border border-solid border-outer-space-800 bg-dk-gray-800-dark p-3">
         <h3 className="mb-2 text-dk-sm text-dk-gray-700">Modal-style action row</h3>
         <div className="flex justify-between gap-1.5">
             <Button ui="dashkit" variant="outline-danger" size="sm">

--- a/app/features/security-txt/ui/EmptySecurityTxtCard.tsx
+++ b/app/features/security-txt/ui/EmptySecurityTxtCard.tsx
@@ -19,7 +19,7 @@ export function EmptySecurityTxtCard({ programAddress }: { programAddress: strin
                         This program did not provide Security.txt information yet. If you are the maintainer of this
                         program you can use the following command to add your information.
                     </p>
-                    <div className="flex items-start rounded-dk border border-solid border-dk-card-outline-dark p-1.5 text-left md:items-center">
+                    <div className="flex items-start rounded-dk border border-solid border-outer-space-800 p-1.5 text-left md:items-center">
                         <Copyable text={copyableTxt}>
                             <code className="min-w-0 flex-1 break-all font-mono text-sm text-dk-gray-700 md:overflow-x-auto md:whitespace-nowrap md:break-normal">
                                 {copyableTxt}

--- a/app/shared/ui/Card/BaseCard.tsx
+++ b/app/shared/ui/Card/BaseCard.tsx
@@ -24,8 +24,7 @@ const cardVariants = cva(['relative flex min-w-0 flex-col break-words'], {
             sm: 'mb-2',
         },
         ui: {
-            dashkit:
-                'mb-6 rounded-lg border border-solid border-dk-card-outline-dark bg-dk-gray-800-dark shadow-dk-card',
+            dashkit: 'mb-6 rounded-lg border border-solid border-outer-space-800 bg-dk-gray-800-dark shadow-dk-card',
             tw: 'rounded-xl border border-solid border-heavy-metal-950 bg-heavy-metal-800 text-neutral-200',
         },
         // Card-level padding; only meaningful when ui="tw" (matches the legacy OKLCH Card's `variant` prop).

--- a/app/shared/ui/FormControl/FormControl.tsx
+++ b/app/shared/ui/FormControl/FormControl.tsx
@@ -11,7 +11,7 @@ const formControlVariants = cva(['block', 'w-full', 'bg-transparent', 'text-inhe
             // Bootstrap .form-control baseline equivalent: bordered, padded, rounded.
             // No focus chrome to match production (Bootstrap's .form-control:focus set `outline: 0`).
             default:
-                'rounded-lg border border-solid border-dk-card-outline-dark px-3 py-2 focus:outline-none focus-visible:outline-none',
+                'rounded-lg border border-solid border-outer-space-800 px-3 py-2 focus:outline-none focus-visible:outline-none',
             // .form-control-flush: no border, no horizontal padding, no focus chrome.
             flush: 'resize-none border-0 px-0 py-2 focus:outline-none focus-visible:outline-none',
             // .form-control-flush + .form-control-auto: no border, no padding, auto height, no focus chrome.

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -33,12 +33,11 @@ export type BaseNavigationTabsProps = {
     /**
      * Wraps the tab bar in a sticky, full-bleed container that raises a shadow once it sticks to the
      * top. Use for route-based tabs that should pin (the block page); `scrollSpy` turns this on too.
-     * Provide the background color via `wrapperClassName` (e.g. "bg-heavy-metal-900").
+     * The wrapper owns its own background (`bg-heavy-metal-900`) so a sticky bar can't render
+     * transparent. Pass the object form to position the wrapper, e.g. `{ className: 'mt-3 lg:mt-0' }`.
      */
-    sticky?: boolean;
+    sticky?: boolean | { className?: string };
     tabs: NavigationTab[];
-    /** Applied to the sticky wrapper (when `sticky` or `scrollSpy`). Use for background color. */
-    wrapperClassName?: string;
 };
 
 export function BaseNavigationTabs({
@@ -52,11 +51,11 @@ export function BaseNavigationTabs({
     disabledHint,
     scrollSpy,
     sticky,
-    wrapperClassName,
 }: BaseNavigationTabsProps) {
     // Scroll-spy tabs are always pinned; `sticky` pins route-based tabs too. Both share the same
     // sticky wrapper + shadow-on-stuck; only the active-tab tracking below is scroll-spy specific.
-    const isSticky = scrollSpy || sticky;
+    const isSticky = scrollSpy || Boolean(sticky);
+    const stickyClassName = typeof sticky === 'object' ? sticky.className : undefined;
     const { registeredTabs, registerTab, unregisterTab } = useTabRegistration();
 
     const wrapperRef = useRef<HTMLDivElement>(null);
@@ -200,8 +199,9 @@ export function BaseNavigationTabs({
                     'pl-[calc(50vw-50%)] pr-[calc(50vw-50%)]',
                     'overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
                     'transition-[box-shadow] duration-200',
+                    'bg-heavy-metal-900',
                     stuck && 'shadow-[0_6px_16px_rgba(0,0,0,0.45)]',
-                    wrapperClassName,
+                    stickyClassName,
                 )}
             >
                 {tabBar}

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -30,13 +30,6 @@ export type BaseNavigationTabsProps = {
      * Implies `sticky` (scroll-spy tabs are always pinned).
      */
     scrollSpy?: boolean;
-    /**
-     * Wraps the tab bar in a sticky, full-bleed container that raises a shadow once it sticks to the
-     * top. Use for route-based tabs that should pin (the block page); `scrollSpy` turns this on too.
-     * The wrapper owns its own background (`bg-heavy-metal-900`) so a sticky bar can't render
-     * transparent, and its spacing to the surrounding blocks comes from the page's `PageSections`
-     * rhythm — a sticky tab bar carries no per-page margins.
-     */
     sticky?: boolean;
     tabs: NavigationTab[];
 };
@@ -150,11 +143,7 @@ export function BaseNavigationTabs({
 
     const tabBar = (
         <NavigationTabsContext.Provider value={contextValue}>
-            <div
-                ref={tablistRef}
-                role="tablist"
-                className={cn('inline-flex w-full gap-[18px] overflow-hidden', className)}
-            >
+            <div ref={tablistRef} role="tablist" className={cn('inline-flex w-full gap-5 overflow-hidden', className)}>
                 {visibleTabs.map(tab => (
                     <TabLink
                         key={tab.path}

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -34,9 +34,10 @@ export type BaseNavigationTabsProps = {
      * Wraps the tab bar in a sticky, full-bleed container that raises a shadow once it sticks to the
      * top. Use for route-based tabs that should pin (the block page); `scrollSpy` turns this on too.
      * The wrapper owns its own background (`bg-heavy-metal-900`) so a sticky bar can't render
-     * transparent. Pass the object form to position the wrapper, e.g. `{ className: 'mt-3 lg:mt-0' }`.
+     * transparent, and its spacing to the surrounding blocks comes from the page's `PageSections`
+     * rhythm — a sticky tab bar carries no per-page margins.
      */
-    sticky?: boolean | { className?: string };
+    sticky?: boolean;
     tabs: NavigationTab[];
 };
 
@@ -55,7 +56,6 @@ export function BaseNavigationTabs({
     // Scroll-spy tabs are always pinned; `sticky` pins route-based tabs too. Both share the same
     // sticky wrapper + shadow-on-stuck; only the active-tab tracking below is scroll-spy specific.
     const isSticky = scrollSpy || Boolean(sticky);
-    const stickyClassName = typeof sticky === 'object' ? sticky.className : undefined;
     const { registeredTabs, registerTab, unregisterTab } = useTabRegistration();
 
     const wrapperRef = useRef<HTMLDivElement>(null);
@@ -102,14 +102,13 @@ export function BaseNavigationTabs({
 
     useEffect(() => {
         if (!isSticky) return;
-        const el = wrapperRef.current;
-        if (!el) return;
         const update = () => {
             // Stuck = the sticky bar has reached the top of the viewport (top: 0). Deriving this from the
             // bar's vertical position — rather than an IntersectionObserver with threshold 1 — keeps the
             // shadow correct even when the bar is full-bleed (100vw): a hairline of horizontal overflow
             // would otherwise drop the intersection ratio below 1 and pin `stuck` on permanently.
-            setStuck(el.getBoundingClientRect().top <= 0);
+            const el = wrapperRef.current;
+            if (el) setStuck(el.getBoundingClientRect().top <= 0);
         };
         window.addEventListener('scroll', update, { passive: true });
         update();
@@ -201,7 +200,6 @@ export function BaseNavigationTabs({
                     'transition-[box-shadow] duration-200',
                     'bg-heavy-metal-900',
                     stuck && 'shadow-[0_6px_16px_rgba(0,0,0,0.45)]',
-                    stickyClassName,
                 )}
             >
                 {tabBar}

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -27,12 +27,17 @@ export type BaseNavigationTabsProps = {
     onTabClick?: (path: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
     /**
      * Enables scroll-spy mode: active tab tracks scroll position, clicking scrolls smoothly.
-     * Wraps the tab bar in a sticky full-width container with a shadow on stuck.
-     * Use `wrapperClassName` to provide the background color (e.g. "bg-heavy-metal-900").
+     * Implies `sticky` (scroll-spy tabs are always pinned).
      */
     scrollSpy?: boolean;
+    /**
+     * Wraps the tab bar in a sticky, full-bleed container that raises a shadow once it sticks to the
+     * top. Use for route-based tabs that should pin (the block page); `scrollSpy` turns this on too.
+     * Provide the background color via `wrapperClassName` (e.g. "bg-heavy-metal-900").
+     */
+    sticky?: boolean;
     tabs: NavigationTab[];
-    /** Applied to the sticky wrapper when `scrollSpy` is true. Use for background color. */
+    /** Applied to the sticky wrapper (when `sticky` or `scrollSpy`). Use for background color. */
     wrapperClassName?: string;
 };
 
@@ -46,8 +51,12 @@ export function BaseNavigationTabs({
     className,
     disabledHint,
     scrollSpy,
+    sticky,
     wrapperClassName,
 }: BaseNavigationTabsProps) {
+    // Scroll-spy tabs are always pinned; `sticky` pins route-based tabs too. Both share the same
+    // sticky wrapper + shadow-on-stuck; only the active-tab tracking below is scroll-spy specific.
+    const isSticky = scrollSpy || sticky;
     const { registeredTabs, registerTab, unregisterTab } = useTabRegistration();
 
     const wrapperRef = useRef<HTMLDivElement>(null);
@@ -92,19 +101,28 @@ export function BaseNavigationTabs({
         [scrollToSection],
     );
 
-    useStickyHeaderHeight(wrapperRef, !!scrollSpy);
-
     useEffect(() => {
-        if (!scrollSpy) return;
+        if (!isSticky) return;
+        const el = wrapperRef.current;
+        if (!el) return;
         const update = () => {
-            const rect = wrapperRef.current?.getBoundingClientRect();
             // Stuck = the sticky bar has reached the top of the viewport (top: 0). Deriving this from the
             // bar's vertical position — rather than an IntersectionObserver with threshold 1 — keeps the
             // shadow correct even when the bar is full-bleed (100vw): a hairline of horizontal overflow
             // would otherwise drop the intersection ratio below 1 and pin `stuck` on permanently.
-            if (rect) setStuck(rect.top <= 0);
+            setStuck(el.getBoundingClientRect().top <= 0);
+        };
+        window.addEventListener('scroll', update, { passive: true });
+        update();
+        return () => window.removeEventListener('scroll', update);
+    }, [isSticky]);
 
-            const tabHeight = rect?.height ?? tablistRef.current?.getBoundingClientRect().height ?? 0;
+    useStickyHeaderHeight(wrapperRef, !!isSticky);
+
+    useEffect(() => {
+        if (!scrollSpy) return;
+        const update = () => {
+            const tabHeight = (wrapperRef.current ?? tablistRef.current)?.getBoundingClientRect().height ?? 0;
             // Activate when section is in the upper third of the visible content area
             const threshold = window.scrollY + tabHeight + window.innerHeight * 0.3;
             let active = tabs[0]?.path ?? '';
@@ -172,7 +190,7 @@ export function BaseNavigationTabs({
         </NavigationTabsContext.Provider>
     );
 
-    if (scrollSpy) {
+    if (isSticky) {
         return (
             <div
                 ref={wrapperRef}

--- a/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
@@ -11,10 +11,21 @@ type NavigationTabsProps = {
     buildHref: (path: string) => string;
     children?: React.ReactNode;
     className?: string;
+    /** Pin the tab bar to the top with a shadow on stuck (see BaseNavigationTabs `sticky`). */
+    sticky?: boolean;
     tabs: NavigationTab[];
+    /** Applied to the sticky wrapper. Use for background color. */
+    wrapperClassName?: string;
 };
 
-export function NavigationTabs({ buildHref, tabs, children, className }: NavigationTabsProps) {
+export function NavigationTabs({
+    buildHref,
+    tabs,
+    children,
+    className,
+    sticky,
+    wrapperClassName,
+}: NavigationTabsProps) {
     const segment = useSelectedLayoutSegment();
     const activeValue = segment ?? '';
     const router = useRouter();
@@ -33,6 +44,8 @@ export function NavigationTabs({ buildHref, tabs, children, className }: Navigat
             onSelectChange={onSelectChange}
             buildHref={buildHref}
             className={className}
+            sticky={sticky}
+            wrapperClassName={wrapperClassName}
         >
             {children}
         </BaseNavigationTabs>

--- a/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
@@ -12,20 +12,11 @@ type NavigationTabsProps = {
     children?: React.ReactNode;
     className?: string;
     /** Pin the tab bar to the top with a shadow on stuck (see BaseNavigationTabs `sticky`). */
-    sticky?: boolean;
+    sticky?: boolean | { className?: string };
     tabs: NavigationTab[];
-    /** Applied to the sticky wrapper. Use for background color. */
-    wrapperClassName?: string;
 };
 
-export function NavigationTabs({
-    buildHref,
-    tabs,
-    children,
-    className,
-    sticky,
-    wrapperClassName,
-}: NavigationTabsProps) {
+export function NavigationTabs({ buildHref, tabs, children, className, sticky }: NavigationTabsProps) {
     const segment = useSelectedLayoutSegment();
     const activeValue = segment ?? '';
     const router = useRouter();
@@ -45,7 +36,6 @@ export function NavigationTabs({
             buildHref={buildHref}
             className={className}
             sticky={sticky}
-            wrapperClassName={wrapperClassName}
         >
             {children}
         </BaseNavigationTabs>

--- a/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
@@ -12,7 +12,7 @@ type NavigationTabsProps = {
     children?: React.ReactNode;
     className?: string;
     /** Pin the tab bar to the top with a shadow on stuck (see BaseNavigationTabs `sticky`). */
-    sticky?: boolean | { className?: string };
+    sticky?: boolean;
     tabs: NavigationTab[];
 };
 

--- a/app/shared/ui/page-layout/PageHeader.tsx
+++ b/app/shared/ui/page-layout/PageHeader.tsx
@@ -3,13 +3,8 @@ import * as React from 'react';
 
 import { cnPrefixed } from '@/app/components/shared/utils';
 
-// The eyebrow + title header of a detail page (Transaction / Block / Inspector). It sits above the
-// page's <PageSections> block rhythm as a direct child of <PageLayout>, owning its own vertical
-// padding (`py-6`) and the gap down to the first section (`mb-3`). The typography and the
-// eyebrow → title gap are constant across every page — that's the design-system part.
 const pageHeaderClassName = 'mb-3 flex flex-col gap-1.5 py-6';
 
-// The title font scales up one step from `md`, matching the transaction page.
 const pageTitleVariants = cva('m-0 font-normal leading-none text-white', {
     defaultVariants: { size: 'default' },
     variants: {
@@ -24,7 +19,6 @@ export interface PageHeaderProps
     extends Omit<React.HTMLAttributes<HTMLElement>, 'title'>, VariantProps<typeof pageTitleVariants> {
     /** Small uppercased label above the title (e.g. "Details"). Omitted when not provided. */
     eyebrow?: React.ReactNode;
-    /** The page title, rendered as the page's single `<h1>`. */
     title: React.ReactNode;
 }
 

--- a/app/shared/ui/page-layout/PageHeader.tsx
+++ b/app/shared/ui/page-layout/PageHeader.tsx
@@ -3,24 +3,11 @@ import * as React from 'react';
 
 import { cnPrefixed } from '@/app/components/shared/utils';
 
-// The eyebrow + title header of a detail page. The typography and eyebrow → title gap are constant
-// (the design-system part); `spacing` picks how the header sits relative to the page's block rhythm:
-//
-// - `inline` (transaction page): the header is the first child of <PageLayout gap="default">, so it
-//   participates in the between-blocks rhythm. The negative bottom margin (`-mb-6`, reset to `mb-0`
-//   from `lg`) offsets part of that gap so the block below sits close under the title. It's paired
-//   with the layout gap on purpose — keep the two together when adjusting page spacing.
-// - `standalone` (block page): the header sits outside the rhythm, directly under
-//   <PageLayout gap="none">, and owns its own vertical padding + bottom gap to the first section.
-const pageHeaderVariants = cva('flex flex-col gap-1.5', {
-    defaultVariants: { spacing: 'inline' },
-    variants: {
-        spacing: {
-            inline: '-mb-6 pb-3 pt-2 lg:mb-0',
-            standalone: 'mb-3 py-6',
-        },
-    },
-});
+// The eyebrow + title header of a detail page (Transaction / Block / Inspector). It sits above the
+// page's <PageSections> block rhythm as a direct child of <PageLayout>, owning its own vertical
+// padding (`py-6`) and the gap down to the first section (`mb-3`). The typography and the
+// eyebrow → title gap are constant across every page — that's the design-system part.
+const pageHeaderClassName = 'mb-3 flex flex-col gap-1.5 py-6';
 
 // The title font scales up one step from `md`, matching the transaction page.
 const pageTitleVariants = cva('m-0 font-normal leading-none text-white', {
@@ -34,10 +21,7 @@ const pageTitleVariants = cva('m-0 font-normal leading-none text-white', {
 });
 
 export interface PageHeaderProps
-    extends
-        Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
-        VariantProps<typeof pageHeaderVariants>,
-        VariantProps<typeof pageTitleVariants> {
+    extends Omit<React.HTMLAttributes<HTMLElement>, 'title'>, VariantProps<typeof pageTitleVariants> {
     /** Small uppercased label above the title (e.g. "Details"). Omitted when not provided. */
     eyebrow?: React.ReactNode;
     /** The page title, rendered as the page's single `<h1>`. */
@@ -45,8 +29,8 @@ export interface PageHeaderProps
 }
 
 const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
-    ({ children, className, eyebrow, size, spacing, title, ...props }, ref) => (
-        <header ref={ref} className={cnPrefixed(pageHeaderVariants({ spacing }), className)} {...props}>
+    ({ children, className, eyebrow, size, title, ...props }, ref) => (
+        <header ref={ref} className={cnPrefixed(pageHeaderClassName, className)} {...props}>
             {eyebrow != undefined && eyebrow !== false && (
                 <span className="text-xs font-normal uppercase text-muted">{eyebrow}</span>
             )}
@@ -57,4 +41,4 @@ const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
 );
 PageHeader.displayName = 'PageHeader';
 
-export { PageHeader, pageHeaderVariants, pageTitleVariants };
+export { PageHeader, pageTitleVariants };

--- a/app/shared/ui/page-layout/PageHeader.tsx
+++ b/app/shared/ui/page-layout/PageHeader.tsx
@@ -1,0 +1,60 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cnPrefixed } from '@/app/components/shared/utils';
+
+// The eyebrow + title header of a detail page. The typography and eyebrow → title gap are constant
+// (the design-system part); `spacing` picks how the header sits relative to the page's block rhythm:
+//
+// - `inline` (transaction page): the header is the first child of <PageLayout gap="default">, so it
+//   participates in the between-blocks rhythm. The negative bottom margin (`-mb-6`, reset to `mb-0`
+//   from `lg`) offsets part of that gap so the block below sits close under the title. It's paired
+//   with the layout gap on purpose — keep the two together when adjusting page spacing.
+// - `standalone` (block page): the header sits outside the rhythm, directly under
+//   <PageLayout gap="none">, and owns its own vertical padding + bottom gap to the first section.
+const pageHeaderVariants = cva('flex flex-col gap-1.5', {
+    defaultVariants: { spacing: 'inline' },
+    variants: {
+        spacing: {
+            inline: '-mb-6 pb-3 pt-2 lg:mb-0',
+            standalone: 'mb-3 py-6',
+        },
+    },
+});
+
+// The title font scales up one step from `md`, matching the transaction page.
+const pageTitleVariants = cva('m-0 font-normal leading-none text-white', {
+    defaultVariants: { size: 'default' },
+    variants: {
+        size: {
+            default: 'text-2xl md:text-3xl',
+            sm: 'text-xl md:text-2xl',
+        },
+    },
+});
+
+export interface PageHeaderProps
+    extends
+        Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
+        VariantProps<typeof pageHeaderVariants>,
+        VariantProps<typeof pageTitleVariants> {
+    /** Small uppercased label above the title (e.g. "Details"). Omitted when not provided. */
+    eyebrow?: React.ReactNode;
+    /** The page title, rendered as the page's single `<h1>`. */
+    title: React.ReactNode;
+}
+
+const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
+    ({ children, className, eyebrow, size, spacing, title, ...props }, ref) => (
+        <header ref={ref} className={cnPrefixed(pageHeaderVariants({ spacing }), className)} {...props}>
+            {eyebrow != undefined && eyebrow !== false && (
+                <span className="text-xs font-normal uppercase text-muted">{eyebrow}</span>
+            )}
+            <h1 className={pageTitleVariants({ size })}>{title}</h1>
+            {children}
+        </header>
+    ),
+);
+PageHeader.displayName = 'PageHeader';
+
+export { PageHeader, pageHeaderVariants, pageTitleVariants };

--- a/app/shared/ui/page-layout/PageLayout.tsx
+++ b/app/shared/ui/page-layout/PageLayout.tsx
@@ -1,0 +1,32 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cnPrefixed } from '@/app/components/shared/utils';
+
+// The shell of a detail page (Transaction / Block / Account): centres the content column, caps its
+// width and applies the page's horizontal + top padding. It does NOT own the vertical rhythm between
+// blocks — that lives in <PageSections>, so a page composes the two (see the story). Splitting them
+// lets the block page keep its header outside the rhythm while the transaction page keeps it inside.
+//
+// Project breakpoints switch the wide values at `lg` (992px): the mobile/tablet values run through
+// `md`, the desktop values begin at `lg`.
+const pageLayoutVariants = cva('mx-auto flex flex-col px-4 pt-3 lg:px-6 lg:pt-5', {
+    defaultVariants: { width: 'default' },
+    variants: {
+        // Content column max-width. `default` caps at the detail-page width; `full` spans the parent.
+        width: {
+            default: 'max-w-5xl',
+            full: 'max-w-none',
+        },
+    },
+});
+
+export interface PageLayoutProps
+    extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof pageLayoutVariants> {}
+
+const PageLayout = React.forwardRef<HTMLDivElement, PageLayoutProps>(({ className, width, ...props }, ref) => (
+    <div ref={ref} className={cnPrefixed(pageLayoutVariants({ width }), className)} {...props} />
+));
+PageLayout.displayName = 'PageLayout';
+
+export { PageLayout, pageLayoutVariants };

--- a/app/shared/ui/page-layout/PageLayout.tsx
+++ b/app/shared/ui/page-layout/PageLayout.tsx
@@ -10,16 +10,22 @@ import { cnPrefixed } from '@/app/components/shared/utils';
 //
 // Project breakpoints switch the wide values at `lg` (992px): the mobile/tablet values run through
 // `md`, the desktop values begin at `lg`.
-const pageLayoutVariants = cva('mx-auto flex flex-col px-4 pt-3 lg:px-6 lg:pt-5', {
-    defaultVariants: { width: 'default' },
-    variants: {
-        // Content column max-width. `default` caps at the detail-page width; `full` spans the parent.
-        width: {
-            default: 'max-w-5xl',
-            full: 'max-w-none',
+//
+// The `selection:*` utilities give every detail page the same translucent text-selection highlight,
+// derived from the shared `accent` token, so callers never re-declare it.
+const pageLayoutVariants = cva(
+    'mx-auto flex flex-col px-4 pt-3 selection:bg-accent/25 selection:text-inherit lg:px-6 lg:pt-5',
+    {
+        defaultVariants: { width: 'default' },
+        variants: {
+            // Content column max-width. `default` caps at the detail-page width; `full` spans the parent.
+            width: {
+                default: 'max-w-5xl',
+                full: 'max-w-none',
+            },
         },
     },
-});
+);
 
 export interface PageLayoutProps
     extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof pageLayoutVariants> {}

--- a/app/shared/ui/page-layout/PageLayout.tsx
+++ b/app/shared/ui/page-layout/PageLayout.tsx
@@ -3,16 +3,6 @@ import * as React from 'react';
 
 import { cnPrefixed } from '@/app/components/shared/utils';
 
-// The shell of a detail page (Transaction / Block / Account): centres the content column, caps its
-// width and applies the page's horizontal + top padding. It does NOT own the vertical rhythm between
-// blocks — that lives in <PageSections>, so a page composes the two (see the story). Splitting them
-// lets the block page keep its header outside the rhythm while the transaction page keeps it inside.
-//
-// Project breakpoints switch the wide values at `lg` (992px): the mobile/tablet values run through
-// `md`, the desktop values begin at `lg`.
-//
-// The `selection:*` utilities give every detail page the same translucent text-selection highlight,
-// derived from the shared `accent` token, so callers never re-declare it.
 const pageLayoutVariants = cva(
     'mx-auto flex flex-col px-4 pt-3 selection:bg-accent/25 selection:text-inherit lg:px-6 lg:pt-5',
     {

--- a/app/shared/ui/page-layout/PageSections.tsx
+++ b/app/shared/ui/page-layout/PageSections.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { cnPrefixed } from '@/app/components/shared/utils';
+
+// The vertical rhythm between a detail page's blocks — the single value the design system is built
+// around, so a page never re-types it.
+export const PAGE_SECTION_GAP = 'space-y-9 lg:space-y-12';
+
+// A vertical stack of a detail page's blocks with the standard between-blocks rhythm. Pair it with
+// <PageLayout>: put it inside the shell and drop the page's blocks in. A page keeps its header inside
+// the stack (transaction page — the header participates in the rhythm) or above it (block page — the
+// header owns its own gap), depending on the <PageHeader spacing> it uses.
+const PageSections = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, ...props }, ref) => (
+        <div ref={ref} className={cnPrefixed('flex flex-col', PAGE_SECTION_GAP, className)} {...props} />
+    ),
+);
+PageSections.displayName = 'PageSections';
+
+export { PageSections };

--- a/app/shared/ui/page-layout/PageSections.tsx
+++ b/app/shared/ui/page-layout/PageSections.tsx
@@ -7,9 +7,8 @@ import { cnPrefixed } from '@/app/components/shared/utils';
 export const PAGE_SECTION_GAP = 'space-y-9 lg:space-y-12';
 
 // A vertical stack of a detail page's blocks with the standard between-blocks rhythm. Pair it with
-// <PageLayout>: put it inside the shell and drop the page's blocks in. A page keeps its header inside
-// the stack (transaction page — the header participates in the rhythm) or above it (block page — the
-// header owns its own gap), depending on the <PageHeader spacing> it uses.
+// <PageLayout>: put it inside the shell and drop the page's blocks in. The page's <PageHeader> sits
+// above this stack (a direct child of <PageLayout>), owning its own gap down to the first block.
 const PageSections = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
     ({ className, ...props }, ref) => (
         <div ref={ref} className={cnPrefixed('flex flex-col', PAGE_SECTION_GAP, className)} {...props} />

--- a/app/shared/ui/page-layout/PageSections.tsx
+++ b/app/shared/ui/page-layout/PageSections.tsx
@@ -2,13 +2,8 @@ import * as React from 'react';
 
 import { cnPrefixed } from '@/app/components/shared/utils';
 
-// The vertical rhythm between a detail page's blocks — the single value the design system is built
-// around, so a page never re-types it.
 export const PAGE_SECTION_GAP = 'space-y-9 lg:space-y-12';
 
-// A vertical stack of a detail page's blocks with the standard between-blocks rhythm. Pair it with
-// <PageLayout>: put it inside the shell and drop the page's blocks in. The page's <PageHeader> sits
-// above this stack (a direct child of <PageLayout>), owning its own gap down to the first block.
 const PageSections = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
     ({ className, ...props }, ref) => (
         <div ref={ref} className={cnPrefixed('flex flex-col', PAGE_SECTION_GAP, className)} {...props} />

--- a/app/shared/ui/page-layout/__stories__/PageLayout.stories.tsx
+++ b/app/shared/ui/page-layout/__stories__/PageLayout.stories.tsx
@@ -1,0 +1,188 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import React from 'react';
+
+import { Switch } from '@/app/components/shared/ui/switch';
+
+import { PageHeader } from '../PageHeader';
+import { PageLayout } from '../PageLayout';
+import { PageSections } from '../PageSections';
+
+// Design-system layout primitives for a detail page (Transaction / Block / Account). Compose them:
+// `PageLayout` is the shell, `PageSections` is the block rhythm, `PageHeader` is the eyebrow + title.
+// All live in `@/app/shared/ui/page-layout` and are applied directly by the real pages — there is no
+// separate constant to hand-wire.
+const meta = {
+    component: PageLayout,
+    parameters: {
+        docs: {
+            description: {
+                component: [
+                    'Layout primitives for a detail page (Transaction / Block / Account).',
+                    '',
+                    '- `PageLayout` — the page shell: content max-width + horizontal/top padding. The wide',
+                    '  values switch at `lg` (992px). It does not own the between-blocks rhythm.',
+                    '- `PageSections` — the between-blocks vertical rhythm, as a stack that wraps the blocks.',
+                    '- `PageHeader` — the eyebrow + title. `spacing="inline"` (default, transaction page) sits',
+                    '  inside the rhythm and carries the negative margin that tightens it against the sticky',
+                    '  tabs; `spacing="standalone"` (block page) sits above the rhythm and owns its own gap.',
+                    '',
+                    '## References',
+                    '',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) — the block surface the example blocks stand in for.',
+                    '- [PageContainer](?path=/docs/components-shared-pagecontainer--docs) — the Bootstrap-container replacement for list/legacy pages.',
+                ].join('\n'),
+            },
+        },
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    title: 'Design System/Page Layout',
+} satisfies Meta<typeof PageLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// A stand-in content block, matched to the detail-page card surface.
+function Block({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="rounded-xl border border-solid border-heavy-metal-950 bg-heavy-metal-800 px-6 py-8 text-sm text-neutral-200">
+            {children}
+        </div>
+    );
+}
+
+// Reference: what each spacing token resolves to per tier. Documentation only — pages get these
+// values by applying the components, never by reading this table.
+const TIERS = [
+    { key: 'mobile', label: 'Mobile', range: 'xs–md' },
+    { key: 'desktop', label: 'Desktop', range: 'lg+' },
+] as const;
+
+const SPACING_REFERENCE: { name: string; label: string; values: Record<'mobile' | 'desktop', string> }[] = [
+    { label: 'Page padding (horizontal)', name: 'px-4 lg:px-6', values: { desktop: '24px', mobile: '16px' } },
+    { label: 'Before header (page top)', name: 'pt-3 lg:pt-5', values: { desktop: '20px', mobile: '12px' } },
+    { label: 'Eyebrow → title', name: 'gap-1.5', values: { desktop: '6px', mobile: '6px' } },
+    { label: 'Between blocks', name: 'space-y-9 lg:space-y-12', values: { desktop: '48px', mobile: '36px' } },
+];
+
+// The transaction-page shape: the header sits inside <PageSections> as the first block (inline
+// spacing), so it participates in the rhythm. This is the common case.
+export const Default: Story = {
+    render: () => (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <PageLayout>
+                <PageSections>
+                    <PageHeader eyebrow="Details" title="Transaction" />
+                    <Block>Summary</Block>
+                    <Block>Accounts</Block>
+                    <Block>Instructions</Block>
+                </PageSections>
+            </PageLayout>
+        </div>
+    ),
+};
+
+// The block-page shape: the header sits above <PageSections> (standalone spacing) and owns its own
+// gap to the first section.
+export const StandaloneHeader: Story = {
+    render: () => (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <PageLayout>
+                <PageHeader eyebrow="Details" spacing="standalone" title="Block" />
+                <PageSections>
+                    <Block>Overview</Block>
+                    <Block>Transactions</Block>
+                </PageSections>
+            </PageLayout>
+        </div>
+    ),
+};
+
+// `width="full"` spans the parent instead of capping at max-w-5xl.
+export const FullWidth: Story = {
+    render: () => (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <PageLayout width="full">
+                <PageSections>
+                    <PageHeader eyebrow="width=full" title="Full-width column" />
+                    <Block>Spans the parent instead of capping at max-w-5xl.</Block>
+                </PageSections>
+            </PageLayout>
+        </div>
+    ),
+};
+
+// The per-tier spacing reference table for design hand-off.
+function ReferenceView() {
+    return (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <div className="mx-auto w-full max-w-5xl px-4">
+                <h2 className="m-0 mb-3 text-xs font-medium uppercase tracking-wide text-outer-space-300">
+                    Page spacing — per tier
+                </h2>
+                <div className="overflow-x-auto rounded-lg border border-solid border-outer-space-800">
+                    <table className="w-full border-collapse text-sm text-white">
+                        <thead>
+                            <tr className="text-left text-xs uppercase text-outer-space-300">
+                                <th className="px-3 py-2 font-normal">Spacing</th>
+                                <th className="px-3 py-2 font-normal">Class</th>
+                                {TIERS.map(t => (
+                                    <th key={t.key} className="px-3 py-2 font-normal">
+                                        {t.label} ({t.range})
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {SPACING_REFERENCE.map(s => (
+                                <tr key={s.name} className="border-t border-solid border-outer-space-800">
+                                    <td className="px-3 py-2">{s.label}</td>
+                                    <td className="px-3 py-2 font-mono text-outer-space-300">{s.name}</td>
+                                    {TIERS.map(t => (
+                                        <td key={t.key} className="px-3 py-2 font-mono">
+                                            {s.values[t.key]}
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export const Reference: Story = {
+    render: () => <ReferenceView />,
+};
+
+// Live example with an outline overlay toggle, so the block boxes and the gaps between them are
+// visible without altering the real layout.
+function AnnotatedView() {
+    const [outline, setOutline] = React.useState(true);
+    const ring = outline ? 'outline outline-1 outline-dashed outline-accent/50' : '';
+    return (
+        <div className="min-h-screen bg-heavy-metal-900 py-8">
+            <div className="mx-auto mb-6 flex w-full max-w-5xl items-center gap-3 px-4">
+                <Switch aria-label="Show layout outlines" checked={outline} onCheckedChange={setOutline} />
+                <span className="select-none text-sm text-white">Show layout outlines</span>
+            </div>
+            <PageLayout className={ring}>
+                <PageSections className={ring}>
+                    <PageHeader className={ring} eyebrow="Details" title="Transaction" />
+                    <div className={ring}>
+                        <Block>Summary</Block>
+                    </div>
+                    <div className={ring}>
+                        <Block>Accounts</Block>
+                    </div>
+                </PageSections>
+            </PageLayout>
+        </div>
+    );
+}
+
+export const Annotated: Story = {
+    render: () => <AnnotatedView />,
+};

--- a/app/shared/ui/page-layout/__stories__/PageLayout.stories.tsx
+++ b/app/shared/ui/page-layout/__stories__/PageLayout.stories.tsx
@@ -22,9 +22,8 @@ const meta = {
                     '- `PageLayout` — the page shell: content max-width + horizontal/top padding. The wide',
                     '  values switch at `lg` (992px). It does not own the between-blocks rhythm.',
                     '- `PageSections` — the between-blocks vertical rhythm, as a stack that wraps the blocks.',
-                    '- `PageHeader` — the eyebrow + title. `spacing="inline"` (default, transaction page) sits',
-                    '  inside the rhythm and carries the negative margin that tightens it against the sticky',
-                    '  tabs; `spacing="standalone"` (block page) sits above the rhythm and owns its own gap.',
+                    '- `PageHeader` — the eyebrow + title. It sits above `PageSections` as a direct child of',
+                    '  `PageLayout`, owning its own padding and the gap down to the first block.',
                     '',
                     '## References',
                     '',
@@ -65,33 +64,17 @@ const SPACING_REFERENCE: { name: string; label: string; values: Record<'mobile' 
     { label: 'Between blocks', name: 'space-y-9 lg:space-y-12', values: { desktop: '48px', mobile: '36px' } },
 ];
 
-// The transaction-page shape: the header sits inside <PageSections> as the first block (inline
-// spacing), so it participates in the rhythm. This is the common case.
+// The detail-page shape, shared by every page: the header sits above <PageSections> as a direct child
+// of <PageLayout> and owns its own gap down to the first block.
 export const Default: Story = {
     render: () => (
         <div className="min-h-screen bg-heavy-metal-900 py-8">
             <PageLayout>
+                <PageHeader eyebrow="Details" title="Transaction" />
                 <PageSections>
-                    <PageHeader eyebrow="Details" title="Transaction" />
                     <Block>Summary</Block>
                     <Block>Accounts</Block>
                     <Block>Instructions</Block>
-                </PageSections>
-            </PageLayout>
-        </div>
-    ),
-};
-
-// The block-page shape: the header sits above <PageSections> (standalone spacing) and owns its own
-// gap to the first section.
-export const StandaloneHeader: Story = {
-    render: () => (
-        <div className="min-h-screen bg-heavy-metal-900 py-8">
-            <PageLayout>
-                <PageHeader eyebrow="Details" spacing="standalone" title="Block" />
-                <PageSections>
-                    <Block>Overview</Block>
-                    <Block>Transactions</Block>
                 </PageSections>
             </PageLayout>
         </div>
@@ -103,8 +86,8 @@ export const FullWidth: Story = {
     render: () => (
         <div className="min-h-screen bg-heavy-metal-900 py-8">
             <PageLayout width="full">
+                <PageHeader eyebrow="width=full" title="Full-width column" />
                 <PageSections>
-                    <PageHeader eyebrow="width=full" title="Full-width column" />
                     <Block>Spans the parent instead of capping at max-w-5xl.</Block>
                 </PageSections>
             </PageLayout>
@@ -169,8 +152,8 @@ function AnnotatedView() {
                 <span className="select-none text-sm text-white">Show layout outlines</span>
             </div>
             <PageLayout className={ring}>
+                <PageHeader className={ring} eyebrow="Details" title="Transaction" />
                 <PageSections className={ring}>
-                    <PageHeader className={ring} eyebrow="Details" title="Transaction" />
                     <div className={ring}>
                         <Block>Summary</Block>
                     </div>

--- a/app/shared/ui/page-layout/__tests__/PageHeader.spec.tsx
+++ b/app/shared/ui/page-layout/__tests__/PageHeader.spec.tsx
@@ -19,14 +19,8 @@ describe('PageHeader', () => {
         expect(screen.queryByText('Details')).not.toBeInTheDocument();
     });
 
-    it('should default to the inline spacing that tightens it against the sticky tabs', () => {
-        render(<PageHeader title="Transaction" />);
-
-        expect(screen.getByRole('banner')).toHaveClass('-mb-6', 'lg:mb-0', 'gap-1.5');
-    });
-
-    it('should use standalone spacing (own padding, no negative margin) when requested', () => {
-        render(<PageHeader spacing="standalone" title="Block" />);
+    it('should own its vertical padding and the gap down to the first section', () => {
+        render(<PageHeader title="Block" />);
         const header = screen.getByRole('banner');
 
         expect(header).toHaveClass('mb-3', 'py-6', 'gap-1.5');

--- a/app/shared/ui/page-layout/__tests__/PageHeader.spec.tsx
+++ b/app/shared/ui/page-layout/__tests__/PageHeader.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from '../PageHeader';
+
+describe('PageHeader', () => {
+    it('should render the title as the page h1', () => {
+        render(<PageHeader title="Transaction" />);
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Transaction' })).toBeInTheDocument();
+    });
+
+    it('should render the eyebrow when provided and omit it otherwise', () => {
+        const { rerender } = render(<PageHeader eyebrow="Details" title="Transaction" />);
+        expect(screen.getByText('Details')).toBeInTheDocument();
+
+        rerender(<PageHeader title="Transaction" />);
+        expect(screen.queryByText('Details')).not.toBeInTheDocument();
+    });
+
+    it('should default to the inline spacing that tightens it against the sticky tabs', () => {
+        render(<PageHeader title="Transaction" />);
+
+        expect(screen.getByRole('banner')).toHaveClass('-mb-6', 'lg:mb-0', 'gap-1.5');
+    });
+
+    it('should use standalone spacing (own padding, no negative margin) when requested', () => {
+        render(<PageHeader spacing="standalone" title="Block" />);
+        const header = screen.getByRole('banner');
+
+        expect(header).toHaveClass('mb-3', 'py-6', 'gap-1.5');
+        expect(header).not.toHaveClass('-mb-6');
+    });
+
+    it('should scale the title down when size is sm', () => {
+        render(<PageHeader size="sm" title="Transaction" />);
+
+        expect(screen.getByRole('heading', { level: 1 })).toHaveClass('text-xl', 'md:text-2xl');
+    });
+
+    it('should render additional children after the title', () => {
+        render(
+            <PageHeader title="Transaction">
+                <p>subtitle</p>
+            </PageHeader>,
+        );
+
+        expect(screen.getByText('subtitle')).toBeInTheDocument();
+    });
+
+    it('should merge a custom className and forward the ref to the header element', () => {
+        const ref = createRef<HTMLElement>();
+        render(<PageHeader ref={ref} className="custom-class" title="Transaction" />);
+
+        expect(screen.getByRole('banner')).toHaveClass('custom-class', 'flex');
+        expect(ref.current?.tagName).toBe('HEADER');
+    });
+});

--- a/app/shared/ui/page-layout/__tests__/PageLayout.spec.tsx
+++ b/app/shared/ui/page-layout/__tests__/PageLayout.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { PageLayout } from '../PageLayout';
+
+describe('PageLayout', () => {
+    it('should render its children', () => {
+        render(
+            <PageLayout>
+                <div>block</div>
+            </PageLayout>,
+        );
+
+        expect(screen.getByText('block')).toBeInTheDocument();
+    });
+
+    it('should apply the default shell padding and max-width', () => {
+        render(<PageLayout data-testid="layout">content</PageLayout>);
+        const root = screen.getByTestId('layout');
+
+        expect(root).toHaveClass('mx-auto', 'flex', 'flex-col', 'px-4', 'lg:px-6', 'pt-3', 'lg:pt-5');
+        expect(root).toHaveClass('max-w-5xl');
+    });
+
+    it('should not own the between-blocks rhythm (that lives in PageSections)', () => {
+        render(<PageLayout data-testid="layout">content</PageLayout>);
+
+        expect(screen.getByTestId('layout')).not.toHaveClass('space-y-9', 'lg:space-y-12');
+    });
+
+    it('should span the parent when width is full', () => {
+        render(
+            <PageLayout data-testid="layout" width="full">
+                content
+            </PageLayout>,
+        );
+        const root = screen.getByTestId('layout');
+
+        expect(root).toHaveClass('max-w-none');
+        expect(root).not.toHaveClass('max-w-5xl');
+    });
+
+    it('should merge a custom className and forward arbitrary props', () => {
+        render(
+            <PageLayout className="custom-class" data-testid="layout">
+                content
+            </PageLayout>,
+        );
+
+        expect(screen.getByTestId('layout')).toHaveClass('custom-class', 'mx-auto');
+    });
+
+    it('should forward the ref to the underlying element', () => {
+        const ref = createRef<HTMLDivElement>();
+        render(<PageLayout ref={ref}>content</PageLayout>);
+
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+});

--- a/app/shared/ui/page-layout/__tests__/PageSections.spec.tsx
+++ b/app/shared/ui/page-layout/__tests__/PageSections.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { PageSections } from '../PageSections';
+
+describe('PageSections', () => {
+    it('should render its children stacked with the standard between-blocks rhythm', () => {
+        render(
+            <PageSections data-testid="sections">
+                <div>first</div>
+                <div>second</div>
+            </PageSections>,
+        );
+        const root = screen.getByTestId('sections');
+
+        expect(root).toHaveClass('flex', 'flex-col', 'space-y-9', 'lg:space-y-12');
+        expect(screen.getByText('first')).toBeInTheDocument();
+        expect(screen.getByText('second')).toBeInTheDocument();
+    });
+
+    it('should merge a custom className and forward the ref', () => {
+        const ref = createRef<HTMLDivElement>();
+        render(
+            <PageSections ref={ref} className="custom-class" data-testid="sections">
+                content
+            </PageSections>,
+        );
+
+        expect(screen.getByTestId('sections')).toHaveClass('custom-class', 'flex');
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+});

--- a/app/shared/ui/page-layout/index.ts
+++ b/app/shared/ui/page-layout/index.ts
@@ -1,0 +1,7 @@
+export { PageLayout, pageLayoutVariants } from './PageLayout';
+export type { PageLayoutProps } from './PageLayout';
+
+export { PageSections } from './PageSections';
+
+export { PageHeader, pageHeaderVariants, pageTitleVariants } from './PageHeader';
+export type { PageHeaderProps } from './PageHeader';

--- a/app/shared/ui/page-layout/index.ts
+++ b/app/shared/ui/page-layout/index.ts
@@ -3,5 +3,5 @@ export type { PageLayoutProps } from './PageLayout';
 
 export { PageSections } from './PageSections';
 
-export { PageHeader, pageHeaderVariants, pageTitleVariants } from './PageHeader';
+export { PageHeader, pageTitleVariants } from './PageHeader';
 export type { PageHeaderProps } from './PageHeader';

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -25,6 +25,7 @@ import { generateTokenBalanceRows, TokenBalancesCard } from '@/app/features/tran
 import { AutoRefresh, useAutoRefreshState } from '@/app/shared/lib/use-auto-refresh';
 import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
 import { BaseNavigationTabs } from '@/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs';
+import { PageHeader, PageLayout, PageSections } from '@/app/shared/ui/page-layout';
 import { useLogsPanelScrollSync } from '@/app/tx/[signature]/use-logs-scroll-sync';
 import useTabVisibility from '@/app/utils/use-tab-visibility';
 
@@ -85,25 +86,26 @@ export function TransactionDetailsPageClient({ params: { signature: raw } }: Pro
     }
 
     return (
-        <div className="mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:space-y-12 lg:px-6 lg:pt-5">
-            <header className="-mb-6 flex flex-col gap-1.5 pb-3 pt-2 lg:mb-0">
-                <span className="text-xs font-normal uppercase text-muted">Details</span>
-                <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Transaction</h1>
-            </header>
+        // The translucent-green text-selection highlight (`#13d89b` at 25% alpha) is a one-off colour,
+        // not a token; kept as a literal so the transaction and block pages stay visually in step.
+        <PageLayout className="selection:bg-[#13d89b40] selection:text-inherit">
+            <PageSections>
+                <PageHeader eyebrow="Details" title="Transaction" />
 
-            {signature === undefined ? (
-                <ErrorCard text={`Signature "${raw}" is not valid`} />
-            ) : clusterStatus === ClusterStatus.Failure ? (
-                <ErrorCard text="RPC is not responding. Please change your RPC url and try again." />
-            ) : (
-                <SignatureContext.Provider value={signature}>
-                    <SummaryCard signature={signature} autoRefresh={autoRefresh} />
-                    <Suspense fallback={<LoadingCard message="Loading transaction details" />}>
-                        <DetailsSection signature={signature} />
-                    </Suspense>
-                </SignatureContext.Provider>
-            )}
-        </div>
+                {signature === undefined ? (
+                    <ErrorCard text={`Signature "${raw}" is not valid`} />
+                ) : clusterStatus === ClusterStatus.Failure ? (
+                    <ErrorCard text="RPC is not responding. Please change your RPC url and try again." />
+                ) : (
+                    <SignatureContext.Provider value={signature}>
+                        <SummaryCard signature={signature} autoRefresh={autoRefresh} />
+                        <Suspense fallback={<LoadingCard message="Loading transaction details" />}>
+                            <DetailsSection signature={signature} />
+                        </Suspense>
+                    </SignatureContext.Provider>
+                )}
+            </PageSections>
+        </PageLayout>
     );
 }
 

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -86,12 +86,9 @@ export function TransactionDetailsPageClient({ params: { signature: raw } }: Pro
     }
 
     return (
-        // The translucent-green text-selection highlight (`#13d89b` at 25% alpha) is a one-off colour,
-        // not a token; kept as a literal so the transaction and block pages stay visually in step.
-        <PageLayout className="selection:bg-[#13d89b40] selection:text-inherit">
+        <PageLayout>
+            <PageHeader eyebrow="Details" title="Transaction" />
             <PageSections>
-                <PageHeader eyebrow="Details" title="Transaction" />
-
                 {signature === undefined ? (
                     <ErrorCard text={`Signature "${raw}" is not valid`} />
                 ) : clusterStatus === ClusterStatus.Failure ? (
@@ -159,13 +156,7 @@ function DetailsSection({ signature }: SignatureProps) {
 
     return (
         <>
-            <BaseNavigationTabs
-                scrollSpy
-                tabs={tabs}
-                buildHref={path => `#${path}`}
-                wrapperClassName="bg-heavy-metal-900"
-                className="gap-5"
-            />
+            <BaseNavigationTabs scrollSpy tabs={tabs} buildHref={path => `#${path}`} className="gap-5" />
             <Suspense fallback={<LoadingCard message="Loading accounts" />}>
                 <AccountsCard signature={signature} />
             </Suspense>

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -156,7 +156,7 @@ function DetailsSection({ signature }: SignatureProps) {
 
     return (
         <>
-            <BaseNavigationTabs scrollSpy tabs={tabs} buildHref={path => `#${path}`} className="gap-5" />
+            <BaseNavigationTabs scrollSpy tabs={tabs} buildHref={path => `#${path}`} />
             <Suspense fallback={<LoadingCard message="Loading accounts" />}>
                 <AccountsCard signature={signature} />
             </Suspense>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,7 +53,6 @@ export const dkColors = {
     'rainbow-5': '#1dd79b',
     'popover-bg': '#1A1A1A',
     'popover-border': 'rgba(255,255,255,0.1)',
-    'card-outline-dark': 'oklch(33.501% 0.01351 189.14)', // = outer-space-800; matches the tx-inspector card outline
     'input-placeholder-dark': '#ccc',
 };
 


### PR DESCRIPTION
MERGE AFTER [#1212](https://github.com/solana-foundation/explorer/pull/1212)

## Description
Introducing reusable PageHeader and PageLayout components
and replaced the custom solution on tx and block pages with new components

## Type of change

-   [x] Design update

## Testing
no specific changes, it should be any ui change on block and transaction page

## Related Issues
[HOO-1400](https://linear.app/solana-fndn/issue/HOO-1400)
[HOO-1584](https://linear.app/solana-fndn/issue/HOO-1584/create-reusable-page-components)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass on the PR

## Additional Notes

Extracted and isolated from the shared design-system work in https://github.com/hoodieshq/explorer/pull/132 (vote-account page) — only the `DSCOMMON_*` tokens and the Sizes reference, not `PageHeader` / `StickyHeader`. The reference's header slot uses an inline eyebrow/title stand-in so it stands alone.
