### PR TITLE
chore: disallow crawlers for /mcp

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /mcp/start
 Disallow: /api/
 Disallow: /mcp
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /api/
+Disallow: /mcp
 
 Sitemap: https://explorer.solana.com/sitemap.xml


### PR DESCRIPTION
## Description
Add a Disallow: /mcp rule to robots.txt so bots and analytics crawlers stop hitting the /mcp endpoint and everything under it.

## Type of change
-   [x] Documentation update

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR