### PR TITLE
chore(sentry): improve sentry and trace sample rates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,13 +86,23 @@ MCP_GA_API_SECRET=
 MCP_SOLANA_RPC_URL_MAINNET_BETA=
 MCP_SOLANA_RPC_URL_DEVNET=
 MCP_SOLANA_RPC_URL_TESTNET=
-## Configuration for Sentry feature enabled
-### Sentry is disabled by default. To enable error reporting, set SENTRY_DSN to
-### your project's DSN (found in Sentry under Settings > Projects > Client Keys).
-### Without a DSN all Sentry calls are silent no-ops.
-### SENTRY_ORG, SENTRY_PRJ, and SENTRY_AUTH_TOKEN are only needed for source-map
-### uploads during production builds.
+## Sentry
+### Off by default: without a DSN every Sentry call is a no-op.
+### Project identity — fixed once per Sentry project; used for source-map uploads.
 SENTRY_ORG=
-SENTRY_DSN=
 SENTRY_PRJ=
+### Keys and secrets — rotated over time. NEXT_PUBLIC_SENTRY_DSN (safe to expose) enables browser
+### reporting and is the server/edge default; SENTRY_DSN overrides it for server/edge only.
+### SENTRY_AUTH_TOKEN: source-map uploads in production builds only.
+NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
+SENTRY_DSN=
+### Web Vitals: multiplier (0-1] on the code-owned rate (sentry/vitals.mjs) for client
+### pageload/navigation transactions. Unset or 0 = off, baseline sampling applies.
+NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE=
+### Emergency dampeners: multiplier [0-1] on a runtime's baseline trace rate
+### (TRACE_SAMPLE_RATES, sentry/config.mjs). Unset = unchanged, 0 = mute.
+### SERVER covers edge; EDGE overrides it.
+NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT=
+TELEMETRY_TRACE_SAMPLE_RATE_EDGE=
+TELEMETRY_TRACE_SAMPLE_RATE_SERVER=

--- a/.env.example
+++ b/.env.example
@@ -97,11 +97,11 @@ SENTRY_PRJ=
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
 SENTRY_DSN=
-### Web Vitals: multiplier (0-1] on the code-owned rate (sentry/vitals.mjs) for client
+### Web Vitals: multiplier (0-1] on the code-owned rate (sentry/lib/vitals.mjs) for client
 ### pageload/navigation transactions. Unset or 0 = off, baseline sampling applies.
 NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE=
 ### Emergency dampeners: multiplier [0-1] on a runtime's baseline trace rate
-### (TRACE_SAMPLE_RATES, sentry/config.mjs). Unset = unchanged, 0 = mute.
+### (TRACE_SAMPLE_RATES, sentry/lib/config.mjs). Unset = unchanged, 0 = mute.
 ### SERVER covers edge; EDGE overrides it.
 NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT=
 TELEMETRY_TRACE_SAMPLE_RATE_EDGE=

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-import { createSentryConfig } from './sentry/config';
+import { createSentryConfig } from './sentry';
 
 Sentry.init(createSentryConfig('client'));
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,7 @@ import { withBotId } from 'botid/next/config';
 import { fileURLToPath } from 'url';
 
 import { buildRedirects } from './config/redirects.mjs';
-import { createSentryBuildConfig } from './sentry/config.mjs';
+import { createSentryBuildConfig } from './sentry/lib/config.mjs';
 
 // Pin both file-tracing and Turbopack to the project root; otherwise Next walks up to a parent
 // pnpm-workspace.yaml (e.g. in git worktrees) and the two roots disagree.

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,6 +5,6 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-import { createSentryConfig } from './sentry/config';
+import { createSentryConfig } from './sentry';
 
 Sentry.init(createSentryConfig('edge'));

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,6 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-import { createSentryConfig } from './sentry/config';
+import { createSentryConfig } from './sentry';
 
 Sentry.init(createSentryConfig('server'));

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -35,6 +35,6 @@ variable in Vercel and redeploy. Rollback at any point: restore the previous val
 
 ## Where the rates live
 
-Code-owned baselines sit in `lib/config.mjs`: `SAMPLE_RATES` (error events) and `TRACE_SAMPLE_RATES` (traces), each
+Code-owned baselines sit in `lib/config.mjs`: `ERROR_SAMPLE_RATES` (error events) and `TRACE_SAMPLE_RATES` (traces), each
 with a `TODO(rollout)` ladder describing the next steps. The vitals ceiling is `VITALS_TRACE_SAMPLE_RATE` in
 `lib/vitals.mjs`.

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -1,0 +1,14 @@
+# Sentry configuration
+
+`NEXT_PUBLIC_*` values are inlined at build time — every change below needs a redeploy.
+
+When production floods Sentry, adjust in Vercel:
+
+- *Too many transactions* — lower or unset `NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE`; unset = near-zero baseline
+- *Too many baseline traces* — set the runtime's dampener to a fraction, or `0` to mute:
+  `NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT`, `TELEMETRY_TRACE_SAMPLE_RATE_SERVER` (covers edge),
+  `TELEMETRY_TRACE_SAMPLE_RATE_EDGE` (edge override)
+- *Too many errors* — unset `NEXT_PUBLIC_SENTRY_DSN` (browser) or `SENTRY_DSN` (server/edge); reporting stops entirely
+
+Code-owned rates live in `SAMPLE_RATES` (errors) and `TRACE_SAMPLE_RATES` (traces) in `lib/config.mjs`, and
+`VITALS_TRACE_SAMPLE_RATE` (`lib/vitals.mjs`).

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -1,14 +1,40 @@
 # Sentry configuration
 
-`NEXT_PUBLIC_*` values are inlined at build time — every change below needs a redeploy.
+Sampling and DSNs resolve in `lib/config.mjs`; every env var below is read through `lib/env.mjs`. Env changes only
+apply on the next deployment (`NEXT_PUBLIC_*` values are additionally inlined at build), so every action below ends
+with a redeploy.
 
-When production floods Sentry, adjust in Vercel:
+## Variables and their defaults
 
-- *Too many transactions* — lower or unset `NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE`; unset = near-zero baseline
-- *Too many baseline traces* — set the runtime's dampener to a fraction, or `0` to mute:
-  `NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT`, `TELEMETRY_TRACE_SAMPLE_RATE_SERVER` (covers edge),
-  `TELEMETRY_TRACE_SAMPLE_RATE_EDGE` (edge override)
-- *Too many errors* — unset `NEXT_PUBLIC_SENTRY_DSN` (browser) or `SENTRY_DSN` (server/edge); reporting stops entirely
+| Variable                                        | Unset (the default)                                          | Set to `v`                                                 |
+| ----------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| `NEXT_PUBLIC_SENTRY_DSN`                        | Browser reporting off                                        | Browser reports here; server/edge fall back to it           |
+| `SENTRY_DSN`                                    | Server/edge fall back to the public var, else off            | Server/edge report here                                     |
+| `NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE`      | Vitals off — pageloads sample at the 1e-8 client baseline    | Pageload/navigation sampled at `0.001 × v`, `v` in (0, 1]  |
+| `NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT`| Client trace baseline 1e-8 unchanged                         | Client traces at `1e-8 × v`; `0` mutes them                 |
+| `TELEMETRY_TRACE_SAMPLE_RATE_SERVER`            | Server trace baseline 1e-5 unchanged                         | Server — and edge, unless the EDGE var is set — at `1e-5 × v`; `0` mutes |
+| `TELEMETRY_TRACE_SAMPLE_RATE_EDGE`              | Edge follows the SERVER var                                  | Edge-only override; `0` mutes edge alone                    |
 
-Code-owned rates live in `SAMPLE_RATES` (errors) and `TRACE_SAMPLE_RATES` (traces) in `lib/config.mjs`, and
-`VITALS_TRACE_SAMPLE_RATE` (`lib/vitals.mjs`).
+Unparsable or negative values read as unset; values above 1 clamp to 1. The multipliers only lower the code-owned
+baselines — they can never raise them.
+
+## Under a flood
+
+Identify the flood in Sentry → Stats first: errors or transactions, and which runtime tag. Then set the matching
+variable in Vercel and redeploy. Rollback at any point: restore the previous value and redeploy again.
+
+| Flood                        | Set                                                        | Effect                                                    |
+| ---------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| Server overloaded by spans   | `TELEMETRY_TRACE_SAMPLE_RATE_SERVER=0.1`                    | Server and edge traces cut 10× (1e-5 → 1e-6)               |
+| …still flooding              | `TELEMETRY_TRACE_SAMPLE_RATE_SERVER=0`                      | Server and edge traces stop entirely                       |
+| Edge alone floods            | `TELEMETRY_TRACE_SAMPLE_RATE_EDGE=0`                        | Edge traces stop; server keeps its rate                    |
+| Vitals transactions flood    | `NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE=0.1`              | Pageload rate 0.001 → 1e-4; unset the var to switch vitals off |
+| Client baseline traces flood | `NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT=0`          | Client traces stop                                         |
+| Browser errors flood         | Unset `NEXT_PUBLIC_SENTRY_DSN`                              | Browser reporting stops; server/edge keep `SENTRY_DSN`     |
+| Server/edge errors flood     | Unset `SENTRY_DSN` **and** `NEXT_PUBLIC_SENTRY_DSN`         | All reporting stops — the server falls back to the public var, so both must go |
+
+## Where the rates live
+
+Code-owned baselines sit in `lib/config.mjs`: `SAMPLE_RATES` (error events) and `TRACE_SAMPLE_RATES` (traces), each
+with a `TODO(rollout)` ladder describing the next steps. The vitals ceiling is `VITALS_TRACE_SAMPLE_RATE` in
+`lib/vitals.mjs`.

--- a/sentry/config.mjs
+++ b/sentry/config.mjs
@@ -2,12 +2,19 @@
  * @typedef {'client' | 'server' | 'edge'} RuntimeContext
  */
 
+// Server traces are ~5 spans each; browser pageloads emit hundreds, so client/edge stay near zero.
+const TRACE_SAMPLE_RATES = {
+    client: 1 / 100000000,
+    edge: 1 / 100000000,
+    server: 1 / 100000,
+};
+
 /**
  * Creates the common Sentry configuration for all runtimes
- * @param {RuntimeContext} _context - The runtime context (client, server, or edge)
+ * @param {RuntimeContext} context - The runtime context (client, server, or edge)
  * @returns {import('@sentry/core').Options} Sentry configuration options
  */
-export function createSentryConfig(_context) {
+export function createSentryConfig(context) {
     return {
         sampleRate: 1,
 
@@ -34,7 +41,7 @@ export function createSentryConfig(_context) {
                 return 0;
             }
 
-            return 1 / 100000000;
+            return TRACE_SAMPLE_RATES[context];
         },
 
         // Enable logs to be sent to Sentry

--- a/sentry/index.ts
+++ b/sentry/index.ts
@@ -5,7 +5,7 @@ import type { SentryBuildOptions } from '@sentry/nextjs';
 import {
     createSentryBuildConfig as createSentryBuildConfigMjs,
     createSentryConfig as createSentryConfigMjs,
-} from './config.mjs';
+} from './lib/config.mjs';
 
 type RuntimeContext = 'client' | 'server' | 'edge';
 

--- a/sentry/lib/__tests__/config.spec.ts
+++ b/sentry/lib/__tests__/config.spec.ts
@@ -1,0 +1,193 @@
+import type { TracesSamplerSamplingContext } from '@sentry/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSentryConfig } from '../config.mjs';
+import { clientSentryDsn, serverSentryDsn, traceSampleRateMultiplier, vitalsSampleRateMultiplier } from '../env.mjs';
+
+const samplingContext = (name: string, op?: string): TracesSamplerSamplingContext => ({
+    attributes: op ? { 'sentry.op': op } : {},
+    inheritOrSampleWith: (fallback: number) => fallback,
+    name,
+});
+
+const sample = (context: 'client' | 'server' | 'edge', name: string, op?: string): number | boolean => {
+    const { tracesSampler } = createSentryConfig(context);
+    if (!tracesSampler) {
+        throw new Error('tracesSampler is not configured');
+    }
+    return tracesSampler(samplingContext(name, op));
+};
+
+const CLIENT_BASELINE = 1 / 100000000;
+const SERVER_BASELINE = 1 / 100000;
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('vitalsSampleRateMultiplier', () => {
+    it('should return undefined when the var is unset', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', undefined);
+        expect(vitalsSampleRateMultiplier()).toBeUndefined();
+    });
+
+    it.each(['0', '-1', 'garbage', 'NaN', 'Infinity', ''])('should return undefined for %j', value => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', value);
+        expect(vitalsSampleRateMultiplier()).toBeUndefined();
+    });
+
+    it('should parse a rate within (0, 1]', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '0.5');
+        expect(vitalsSampleRateMultiplier()).toBe(0.5);
+    });
+
+    it('should clamp values above 1', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '5');
+        expect(vitalsSampleRateMultiplier()).toBe(1);
+    });
+});
+
+describe('traceSampleRateMultiplier', () => {
+    it('should read the per-runtime var', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT', '0.5');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0.25');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_EDGE', '0');
+        expect(traceSampleRateMultiplier('client')).toBe(0.5);
+        expect(traceSampleRateMultiplier('server')).toBe(0.25);
+        expect(traceSampleRateMultiplier('edge')).toBe(0);
+    });
+
+    it('should fall back to the server var for edge', () => {
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0.25');
+        expect(traceSampleRateMultiplier('edge')).toBe(0.25);
+    });
+
+    it('should let an explicit edge var override the server fallback', () => {
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0.25');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_EDGE', '0');
+        expect(traceSampleRateMultiplier('edge')).toBe(0);
+    });
+
+    it('should return undefined when unset or unparsable', () => {
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', 'garbage');
+        expect(traceSampleRateMultiplier('client')).toBeUndefined();
+        expect(traceSampleRateMultiplier('server')).toBeUndefined();
+    });
+
+    it('should clamp values above 1', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT', '5');
+        expect(traceSampleRateMultiplier('client')).toBe(1);
+    });
+});
+
+describe('DSN helpers', () => {
+    it('should expose only the public var to the client', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@sentry.example/1');
+        vi.stubEnv('SENTRY_DSN', 'https://private@sentry.example/2');
+        expect(clientSentryDsn()).toBe('https://public@sentry.example/1');
+    });
+
+    it('should prefer the private var on the server', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@sentry.example/1');
+        vi.stubEnv('SENTRY_DSN', 'https://private@sentry.example/2');
+        expect(serverSentryDsn()).toBe('https://private@sentry.example/2');
+    });
+
+    it('should fall back to the public var on the server', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@sentry.example/1');
+        vi.stubEnv('SENTRY_DSN', undefined);
+        expect(serverSentryDsn()).toBe('https://public@sentry.example/1');
+    });
+
+    it('should leave the client without a DSN when only the private var is set', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', undefined);
+        vi.stubEnv('SENTRY_DSN', 'https://private@sentry.example/2');
+        expect(clientSentryDsn()).toBeUndefined();
+        expect(serverSentryDsn()).toBe('https://private@sentry.example/2');
+    });
+});
+
+describe('createSentryConfig dsn', () => {
+    it('should wire the public DSN for the client and the private one for server/edge', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@sentry.example/1');
+        vi.stubEnv('SENTRY_DSN', 'https://private@sentry.example/2');
+        expect(createSentryConfig('client').dsn).toBe('https://public@sentry.example/1');
+        expect(createSentryConfig('server').dsn).toBe('https://private@sentry.example/2');
+        expect(createSentryConfig('edge').dsn).toBe('https://private@sentry.example/2');
+    });
+
+    it('should keep server/edge reporting when the public var is absent', () => {
+        vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', undefined);
+        vi.stubEnv('SENTRY_DSN', 'https://private@sentry.example/2');
+        expect(createSentryConfig('client').dsn).toBeUndefined();
+        expect(createSentryConfig('server').dsn).toBe('https://private@sentry.example/2');
+        expect(createSentryConfig('edge').dsn).toBe('https://private@sentry.example/2');
+    });
+});
+
+describe('sampleRate', () => {
+    it('should keep error events at full sample on every runtime', () => {
+        expect(createSentryConfig('client').sampleRate).toBe(1);
+        expect(createSentryConfig('server').sampleRate).toBe(1);
+        expect(createSentryConfig('edge').sampleRate).toBe(1);
+    });
+});
+
+describe('tracesSampler vitals gate', () => {
+    it.each(['pageload', 'navigation'])('should scale the vitals rate for client %s', op => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '1');
+        expect(sample('client', '/address/abc', op)).toBe(0.001);
+    });
+
+    it('should apply a fractional multiplier', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '0.5');
+        expect(sample('client', '/address/abc', 'pageload')).toBe(0.0005);
+    });
+
+    it('should keep the baseline for other client ops', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '1');
+        expect(sample('client', 'GET /api/foo', 'http.client')).toBe(CLIENT_BASELINE);
+    });
+
+    it('should keep the baseline for server and edge regardless of op', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '1');
+        expect(sample('server', '/address/abc', 'pageload')).toBe(SERVER_BASELINE);
+        expect(sample('edge', '/address/abc', 'pageload')).toBe(CLIENT_BASELINE);
+    });
+
+    it('should fall back to the baseline when the var is unset', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', undefined);
+        expect(sample('client', '/address/abc', 'pageload')).toBe(CLIENT_BASELINE);
+    });
+
+    it.each(['0', 'garbage', '-0.5'])('should fall back to the baseline for %j', value => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', value);
+        expect(sample('client', '/address/abc', 'pageload')).toBe(CLIENT_BASELINE);
+    });
+
+    it('should dampen the baseline with the per-runtime multiplier', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT', '0.5');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_EDGE', '1');
+        expect(sample('client', '/address/abc', 'http.client')).toBe(CLIENT_BASELINE * 0.5);
+        expect(sample('server', 'GET /address/abc')).toBe(0);
+        expect(sample('edge', 'GET /address/abc')).toBe(CLIENT_BASELINE);
+    });
+
+    it('should mute edge through the server fallback', () => {
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0');
+        expect(sample('edge', 'GET /address/abc')).toBe(0);
+    });
+
+    it('should keep the vitals gate ahead of the baseline multiplier', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '1');
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT', '0');
+        expect(sample('client', '/address/abc', 'pageload')).toBe(0.001);
+    });
+
+    it('should keep the zero branches ahead of the vitals gate', () => {
+        vi.stubEnv('NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE', '1');
+        expect(sample('client', '/.well-known/foo', 'pageload')).toBe(0);
+        expect(sample('client', 'GET https://iad1.suspense-cache.vercel-infra.com/v1/x', 'pageload')).toBe(0);
+    });
+});

--- a/sentry/lib/__tests__/config.spec.ts
+++ b/sentry/lib/__tests__/config.spec.ts
@@ -2,7 +2,13 @@ import type { TracesSamplerSamplingContext } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createSentryConfig } from '../config.mjs';
-import { clientSentryDsn, serverSentryDsn, traceSampleRateMultiplier, vitalsSampleRateMultiplier } from '../env.mjs';
+import {
+    clientSentryDsn,
+    serverSentryDsn,
+    sourcemapUploadsDisabled,
+    traceSampleRateMultiplier,
+    vitalsSampleRateMultiplier,
+} from '../env.mjs';
 
 const samplingContext = (name: string, op?: string): TracesSamplerSamplingContext => ({
     attributes: op ? { 'sentry.op': op } : {},
@@ -147,6 +153,26 @@ describe('createSentryConfig environment', () => {
         expect(createSentryConfig('client').environment).toBe('development');
         expect(createSentryConfig('server').environment).toBe('development');
         expect(createSentryConfig('edge').environment).toBe('development');
+    });
+});
+
+describe('sourcemapUploadsDisabled', () => {
+    it('should keep uploads on Vercel production only', () => {
+        vi.stubEnv('VERCEL_ENV', 'production');
+        expect(sourcemapUploadsDisabled()).toBe(false);
+    });
+
+    it('should disable uploads on previews and local builds', () => {
+        vi.stubEnv('VERCEL_ENV', 'preview');
+        expect(sourcemapUploadsDisabled()).toBe(true);
+        vi.stubEnv('VERCEL_ENV', undefined);
+        expect(sourcemapUploadsDisabled()).toBe(true);
+    });
+
+    it('should let the preview override opt uploads back in', () => {
+        vi.stubEnv('VERCEL_ENV', 'preview');
+        vi.stubEnv('ENABLE_SENTRY_SOURCEMAPS_AT_PREVIEW', 'true');
+        expect(sourcemapUploadsDisabled()).toBe(false);
     });
 });
 

--- a/sentry/lib/__tests__/config.spec.ts
+++ b/sentry/lib/__tests__/config.spec.ts
@@ -62,6 +62,12 @@ describe('traceSampleRateMultiplier', () => {
         expect(traceSampleRateMultiplier('edge')).toBe(0.25);
     });
 
+    it('should fall back to the server var when the edge var is unparsable', () => {
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_EDGE', 'garbage');
+        vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0.25');
+        expect(traceSampleRateMultiplier('edge')).toBe(0.25);
+    });
+
     it('should let an explicit edge var override the server fallback', () => {
         vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_SERVER', '0.25');
         vi.stubEnv('TELEMETRY_TRACE_SAMPLE_RATE_EDGE', '0');

--- a/sentry/lib/__tests__/config.spec.ts
+++ b/sentry/lib/__tests__/config.spec.ts
@@ -125,6 +125,25 @@ describe('createSentryConfig dsn', () => {
     });
 });
 
+describe('createSentryConfig environment', () => {
+    it('should report the Vercel environment on every runtime', () => {
+        vi.stubEnv('VERCEL_ENV', 'preview');
+        vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+        expect(createSentryConfig('client').environment).toBe('preview');
+        expect(createSentryConfig('server').environment).toBe('preview');
+        expect(createSentryConfig('edge').environment).toBe('preview');
+    });
+
+    it('should fall back to NODE_ENV outside Vercel', () => {
+        vi.stubEnv('VERCEL_ENV', undefined);
+        vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', undefined);
+        vi.stubEnv('NODE_ENV', 'development');
+        expect(createSentryConfig('client').environment).toBe('development');
+        expect(createSentryConfig('server').environment).toBe('development');
+        expect(createSentryConfig('edge').environment).toBe('development');
+    });
+});
+
 describe('sampleRate', () => {
     it('should keep error events at full sample on every runtime', () => {
         expect(createSentryConfig('client').sampleRate).toBe(1);

--- a/sentry/lib/__tests__/config.spec.ts
+++ b/sentry/lib/__tests__/config.spec.ts
@@ -145,10 +145,13 @@ describe('createSentryConfig environment', () => {
 });
 
 describe('sampleRate', () => {
-    it('should keep error events at full sample on every runtime', () => {
-        expect(createSentryConfig('client').sampleRate).toBe(1);
+    it('should keep server and edge error events at full sample', () => {
         expect(createSentryConfig('server').sampleRate).toBe(1);
         expect(createSentryConfig('edge').sampleRate).toBe(1);
+    });
+
+    it('should sample client error events at the dialled-down rate', () => {
+        expect(createSentryConfig('client').sampleRate).toBe(1 / 1000000);
     });
 });
 

--- a/sentry/lib/config.mjs
+++ b/sentry/lib/config.mjs
@@ -1,4 +1,10 @@
-import { clientSentryDsn, sentryEnvironment, serverSentryDsn, traceSampleRateMultiplier } from './env.mjs';
+import {
+    clientSentryDsn,
+    sentryEnvironment,
+    serverSentryDsn,
+    sourcemapUploadsDisabled,
+    traceSampleRateMultiplier,
+} from './env.mjs';
 import { vitalsTraceSampleRate } from './vitals.mjs';
 
 /**
@@ -105,10 +111,8 @@ export function createSentryBuildConfig() {
         },
 
         // Previews don't need symbolicated traces — uploading 800+ maps × 3 runtimes added ~90s/build.
-        // ENABLE_SENTRY_SOURCEMAPS_AT_PREVIEW (internal) temporarily opts previews into uploads.
         sourcemaps: {
-            disable:
-                process.env.VERCEL_ENV !== 'production' && process.env.ENABLE_SENTRY_SOURCEMAPS_AT_PREVIEW !== 'true',
+            disable: sourcemapUploadsDisabled(),
         },
 
         // Off: widening pulls node_modules chunks into the upload.

--- a/sentry/lib/config.mjs
+++ b/sentry/lib/config.mjs
@@ -9,7 +9,7 @@ import { vitalsTraceSampleRate } from './vitals.mjs';
 // TODO(rollout): client 1e-6 → 1e-4 → 1e-2 → 1; each ×100 step bounds the next volume at 100× the measured
 // one, advance when that still fits quota. Restore 1 when the beforeSend opt-in gate (feat/feedback-widget)
 // lands and becomes the quota guard.
-const SAMPLE_RATES = {
+const ERROR_SAMPLE_RATES = {
     client: 1 / 1000000,
     edge: 1,
     server: 1,
@@ -24,6 +24,12 @@ const TRACE_SAMPLE_RATES = {
     server: 1 / 100000,
 };
 
+// Never-sample name substrings: categories that are noise at any rate, excluded before every other rule.
+const TRACE_EXCLUDES = [
+    '/.well-known', // bot and devtools probes
+    'suspense-cache.vercel-infra.com', // Vercel infra, e.g. GET https://iad1.suspense-cache.vercel-infra.com/v1/*
+];
+
 /**
  * Creates the common Sentry configuration for all runtimes
  * @param {RuntimeContext} context - The runtime context (client, server, or edge)
@@ -33,18 +39,11 @@ export function createSentryConfig(context) {
     return {
         dsn: context === 'client' ? clientSentryDsn() : serverSentryDsn(),
 
-        sampleRate: SAMPLE_RATES[context],
+        sampleRate: ERROR_SAMPLE_RATES[context],
 
         // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
         tracesSampler: (/** @type {import('@sentry/core').TracesSamplerSamplingContext} */ samplingContext) => {
-            // Don't sample .well-known
-            if (samplingContext.name.includes('/.well-known')) {
-                return 0;
-            }
-
-            // Don't sample infrastructure requests:
-            // - GET https://iad1.suspense-cache.vercel-infra.com/v1/suspense-cache/*
-            if (samplingContext.name.includes('suspense-cache.vercel-infra.com')) {
+            if (TRACE_EXCLUDES.some(exclude => samplingContext.name.includes(exclude))) {
                 return 0;
             }
 

--- a/sentry/lib/config.mjs
+++ b/sentry/lib/config.mjs
@@ -1,6 +1,16 @@
+import { clientSentryDsn, serverSentryDsn, traceSampleRateMultiplier } from './env.mjs';
+import { vitalsTraceSampleRate } from './vitals.mjs';
+
 /**
  * @typedef {'client' | 'server' | 'edge'} RuntimeContext
  */
+
+// Error events are rare and load-bearing; every runtime keeps them all.
+const SAMPLE_RATES = {
+    client: 1,
+    edge: 1,
+    server: 1,
+};
 
 // Server traces are ~5 spans each; browser pageloads emit hundreds, so client/edge stay near zero.
 const TRACE_SAMPLE_RATES = {
@@ -16,7 +26,9 @@ const TRACE_SAMPLE_RATES = {
  */
 export function createSentryConfig(context) {
     return {
-        sampleRate: 1,
+        dsn: context === 'client' ? clientSentryDsn() : serverSentryDsn(),
+
+        sampleRate: SAMPLE_RATES[context],
 
         // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
         tracesSampler: (/** @type {import('@sentry/core').TracesSamplerSamplingContext} */ samplingContext) => {
@@ -31,17 +43,23 @@ export function createSentryConfig(context) {
                 return 0;
             }
 
-            // Don't sample health checks or monitoring endpoints
-            if (samplingContext.name.includes('/api/ping')) {
-                return 0;
+            // Vitals sampling off → the baseline map rate applies.
+            if (context === 'client') {
+                const vitalsRate = vitalsTraceSampleRate(samplingContext);
+                if (vitalsRate !== undefined) {
+                    return vitalsRate;
+                }
             }
 
-            // Don't sample all other api endpoints as we should rely on logging
-            if (samplingContext.name.includes('/api/')) {
-                return 0;
-            }
+            // TODO: enable once a client DSN exists so a sampled client trace keeps its server half; callers
+            // can force sampling via sentry-trace headers, so weigh that first:
+            // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/sampling/#inheritance
+            // if (samplingContext.parentSampled !== undefined) {
+            //     return samplingContext.parentSampled;
+            // }
 
-            return TRACE_SAMPLE_RATES[context];
+            // Env multiplier dampens a runtime's baseline in an emergency (0 mutes); unset = unchanged.
+            return TRACE_SAMPLE_RATES[context] * (traceSampleRateMultiplier(context) ?? 1);
         },
 
         // Enable logs to be sent to Sentry

--- a/sentry/lib/config.mjs
+++ b/sentry/lib/config.mjs
@@ -1,4 +1,4 @@
-import { clientSentryDsn, serverSentryDsn, traceSampleRateMultiplier } from './env.mjs';
+import { clientSentryDsn, sentryEnvironment, serverSentryDsn, traceSampleRateMultiplier } from './env.mjs';
 import { vitalsTraceSampleRate } from './vitals.mjs';
 
 /**
@@ -68,7 +68,7 @@ export function createSentryConfig(context) {
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,
 
-        environment: process.env.NODE_ENV,
+        environment: sentryEnvironment(context),
     };
 }
 

--- a/sentry/lib/config.mjs
+++ b/sentry/lib/config.mjs
@@ -5,14 +5,19 @@ import { vitalsTraceSampleRate } from './vitals.mjs';
  * @typedef {'client' | 'server' | 'edge'} RuntimeContext
  */
 
-// Error events are rare and load-bearing; every runtime keeps them all.
+// Server/edge errors are rare and load-bearing; the client starts near zero until quota headroom is proven.
+// TODO(rollout): client 1e-6 → 1e-4 → 1e-2 → 1; each ×100 step bounds the next volume at 100× the measured
+// one, advance when that still fits quota. Restore 1 when the beforeSend opt-in gate (feat/feedback-widget)
+// lands and becomes the quota guard.
 const SAMPLE_RATES = {
-    client: 1,
+    client: 1 / 1000000,
     edge: 1,
     server: 1,
 };
 
 // Server traces are ~5 spans each; browser pageloads emit hundreds, so client/edge stay near zero.
+// TODO(rollout): server 1e-5 → 1e-4 → 1e-3 while span quota holds (dampener env vars are the brake);
+// client/edge baselines stay near zero — client visibility ships via the vitals gate, not this map.
 const TRACE_SAMPLE_RATES = {
     client: 1 / 100000000,
     edge: 1 / 100000000,

--- a/sentry/lib/env.mjs
+++ b/sentry/lib/env.mjs
@@ -63,8 +63,10 @@ export function traceSampleRateMultiplier(context) {
             return parseMultiplier(process.env.NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT);
         case 'edge':
             // Edge is "just server" to developers; the EDGE var exists only for targeted overrides.
-            return parseMultiplier(
-                process.env.TELEMETRY_TRACE_SAMPLE_RATE_EDGE || process.env.TELEMETRY_TRACE_SAMPLE_RATE_SERVER,
+            // Parse each var separately so an unparsable EDGE value falls back to SERVER instead of masking it.
+            return (
+                parseMultiplier(process.env.TELEMETRY_TRACE_SAMPLE_RATE_EDGE) ??
+                parseMultiplier(process.env.TELEMETRY_TRACE_SAMPLE_RATE_SERVER)
             );
         case 'server':
             return parseMultiplier(process.env.TELEMETRY_TRACE_SAMPLE_RATE_SERVER);

--- a/sentry/lib/env.mjs
+++ b/sentry/lib/env.mjs
@@ -1,0 +1,60 @@
+// Each var is referenced statically: Next.js inlines only literal NEXT_PUBLIC_* expressions.
+
+/**
+ * DSN for browser bundles; the client can only ever see the inlined public var.
+ * @returns {string | undefined}
+ */
+export function clientSentryDsn() {
+    return process.env.NEXT_PUBLIC_SENTRY_DSN;
+}
+
+/**
+ * DSN for server/edge; the private var wins, the public one covers all runtimes when set alone.
+ * @returns {string | undefined}
+ */
+export function serverSentryDsn() {
+    return process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+}
+
+/**
+ * @param {string | undefined} raw
+ * @returns {number | undefined} value clamped to [0, 1]; undefined when unset or unparsable
+ */
+function parseMultiplier(raw) {
+    if (!raw) {
+        return undefined;
+    }
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        return undefined;
+    }
+    return Math.min(parsed, 1);
+}
+
+/**
+ * Multiplier applied to the code-owned vitals sample rate, clamped to (0, 1].
+ * @returns {number | undefined} undefined when unset, unparsable, or not positive — vitals sampling off
+ */
+export function vitalsSampleRateMultiplier() {
+    const multiplier = parseMultiplier(process.env.NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE);
+    return multiplier === 0 ? undefined : multiplier;
+}
+
+/**
+ * Multiplier applied to the baseline trace rate of one runtime, clamped to [0, 1] — 0 mutes it.
+ * @param {'client' | 'server' | 'edge'} context
+ * @returns {number | undefined} undefined when unset or unparsable — baseline applies unchanged
+ */
+export function traceSampleRateMultiplier(context) {
+    switch (context) {
+        case 'client':
+            return parseMultiplier(process.env.NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT);
+        case 'edge':
+            // Edge is "just server" to developers; the EDGE var exists only for targeted overrides.
+            return parseMultiplier(
+                process.env.TELEMETRY_TRACE_SAMPLE_RATE_EDGE || process.env.TELEMETRY_TRACE_SAMPLE_RATE_SERVER,
+            );
+        case 'server':
+            return parseMultiplier(process.env.TELEMETRY_TRACE_SAMPLE_RATE_SERVER);
+    }
+}

--- a/sentry/lib/env.mjs
+++ b/sentry/lib/env.mjs
@@ -29,6 +29,15 @@ export function sentryEnvironment(context) {
 }
 
 /**
+ * True unless this is a Vercel production deployment or ENABLE_SENTRY_SOURCEMAPS_AT_PREVIEW opts a preview in.
+ * Reads VERCEL_ENV raw, not sentryEnvironment(): a local production build must never attempt uploads.
+ * @returns {boolean}
+ */
+export function sourcemapUploadsDisabled() {
+    return process.env.VERCEL_ENV !== 'production' && process.env.ENABLE_SENTRY_SOURCEMAPS_AT_PREVIEW !== 'true';
+}
+
+/**
  * @param {string | undefined} raw
  * @returns {number | undefined} value clamped to [0, 1]; undefined when unset or unparsable
  */

--- a/sentry/lib/env.mjs
+++ b/sentry/lib/env.mjs
@@ -17,6 +17,18 @@ export function serverSentryDsn() {
 }
 
 /**
+ * Deployment environment; VERCEL_ENV keeps previews out of production stats, NODE_ENV covers local runs.
+ * @param {'client' | 'server' | 'edge'} context
+ * @returns {string | undefined}
+ */
+export function sentryEnvironment(context) {
+    if (context === 'client') {
+        return process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV;
+    }
+    return process.env.VERCEL_ENV || process.env.NODE_ENV;
+}
+
+/**
  * @param {string | undefined} raw
  * @returns {number | undefined} value clamped to [0, 1]; undefined when unset or unparsable
  */

--- a/sentry/lib/vitals.mjs
+++ b/sentry/lib/vitals.mjs
@@ -1,0 +1,21 @@
+import { vitalsSampleRateMultiplier } from './env.mjs';
+
+// Ceiling for vitals sampling; the env multiplier picks the actual rate, so a mis-set var cannot exceed it.
+const VITALS_TRACE_SAMPLE_RATE = 0.001;
+
+/**
+ * Effective sample rate for client transactions feeding the Web Vitals dashboards.
+ * @param {import('@sentry/core').TracesSamplerSamplingContext} samplingContext
+ * @returns {number | undefined} undefined when the transaction is not pageload/navigation or vitals sampling is off
+ */
+export function vitalsTraceSampleRate(samplingContext) {
+    const op = samplingContext.attributes?.['sentry.op'];
+    if (op !== 'pageload' && op !== 'navigation') {
+        return undefined;
+    }
+    const multiplier = vitalsSampleRateMultiplier();
+    if (multiplier === undefined) {
+        return undefined;
+    }
+    return VITALS_TRACE_SAMPLE_RATE * multiplier;
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Raises Sentry trace sampling and adds the controls needed to feed the Performance dashboards without risking quota.
Server traces were sampled at a flat 1e-8 — effectively nothing reached Sentry, leaving the performance and metrics
views empty.

- Per-runtime `TRACE_SAMPLE_RATES` map: server raised to 10e-6; client/edge stay near zero (browser pageloads emit
  hundreds of spans per trace).
- Web Vitals sampling for client `pageload`/`navigation` transactions, gated by
  `NEXT_PUBLIC_TELEMETRY_VITALS_SAMPLE_RATE` — a multiplier on a code-owned 0.001 ceiling, so a mis-set var cannot
  flood. Inert until a client DSN is configured.
- Emergency dampeners `NEXT_PUBLIC_TELEMETRY_TRACE_SAMPLE_RATE_CLIENT`, `TELEMETRY_TRACE_SAMPLE_RATE_SERVER`
  (covers edge), and `TELEMETRY_TRACE_SAMPLE_RATE_EDGE` scale a runtime's baseline from Vercel without a code change
  (`0` mutes).
- `SAMPLE_RATES` map for error events — server/edge at 1; the client starts at 1e-6 as a deliberately-closed
  position until quota headroom is proven. Each map carries a `TODO(rollout)` ladder (errors: ×100 steps
  1e-6 → 1e-4 → 1e-2 → 1; traces: ×10 steps for the server baseline) with the advance rule — every step bounds the
  next volume at a multiple of the measured one.
- `environment` now reports `VERCEL_ENV` (client: `NEXT_PUBLIC_VERCEL_ENV`) with a `NODE_ENV` fallback, so preview
  deployments stop polluting production stats.
- `/api/*` traces sample at the baseline instead of being zeroed — the near-zero rates make the old blanket
  exclusion unnecessary.
- `sentry/` reshaped as a feature module: `index.ts` barrel + `lib/` with co-located specs; `sentry/README.md` is the
  runbook for flood response.

A commented `parentSampled` block (with docs link) marks where trace inheritance goes once a client DSN exists.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   ~~[ ] Bug fix~~
-   ~~[ ] New feature~~
-   ~~[ ] Protocol integration~~
-   ~~[ ] Documentation update~~
-   [x] Other (please describe): observability configuration — trace sampling, telemetry env controls

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

No UI changes.

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

- 37 vitest specs (`sentry/lib/__tests__/config.spec.ts`) cover DSN wiring, environment resolution, error sample
  rates per runtime, sampler zero-branches, dampener parsing/clamping, and the vitals gate ordering.
- Verified live in headless Chromium against both `next dev` and a production `next build` + `next start`: the
  browser Sentry client reports `environment: "development"` / `"production"` respectively, proving the
  `NEXT_PUBLIC_*`/`NODE_ENV` inlining works client-side.
- Full production build passes.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #<issue-number>, Addresses #<issue-number> -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   ~~[ ] I have run `build:info` script to update build information~~
-   [x] CI/CD checks pass on the PR
-   ~~[ ] Screenshots included — required for protocol screens, recommended for other UI changes~~
-   ~~[ ] For security-related features, I have included links to related information~~

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

Client-side reporting stays off until `NEXT_PUBLIC_SENTRY_DSN` is set; the vitals sampling and the client entries in
both rate maps are inert until then. `feat/feedback-widget` touches the same config at its old path (`beforeSend`
gate) — whichever branch lands second needs a manual port onto the moved file.
